### PR TITLE
Changed the name of the linux binary in github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ env:
   runtime: ~/.local/share/nvim/site/pack/vendor/start
   minidoc-git: https://github.com/echasnovski/mini.doc
   minidoc-path: ~/.local/share/nvim/site/pack/vendor/start/mini.doc
-  nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
+  nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-x86_64.tar.gz
 
 jobs:
   docs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
 
         include:
           - os: ubuntu-latest
-            nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
+            nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-x86_64.tar.gz
             packages: luarocks ripgrep
             manager: sudo apt-get
 


### PR DESCRIPTION
Neovim 0.10.4 changed the name of the Linux binary in their releases,
which was breaking the github actions worflow.
