### PR TITLE
Trying to fix github actions when merging to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout without token
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
There is no GH_PAT configured in the secrets for this new repo. Changed
the variable to GITHUB_TOKEN to check if it has enough permissions, if
it doesn't we will need to create a PAT and add it to the repo secrets.