### PR TITLE
Fix: blink.add_provider is deprecated - use add_source_provider instead

### DIFF
--- a/lua/obsidian/completion/plugin_initializers/blink.lua
+++ b/lua/obsidian/completion/plugin_initializers/blink.lua
@@ -12,7 +12,7 @@ M.providers = {
 }
 
 local function add_provider(blink, provider_name, proivder_module)
-  blink.add_provider(provider_name, {
+  blink.add_source_provider(provider_name, {
     name = provider_name,
     module = proivder_module,
     async = true,

--- a/lua/obsidian/completion/plugin_initializers/blink.lua
+++ b/lua/obsidian/completion/plugin_initializers/blink.lua
@@ -12,7 +12,8 @@ M.providers = {
 }
 
 local function add_provider(blink, provider_name, proivder_module)
-  blink.add_source_provider(provider_name, {
+  local add_source_provider = blink.add_source_provider or blink.add_provider
+  add_source_provider(provider_name, {
     name = provider_name,
     module = proivder_module,
     async = true,


### PR DESCRIPTION
There's a warning while using the latest version of blink saying that blink.add_provider is deprecated and will be removed with version 1.0.0 and to use blink.add_source_provider instead. 

This PR makes that update.