### PR TITLE
feat: `smart_action` shows tag picker when cursor is on a tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed `opts.image_name_func` to `opts.attachments.img_name_func`.
 - Default to not activate ui render when `render-markdown.nvim` or `markview.nvim` is present
+- `smart_action` shows picker for tags (`ObsidianTag`) when cursor is on a tag
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ This is a complete list of all of the options that can be passed to `require("ob
       end,
       opts = { buffer = true },
     },
-    -- Smart action depending on context, either follow link or toggle checkbox.
+    -- Smart action depending on context: follow link, show notes with tag, or toggle checkbox.
     ["<cr>"] = {
       action = function()
         return require("obsidian").util.smart_action()

--- a/doc/obsidian.txt
+++ b/doc/obsidian.txt
@@ -385,7 +385,7 @@ carefully and customize it to your needs:
           end,
           opts = { buffer = true },
         },
-        -- Smart action depending on context, either follow link or toggle checkbox.
+        -- Smart action depending on context: follow link, show notes with tag, or toggle checkbox.
         ["<cr>"] = {
           action = function()
             return require("obsidian").util.smart_action()

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -757,6 +757,11 @@ util.smart_action = function()
     return "<cmd>ObsidianFollowLink<CR>"
   end
 
+  -- show notes with tag if possible
+  if util.cursor_tag(nil, nil) then
+    return "<cmd>ObsidianTag<CR>"
+  end
+
   -- toggle task if possible
   -- cycles through your custom UI checkboxes, default: [ ] [~] [>] [x]
   return "<cmd>ObsidianToggleCheckbox<CR>"


### PR DESCRIPTION
PR for ticket https://github.com/obsidian-nvim/obsidian.nvim/issues/35.

When your cursor is on a tag
![image](https://github.com/user-attachments/assets/fdef0597-f8ce-4f65-8d6b-2ea7db62dc42)

you can press enter (default mapping) to open the tag picker and see all notes with that tag
![image](https://github.com/user-attachments/assets/603a74f0-fc9b-461c-b3d0-8b2a356f0289)
