### PR TITLE
fix: properly remove old buffer on rename

### DIFF
--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -147,9 +147,11 @@ return function(client, data)
     if is_current_buf then
       -- If we're renaming the note of a current buffer, save as the new path.
       if not dry_run then
-        quietly(vim.cmd.saveas, tostring(new_note_path))
-        for bufnr, bufname in util.get_named_buffers() do
-          if bufname == cur_note_path then
+        quietly(function()
+          vim.cmd("keepalt saveas " .. tostring(new_note_path))
+        end)
+        for bufnr, bufname in util.get_named_buffers(true) do
+          if bufname == cur_note_path.filename then
             quietly(vim.cmd.bdelete, bufnr)
           end
         end

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -821,9 +821,9 @@ util.get_external_dependency_info = function(cmd)
 end
 
 ---Get an iterator of (bufnr, bufname) over all named buffers. The buffer names will be absolute paths.
----
+---@param include_unloaded boolean|?
 ---@return function () -> (integer, string)|?
-util.get_named_buffers = function()
+util.get_named_buffers = function(include_unloaded)
   local idx = 0
   local buffers = vim.api.nvim_list_bufs()
 
@@ -833,7 +833,7 @@ util.get_named_buffers = function()
     while idx < #buffers do
       idx = idx + 1
       local bufnr = buffers[idx]
-      if vim.api.nvim_buf_is_loaded(bufnr) then
+      if include_unloaded or vim.api.nvim_buf_is_loaded(bufnr) then
         return bufnr, vim.api.nvim_buf_get_name(bufnr)
       end
     end


### PR DESCRIPTION
Currently, renaming a note does not remove the old buffer. This is because:
- After `saveas`, the old buffer stays, but is unlodaded, so `get_named_buffers` will not include it.
- `cur_note_path` is not a string, buf a `Path`, so the check will never succeed

On another hand, `saveas` overrides the alternate file with the old buffer.
This is more a matter of taste, but I find keeping the altfile what it previously was more intuitive, so the user can't accidentally go back to the now deleted buffer.
