### PR TITLE
Fix: Conflict between backlinks and LaTeX brackets due to ripgrep command

### DIFF
--- a/lua/obsidian/completion/refs.lua
+++ b/lua/obsidian/completion/refs.lua
@@ -1,4 +1,5 @@
 local util = require "obsidian.util"
+local ts_util = require "obsidian.treesitter"
 
 local M = {}
 
@@ -13,6 +14,10 @@ M.RefType = {
 ---@param input string
 ---@return string|?, string|?, obsidian.completion.RefType|?
 local find_search_start = function(input)
+  if ts_util.in_mathzone() then
+    return nil
+  end
+
   for i = string.len(input), 1, -1 do
     local substr = string.sub(input, i)
     if vim.startswith(substr, "]") or vim.endswith(substr, "]") then

--- a/lua/obsidian/treesitter.lua
+++ b/lua/obsidian/treesitter.lua
@@ -1,0 +1,66 @@
+local M = {}
+
+local ts = require "vim.treesitter"
+
+local MATH_NODES = {
+  displayed_equation = true,
+  inline_formula = true,
+  math_environment = true,
+}
+
+local TEXT_NODES = {
+  text_mode = true,
+  label_definition = true,
+  label_reference = true,
+}
+
+local CODE_BLOCK_NODES = {
+  fenced_code_block = true,
+  indented_code_block = true,
+}
+
+function M.in_text(check_parent)
+  local node = ts.get_node { ignore_injections = false }
+  while node do
+    local node_type = node:type()
+    -- if in code block, always consider it as text
+    if CODE_BLOCK_NODES[node_type] then
+      return true
+    end
+    if node_type == "text_mode" then
+      if check_parent then
+        local parent = node:parent()
+        if parent and MATH_NODES[parent:type()] then
+          return false
+        end
+      end
+      return true
+    end
+    if MATH_NODES[node_type] then
+      return false
+    end
+    node = node:parent()
+  end
+  return true
+end
+
+function M.in_mathzone()
+  local node = ts.get_node { ignore_injections = false }
+  while node do
+    local node_type = node:type()
+    -- if in code block, don't consider it math.
+    if CODE_BLOCK_NODES[node_type] then
+      return false
+    end
+    if TEXT_NODES[node_type] then
+      return false
+    end
+    if MATH_NODES[node_type] then
+      return true
+    end
+    node = node:parent()
+  end
+  return false
+end
+
+return M

--- a/test/fixtures/notes/note_with_MathJax.md
+++ b/test/fixtures/notes/note_with_MathJax.md
@@ -1,0 +1,19 @@
+---
+id: note_with_MathJax
+---
+
+# Inline and Display Modes
+
+By the law of large numbers we have that $\widehat{\mathbb{V}[\theta_{i}]} \to \mathbb{V}[\theta_{i}]$, hence
+$$
+\begin{flalign*}
+  \hat{\beta}_{1} &\approx \beta_{1} + \frac{\frac{1}{n} \sum_{i=1}^{n} \left( X_{i} - \mu_{X} \right) U_{i}}{\frac{1}{n} \sum_{i=1}^{n} \left( X_{i} - \mu_{X} \right)^{2}} &&\\
+  \mathbb{V} \left[ \hat{\beta}_{1} \right] &= \mathbb{V} \left[ \beta_{1} + \frac{\frac{1}{n} \sum_{i=1}^{n} \left( X_{i} - \mu_{X} \right) U_{i}}{\sigma_{X}^{2}} \right] &&\\
+  &= \mathbb{V} \left[ \beta_{1} \right] + \mathbb{V} \left[ \frac{\frac{1}{n} \sum_{i=1}^{n} \left( X_{i} - \mu_{X} \right) U_{i}}{\sigma_{X}^{2}} \right] &&\\
+  &= \left( \frac{1}{\sigma_{X}^{2}} \right)^{2} \cdot \left( \frac{1}{n} \right)^{2} \cdot \underbrace{\mathbb{V} \left[ \sum_{i=1}^{n} \left( X_{i} - \mu_{X} \right) U_{i} \right]}_{\textcolor{yellow}{*_{1}}} &&\\
+  &= \left( \frac{1}{\sigma_{X}^{2}} \right)^{2} \cdot \left( \frac{1}{n} \right)^{2} \cdot n \mathbb{V} \left[ \left( X_{i} - \mu_{X} \right) U_{i} \right] &&\\
+  &= \frac{1}{n} \cdot \frac{\mathbb{V} \left[ \left( X_{i} - \mu_{X} \right) U_{i} \right]}{\left( \sigma_{X}^{2} \right)^{2}} &&\\
+\end{flalign*}
+$$
+
+Therefore, $\hat{\beta}_{1} \overset{\text{CLT}}{\sim} \mathcal{N} \left( \beta_{1}, \sigma_{\hat{\beta}_{1}}^{2} \right)$, where $\sigma_{\hat{\beta}_{1}}^{2} = \frac{\mathbb{V} \left[ \left( X_{i} - \mu_{X} \right) U_{i} \right]}{n \cdot \left( \sigma_{X}^{2} \right)^{2}}$.


### PR DESCRIPTION
I added an implementation of the treesitter helper I use for my snippets. 

Essentially it just leverages the treesitter nodes to detect whether we're in math mode (where the parent node is enclosed by `$` or `$$`), or in text mode.

Then, I modified the `find_search_start` function so that it won't run if we're in math mode.

The only issue now, which I need some help for, is that whenever I have inbalanced braces within mathmode, then the treesitter helper will default back to textmode, and we run back into the issue we were trying to fix. For example:
```
$$
\begin{flalign*}
  &\left[ d_{d \right] &&\\
\end{flalign*}
$$
```

This is still better than the original, as before it would return the error even when braces were balanced.