### PR TITLE
Search for templates folder in vault_root first

### DIFF
--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -266,7 +266,7 @@ Client.templates_dir = function(self, workspace)
     return nil
   end
 
-  local paths_to_check = { Path.new(opts.templates.folder), self:vault_root(workspace) / opts.templates.folder }
+  local paths_to_check = { self:vault_root(workspace) / opts.templates.folder, Path.new(opts.templates.folder) }
   for _, path in ipairs(paths_to_check) do
     if path:is_dir() then
       return path


### PR DESCRIPTION
If your templates folder is configured as e. g. 'Templates' and you happen to have a folder of the same name in `$CWD`, this should guard against picking the wrong folder.

I for instance have a folder 'Templates' in my home directory, which is completely unrelated to obsidian. When I start nvim while `$CWD == $HOME`, this folder would be used for obsidian templates instead, which is completely unexpected. In this case, when creating a new daily note for instance, I would get an error message telling me that the daily template could not be found.

Why you ever would want to search for obsidian templates outside your vault I don't understand, so I kept that logic there instead of removing it, but at least I think it should happen as a last resort, not as an override.

This PR simply _reverses_ the list of searched directories in `Client.templates_dir`, trying first inside the vault, and only then fall back to a relative path.