### PR TITLE
feat: makefile is friendlier

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches: [main]
   workflow_dispatch:
@@ -14,8 +14,6 @@ concurrency:
 
 env:
   runtime: ~/.local/share/nvim/site/pack/vendor/start
-  minidoc-git: https://github.com/echasnovski/mini.doc
-  minidoc-path: ~/.local/share/nvim/site/pack/vendor/start/mini.doc
   nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-x86_64.tar.gz
 
 jobs:
@@ -38,7 +36,6 @@ jobs:
           mkdir -p ${{ env.runtime }}
           mkdir -p _neovim
           curl -sL ${{ env.nvim_url }} | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
-          git clone --depth 1 ${{ env.minidoc-git }} ${{ env.minidoc-path }}
           ln -s $(pwd) ${{ env.runtime }}
 
       - name: Generate API docs
@@ -74,5 +71,5 @@ jobs:
         if: github.event_name != 'pull_request'
         with:
           commit_user_name: github-actions[bot]
-          commit_message: 'chore(docs): auto generate docs'
+          commit_message: "chore(docs): auto generate docs"
           branch: ${{ github.head_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default to not activate ui render when `render-markdown.nvim` or `markview.nvim` is present
 - `smart_action` shows picker for tags (`ObsidianTag`) when cursor is on a tag
 - `ObsidianToggleCheckbox` now works with numbered lists
+- `Makefile` is friendlier: self-documenting and automatically gets dependencies
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,31 @@
+SHELL:=/usr/bin/env bash
+
+.DEFAULT_GOAL:=help
+PROJECT_NAME = "obsidian.nvim"
 TEST = test/obsidian
 # This is where you have plenary installed locally. Override this at runtime if yours is elsewhere.
 PLENARY = ~/.local/share/nvim/lazy/plenary.nvim/
 MINIDOC = ~/.local/share/nvim/lazy/mini.doc/
 
-.PHONY : all
-all : style lint test
 
-.PHONY : test
-test :
+################################################################################
+##@ Developmment
+.PHONY: chores
+chores: style lint test ## Run all develoment tasks
+
+.PHONY: test
+test: $(PLENARY) ## Run unit tests
 	PLENARY=$(PLENARY) nvim \
 		--headless \
 		--noplugin \
 		-u test/minimal_init.vim \
 		-c "PlenaryBustedDirectory $(TEST) { minimal_init = './test/minimal_init.vim' }"
 
+$(PLENARY):
+	git clone git@github.com:nvim-lua/plenary.nvim.git $(PLENARY)
+
 .PHONY: api-docs
-api-docs :
+api-docs: $(MINIDOC) ## Generate API documentation with mini.doc
 	MINIDOC=$(MINIDOC) nvim \
 		--headless \
 		--noplugin \
@@ -23,14 +33,28 @@ api-docs :
 		-c "luafile scripts/generate_api_docs.lua" \
 		-c "qa!"
 
-.PHONY : lint
-lint :
+$(MINIDOC):
+	git clone git@github.com:echasnovski/mini.doc.git $(MINIDOC)
+
+.PHONY: lint
+lint: ## Lint the code
 	luacheck .
 
-.PHONY : style
-style :
+.PHONY: style
+style:  ## format the code
 	stylua --check .
 
-.PHONY : version
-version :
+
+################################################################################
+##@ Helpers
+.PHONY: version
+version:  ## Print the obsidian.nvim version
 	@nvim --headless -c 'lua print("v" .. require("obsidian").VERSION)' -c q 2>&1
+
+.PHONY: help
+help:  ## Display this help
+	@echo "Welcome to $$(tput bold)${PROJECT_NAME}$$(tput sgr0) 🥳📈🎉"
+	@echo ""
+	@echo "To get started:"
+	@echo "  >>> $$(tput bold)make chores$$(tput sgr0)"
+	@awk 'BEGIN {FS = ":.*##"; printf "\033[36m\033[0m"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL:=/usr/bin/env bash
 .DEFAULT_GOAL:=help
 PROJECT_NAME = "obsidian.nvim"
 TEST = test/obsidian
-# This is where you have plenary installed locally. Override this at runtime if yours is elsewhere.
+# Depending on your setup you have to override the locations at runtime.
 PLENARY = ~/.local/share/nvim/lazy/plenary.nvim/
 MINIDOC = ~/.local/share/nvim/lazy/mini.doc/
 
@@ -22,7 +22,7 @@ test: $(PLENARY) ## Run unit tests
 		-c "PlenaryBustedDirectory $(TEST) { minimal_init = './test/minimal_init.vim' }"
 
 $(PLENARY):
-	git clone git@github.com:nvim-lua/plenary.nvim.git $(PLENARY)
+	git clone --depth 1 https://github.com/nvim-lua/plenary.nvim.git $(PLENARY)
 
 .PHONY: api-docs
 api-docs: $(MINIDOC) ## Generate API documentation with mini.doc
@@ -34,7 +34,7 @@ api-docs: $(MINIDOC) ## Generate API documentation with mini.doc
 		-c "qa!"
 
 $(MINIDOC):
-	git clone git@github.com:echasnovski/mini.doc.git $(MINIDOC)
+	git clone --depth 1 https://github.com/echasnovski/mini.doc $(MINIDOC)
 
 .PHONY: lint
 lint: ## Lint the code


### PR DESCRIPTION
- it is self documenting: just call `make` to see all targets
- it gets missing dependencies

Now the output of `make` looks like this:
![image](https://github.com/user-attachments/assets/4805f176-c327-4c09-b57a-00184a55a996)


If you don't have deps, like `mini.doc`, it clones it automatically:
![image](https://github.com/user-attachments/assets/f7c9d367-75b2-497e-9294-6b8d64d159ed)
