### PR TITLE
ObsidianToggleCheckbox works in visual mode multiline (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support `text/uri-list` to `ObsidianPasteImg`.
 
+### Changed
+
+- `ObsidianToggleCheckbox` now works in visual mode for multiline toggle
+
 ## [v3.10.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.10.0) - 2025-04-12
 
 ### Added

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -168,7 +168,7 @@ M.register("ObsidianLinks", { opts = { nargs = 0, desc = "Collect all links with
 
 M.register("ObsidianFollowLink", { opts = { nargs = "?", desc = "Follow reference or link under cursor" } })
 
-M.register("ObsidianToggleCheckbox", { opts = { nargs = 0, desc = "Toggle checkbox" } })
+M.register("ObsidianToggleCheckbox", { opts = { nargs = 0, desc = "Toggle checkbox", range = true } })
 
 M.register("ObsidianWorkspace", { opts = { nargs = "?", desc = "Check or switch workspace" } })
 

--- a/lua/obsidian/commands/toggle_checkbox.lua
+++ b/lua/obsidian/commands/toggle_checkbox.lua
@@ -1,10 +1,21 @@
 local toggle_checkbox = require("obsidian.util").toggle_checkbox
 
 ---@param client obsidian.Client
-return function(client)
+return function(client, opts)
+  local start_line, end_line
   local checkboxes = vim.tbl_keys(client.opts.ui.checkboxes)
-  table.sort(checkboxes, function(a, b)
-    return (client.opts.ui.checkboxes[a].order or 1000) < (client.opts.ui.checkboxes[b].order or 1000)
-  end)
-  toggle_checkbox(checkboxes)
+  start_line = opts.line1
+  end_line = opts.line2
+
+  local buf = vim.api.nvim_get_current_buf()
+
+  for line_nb = start_line, end_line do
+    local current_line = vim.api.nvim_buf_get_lines(buf, line_nb - 1, line_nb, false)[1]
+    if current_line and current_line:match("%S") then
+      table.sort(checkboxes, function(a, b)
+        return (client.opts.ui.checkboxes[a].order or 1000) < (client.opts.ui.checkboxes[b].order or 1000)
+      end)
+      toggle_checkbox(checkboxes, line_nb)
+    end
+  end
 end

--- a/lua/obsidian/commands/toggle_checkbox.lua
+++ b/lua/obsidian/commands/toggle_checkbox.lua
@@ -11,7 +11,7 @@ return function(client, opts)
 
   for line_nb = start_line, end_line do
     local current_line = vim.api.nvim_buf_get_lines(buf, line_nb - 1, line_nb, false)[1]
-    if current_line and current_line:match("%S") then
+    if current_line and current_line:match "%S" then
       table.sort(checkboxes, function(a, b)
         return (client.opts.ui.checkboxes[a].order or 1000) < (client.opts.ui.checkboxes[b].order or 1000)
       end)


### PR DESCRIPTION
Modified the toggle_checkbox command implementation so that it works in visual mode as well.
It allows to toggle the checkbox on multiple lines. 

Also added a check to avoid the toggle on empty lines.