### PR TITLE
feat(img_paste) : Add condition to show confirmation message when `default_dir` is not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ObsidianToggleCheckbox` now works in visual mode for multiline toggle
+- Changed condition to respect `confirm_img_paste` even when `default_dir` is not utilized
 
 ## [v3.10.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.10.0) - 2025-04-12
 

--- a/lua/obsidian/img_paste.lua
+++ b/lua/obsidian/img_paste.lua
@@ -111,7 +111,7 @@ M.paste_img = function(opts)
 
   -- Get filename to save to.
   if fname == nil or fname == "" then
-    if opts.default_name ~= nil and not opts.should_confirm then
+    if #opt.default_dir > 0 and opts.default_name ~= nil and not opts.should_confirm then
       fname = opts.default_name
     else
       fname = util.input("Enter file name: ", { default = opts.default_name, completion = "file" })


### PR DESCRIPTION
## 1. Problem

If you use `img_name_fun` to set directory where clipboard-image is saved without using `img_folder`, confirming message is always shown. This is a bit annoying.

There is `confirm_img_paste` to disable confirming message, but it causes the filename and saved path to use default setting automatically.

## 2. Solution

Rather then making new option to confirm, I use the length of `img_folder`. The confirm message is removed if these conditions are satisfied.

1) `confirm_img_paste = false`
2) `img_folder = ''`  (its length is empty)
3) `img_name_func` is not empty