### PR TITLE
feat: support obsidian style %% comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support `text/uri-list` to `ObsidianPasteImg`.
+- Added support for obsidian style `%%` comment
 
 ### Changed
 
@@ -19,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Enhanced completion menu to correctly display and handle non-English (ex. Korean) file names and tags in link, fixing Unicode encoding issues
-
 
 ## [v3.10.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.10.0) - 2025-04-12
 

--- a/after/ftplugin/markdown.lua
+++ b/after/ftplugin/markdown.lua
@@ -1,0 +1,12 @@
+local obsidian = require "obsidian"
+local buf = vim.api.nvim_get_current_buf()
+local buf_dir = vim.fs.dirname(vim.api.nvim_buf_get_name(buf))
+
+local client = obsidian.get_client()
+
+local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, client.opts.workspaces)
+if not workspace then
+  return -- if not in any workspace.
+end
+
+vim.o.commentstring = "%%%s%%"

--- a/after/syntax/markdown.vim
+++ b/after/syntax/markdown.vim
@@ -1,0 +1,2 @@
+" Match %%...%% as comment
+syntax match Comment /%%\_.\{-}%%/


### PR DESCRIPTION
![350914977ab4a859019d82ad7644f9a1](https://github.com/user-attachments/assets/7f51ce6f-eddd-4622-b8b7-5aa932df0c10)

Quite a easy one to implement, no block comment because neovim don't support for now.
It looks far better then the inline html comment for me.
Let me know if people like this! 

@ffricken @sotte @TheMeaningfulEngineer
