### PR TITLE
feat: add statusline component provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a statusline component provider similar to Obsidian app.
 - Added default `image_name_func` similar to Obsidian's.
 - Added support `text/uri-list` to `ObsidianPasteImg`.
 - Added support for obsidian style `%%` comment.

--- a/README.md
+++ b/README.md
@@ -597,6 +597,12 @@ require("obsidian").setup {
       return string.format("![%s](%s)", path.name, path)
     end,
   },
+
+  -- See https://github.com/obsidian-nvim/obsidian.nvim/wiki/Notes-on-configuration#statusline-component
+  statusline = {
+    enabled = true,
+    format = "{{properties}} properties {{backlinks}} backlinks {{words}} words {{chars}} chars",
+  },
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The fork aims to stay close to the original, but fix bugs, include and merge use
 
 📷 **Images:** Paste images into notes.
 
+📈 **Status:** See note status in statusline like obsidian app.
+
 💅 **Syntax:** Additional markdown syntax highlighting, concealing, and extmarks for references, tags, and check-boxes.
 
 [![See this screenshot](https://github.com/epwalsh/obsidian.nvim/assets/8812459/e74f5267-21b5-49bc-a3bb-3b9db5fa6687)](https://github.com/epwalsh/obsidian.nvim/assets/8812459/e74f5267-21b5-49bc-a3bb-3b9db5fa6687)

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -2096,10 +2096,16 @@ end
 
 --- Register the global variable that updates itself
 Client.statusline = function(self)
+  local current_note
+
   local refresh = function()
     local note = self:current_note()
-    if not note then
+    if not note then -- no note
       return ""
+    elseif current_note == note then -- no refresh
+      return
+    else -- refresh
+      current_note = note
     end
 
     self:find_backlinks_async(

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -22,6 +22,7 @@ local AsyncExecutor = require("obsidian.async").AsyncExecutor
 local CallbackManager = require("obsidian.callbacks").CallbackManager
 local block_on = require("obsidian.async").block_on
 local iter = require("obsidian.itertools").iter
+local uv = vim.uv
 
 ---@class obsidian.SearchOpts : obsidian.ABC
 ---
@@ -2091,6 +2092,38 @@ end
 ---@return obsidian.Picker|?
 Client.picker = function(self, picker_name)
   return require("obsidian.pickers").get(self, picker_name)
+end
+
+--- Register the global variable that updates itself
+Client.statusline = function(self)
+  local refresh = function()
+    local note = self:current_note()
+    if not note then
+      return ""
+    end
+
+    self:find_backlinks_async(
+      note,
+      vim.schedule_wrap(function(backlinks)
+        local format = self.opts.statusline.format
+        local wc = vim.fn.wordcount()
+        local info = {
+          words = wc.words,
+          chars = wc.chars,
+          backlinks = #backlinks,
+          properties = vim.tbl_count(note:frontmatter()),
+        }
+        for k, v in pairs(info) do
+          format = format:gsub("{{" .. k .. "}}", v)
+        end
+        vim.g.obsidian = format
+      end)
+    )
+  end
+
+  local timer = uv:new_timer()
+  assert(timer, "Failed to create timer")
+  timer:start(0, 1000, vim.schedule_wrap(refresh))
 end
 
 return Client

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -72,7 +72,7 @@ config.ClientOpts.default = function()
     ---@field format? string
     ---@field enabled? boolean
     statusline = {
-      format = "{{properties}} properties {{backlinks}} backlinks {{words}} words {{chars}} chars",
+      format = "{{backlinks}} backlinks  {{properties}} properties  {{words}} words  {{chars}} chars",
       enabled = true,
     },
   }

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -33,6 +33,7 @@ local config = {}
 ---@field attachments obsidian.config.AttachmentsOpts
 ---@field callbacks obsidian.config.CallbackConfig
 ---@field legacy_commands boolean
+---@field statusline obsidian.config.StatuslineOpts
 config.ClientOpts = {}
 
 --- Get defaults.
@@ -67,6 +68,13 @@ config.ClientOpts.default = function()
     attachments = config.AttachmentsOpts.default(),
     callbacks = config.CallbackConfig.default(),
     legacy_commands = true,
+    ---@class obsidian.config.StatuslineOpts
+    ---@field format? string
+    ---@field enabled? boolean
+    statusline = {
+      format = "{{properties}} properties {{backlinks}} backlinks {{words}} words {{chars}} chars",
+      enabled = true,
+    },
   }
 end
 
@@ -236,6 +244,7 @@ config.ClientOpts.normalize = function(opts, defaults)
   opts.templates = tbl_override(defaults.templates, opts.templates)
   opts.ui = tbl_override(defaults.ui, opts.ui)
   opts.attachments = tbl_override(defaults.attachments, opts.attachments)
+  opts.statusline = tbl_override(defaults.statusline, opts.statusline)
 
   ---------------
   -- Validate. --

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -103,6 +103,10 @@ obsidian.setup = function(opts)
     obsidian.commands.install_legacy(client)
   end
 
+  if opts.statusline.enabled then
+    client:statusline()
+  end
+
   -- Register completion sources, providers
   if opts.completion.nvim_cmp then
     require("obsidian.completion.plugin_initializers.nvim_cmp").register_sources()


### PR DESCRIPTION
If you use lualine: 
```lua
  {
    "nvim-lualine/lualine.nvim",
    opts = {
      sections = {
        lualine_x = {
          "g:obsidian",
        },
      },
    },
  },
```
the status is automatically updated through `vim.g.obsidian`

TODO: 
- [x] add in the readme/wiki.