### PR TITLE
bugfix: rename does not replace id nor delete old buffer if in current note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Enhanced completion menu to correctly display and handle non-English (ex. Korean) file names and tags in link, fixing Unicode encoding issues
+- Fixed bug where `ObsidianRename` did not update the note_id if run in current buffer and not remove the old buffer
 
 ## [v3.10.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.10.0) - 2025-04-12
 

--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -152,11 +152,8 @@ return function(client, data)
       -- If we're renaming the note of a current buffer, save as the new path.
       if not dry_run then
         quietly(vim.cmd.saveas, tostring(new_note_path))
-        for bufnr, bufname in util.get_named_buffers() do
-          if bufname == cur_note_path then
-            quietly(vim.cmd.bdelete, bufnr)
-          end
-        end
+        local new_bufnr_current_note = vim.fn.bufnr(tostring(cur_note_path))
+        quietly(vim.cmd.bdelete, new_bufnr_current_note)
         vim.fn.delete(tostring(cur_note_path))
       else
         log.info("Dry run: saving current buffer as '" .. tostring(new_note_path) .. "' and removing old file")
@@ -186,16 +183,14 @@ return function(client, data)
     end
   end
 
-  if not is_current_buf then
-    -- When the note to rename is not the current buffer we need to update its frontmatter
-    -- to account for the rename.
-    cur_note.id = new_note_id
-    cur_note.path = Path.new(new_note_path)
-    if not dry_run then
-      cur_note:save()
-    else
-      log.info("Dry run: updating frontmatter of '" .. tostring(new_note_path) .. "'")
-    end
+  -- We need to update its frontmatter note_id
+  -- to account for the rename.
+  cur_note.id = new_note_id
+  cur_note.path = Path.new(new_note_path)
+  if not dry_run then
+    cur_note:save()
+  else
+    log.info("Dry run: updating frontmatter of '" .. tostring(new_note_path) .. "'")
   end
 
   local cur_note_rel_path = tostring(client:vault_relative_path(cur_note_path, { strict = true }))


### PR DESCRIPTION
The rename command does not replace the id in the frontmatter with the new name.

Moreover I have noticed that although there was code to delete the old buffer (with the old name) it was not working because saveas() associates the old bufnr to the new buffer and creates an new one for the old and it unloads the old buffer. 

I simplified and fixed the code so the old buffer gets deleted correctly

No issues are directly associated in this repo but it fixes an issue from the original one.

- Issue gathering interesting original repo issues (#74) 

- https://github.com/epwalsh/obsidian.nvim/issues/688 from original repo