### PR TITLE
feat: smart action can toggle heading folds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added default `image_name_func` similar to Obsidian's.
 - Added support `text/uri-list` to `ObsidianPasteImg`.
-- Added support for obsidian style `%%` comment
+- Added support for obsidian style `%%` comment.
 
 ### Changed
 
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ObsidianToggleCheckbox` now works in visual mode for multiline toggle.
 - `ObsidianRename` input field is pre-filled filled with the current note id to ease renaming.
 - Improved type annotations for user commands: add `CommandArgs` type.
+- `smart_action` now can also toggle heading folds.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ This is a complete list of all of the options that can be passed to `require("ob
       end,
       opts = { buffer = true },
     },
-    -- Smart action depending on context: follow link, show notes with tag, or toggle checkbox.
+    -- Smart action depending on context: follow link, show notes with tag, toggle checkbox, or toggle heading fold
     ["<cr>"] = {
       action = function()
         return require("obsidian").util.smart_action()

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -148,6 +148,20 @@ obsidian.setup = function(opts)
         require("obsidian.completion.plugin_initializers.blink").inject_sources()
       end
 
+      local win = vim.api.nvim_get_current_win()
+
+      vim.opt.fillchars = {
+        foldopen = "",
+        foldclose = "",
+        fold = " ",
+        foldsep = " ",
+      }
+      vim.wo[win].foldmethod = "expr"
+      vim.wo[win].foldexpr = "v:lua.require'obsidian.util'.foldexpr()"
+      vim.wo[win].foldtext = ""
+      vim.wo[win].foldlevel = 99
+      vim.wo[win].smoothscroll = true
+
       -- Run enter-note callback.
       client.callback_manager:enter_note(function()
         return obsidian.Note.from_buffer(ev.bufnr)

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -150,14 +150,11 @@ obsidian.setup = function(opts)
 
       local win = vim.api.nvim_get_current_win()
 
-      vim.opt.fillchars = {
-        foldopen = "",
-        foldclose = "",
-        fold = " ",
-        foldsep = " ",
-      }
+      vim.treesitter.start(ev.buf, "markdown") -- for when user don't use nvim-treesitter
+
       vim.wo[win].foldmethod = "expr"
-      vim.wo[win].foldexpr = "v:lua.require'obsidian.util'.foldexpr()"
+      vim.wo[win].foldexpr = "v:lua.vim.treesitter.foldexpr()"
+      vim.wo[win].fillchars = "foldopen:,foldclose:,fold: ,foldsep: "
       vim.wo[win].foldtext = ""
       vim.wo[win].foldlevel = 99
       vim.wo[win].smoothscroll = true

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -1408,22 +1408,4 @@ util.isNan = function(v)
   return tostring(v) == tostring(0 / 0)
 end
 
---- foldexpr from LazyVim
-util.foldexpr = function()
-  local buf = vim.api.nvim_get_current_buf()
-  if vim.b[buf].ts_folds == nil then
-    -- as long as we don't have a filetype, don't bother
-    -- checking if treesitter is available (it won't)
-    if vim.bo[buf].filetype == "" then
-      return "0"
-    end
-    if vim.bo[buf].filetype:find "dashboard" then
-      vim.b[buf].ts_folds = false
-    else
-      vim.b[buf].ts_folds = pcall(vim.treesitter.get_parser, buf)
-    end
-  end
-  return vim.b[buf].ts_folds and vim.treesitter.foldexpr() or "0"
-end
-
 return util


### PR DESCRIPTION
Since pressing `<Enter>` on headings don't make sense, this extends the idea of a smart action that does the most intuitive things pretty well I think.

Also neovim ships with markdown treesitter parser now, it works even if you don't have nvim-treesitter.

@sotte let me know what you think

