### PR TITLE
feat: Add support for ObsidianYesterday | ObsidianTomorrow for non-work week daily notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added default `image_name_func` similar to Obsidian's.
 - Added support `text/uri-list` to `ObsidianPasteImg`.
-- Added support for obsidian style `%%` comment
+- Added support for obsidian style `%%` comment.
+- Added `opts.daily_notes.workweek_only` option which adds support for weekend daily notes.
 
 ### Changed
 

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1996,18 +1996,30 @@ Client.today = function(self)
   return self:_daily(os.time())
 end
 
---- Open (or create) the daily note from the last weekday.
+--- Open (or create) the daily note from the last day.
+---
+--- This is configured via opts.daily_notes.schedule.
 ---
 ---@return obsidian.Note
 Client.yesterday = function(self)
-  return self:_daily(util.working_day_before(os.time()))
+  if self.opts.daily_notes.schedule == "workweek" then
+    return self:_daily(util.working_day_before(os.time()))
+  else
+    return self:_daily(util.previous_day(os.time()))
+  end
 end
 
---- Open (or create) the daily note for the next weekday.
+--- Open (or create) the daily note for the next day.
+---
+--- This is configured via opts.daily_notes.schedule.
 ---
 ---@return obsidian.Note
 Client.tomorrow = function(self)
-  return self:_daily(util.working_day_after(os.time()))
+  if self.opts.daily_notes.schedule == "workweek" then
+    return self:_daily(util.working_day_after(os.time()))
+  else
+    return self:_daily(util.next_day(os.time()))
+  end
 end
 
 --- Open (or create) the daily note for today + `offset_days`.

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1998,28 +1998,34 @@ end
 
 --- Open (or create) the daily note from the last day.
 ---
---- This is configured via opts.daily_notes.schedule.
----
 ---@return obsidian.Note
 Client.yesterday = function(self)
-  if self.opts.daily_notes.schedule == "workweek" then
-    return self:_daily(util.working_day_before(os.time()))
+  local now = os.time()
+  local yesterday
+
+  if self.opts.daily_notes.workweek_only then
+    yesterday = util.working_day_before(now)
   else
-    return self:_daily(util.previous_day(os.time()))
+    yesterday = util.previous_day(now)
   end
+
+  return self:_daily(yesterday)
 end
 
 --- Open (or create) the daily note for the next day.
 ---
---- This is configured via opts.daily_notes.schedule.
----
 ---@return obsidian.Note
 Client.tomorrow = function(self)
-  if self.opts.daily_notes.schedule == "workweek" then
-    return self:_daily(util.working_day_after(os.time()))
+  local now = os.time()
+  local tomorrow
+
+  if self.opts.daily_notes.workweek_only then
+    tomorrow = util.working_day_after(now)
   else
-    return self:_daily(util.next_day(os.time()))
+    tomorrow = util.next_day(now)
   end
+
+  return self:_daily(tomorrow)
 end
 
 --- Open (or create) the daily note for today + `offset_days`.

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -284,6 +284,12 @@ config.LinkStyle = {
   markdown = "markdown",
 }
 
+---@enum obsidian.config.DailyNotesSchedule
+config.DailyNotesSchedule = {
+  calendar = "calendar",
+  workweek = "workweek",
+}
+
 ---@class obsidian.config.CompletionOpts
 ---
 ---@field nvim_cmp boolean
@@ -379,6 +385,7 @@ end
 ---@field alias_format string|?
 ---@field template string|?
 ---@field default_tags string[]|?
+---@field schedule obsidian.config.DailyNotesSchedule|?
 config.DailyNotesOpts = {}
 
 --- Get defaults.
@@ -390,6 +397,7 @@ config.DailyNotesOpts.default = function()
     date_format = nil,
     alias_format = nil,
     default_tags = { "daily-notes" },
+    schedule = "workweek",
   }
 end
 

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -284,12 +284,6 @@ config.LinkStyle = {
   markdown = "markdown",
 }
 
----@enum obsidian.config.DailyNotesSchedule
-config.DailyNotesSchedule = {
-  calendar = "calendar",
-  workweek = "workweek",
-}
-
 ---@class obsidian.config.CompletionOpts
 ---
 ---@field nvim_cmp boolean
@@ -385,7 +379,7 @@ end
 ---@field alias_format string|?
 ---@field template string|?
 ---@field default_tags string[]|?
----@field schedule obsidian.config.DailyNotesSchedule|?
+---@field workweek_only boolean
 config.DailyNotesOpts = {}
 
 --- Get defaults.
@@ -397,7 +391,7 @@ config.DailyNotesOpts.default = function()
     date_format = nil,
     alias_format = nil,
     default_tags = { "daily-notes" },
-    schedule = "workweek",
+    workweek_only = true,
   }
 end
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -594,7 +594,7 @@ end
 ---@param time integer
 ---@return integer
 util.working_day_before = function(time)
-  local previous_day = time - (24 * 60 * 60)
+  local previous_day = util.previous_day(time)
   if util.is_working_day(previous_day) then
     return previous_day
   else
@@ -607,7 +607,7 @@ end
 ---@param time integer
 ---@return integer
 util.working_day_after = function(time)
-  local next_day = time + (24 * 60 * 60)
+  local next_day = util.next_day(time)
   if util.is_working_day(next_day) then
     return next_day
   else

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -573,6 +573,22 @@ util.is_working_day = function(time)
   return not (is_saturday or is_sunday)
 end
 
+--- Returns the previous day from given time
+---
+--- @param time integer
+--- @return integer
+util.previous_day = function(time)
+  return time - (24 * 60 * 60)
+end
+---
+--- Returns the next day from given time
+---
+--- @param time integer
+--- @return integer
+util.next_day = function(time)
+  return time + (24 * 60 * 60)
+end
+
 ---Determines the last working day before a given time
 ---
 ---@param time integer

--- a/test/obsidian/util_spec.lua
+++ b/test/obsidian/util_spec.lua
@@ -29,6 +29,38 @@ describe("util.match_case()", function()
   end)
 end)
 
+describe("util.previous_day", function()
+  it("returns one day prior", function()
+    local now = os.time { year = 2025, month = 4, day = 27 }
+
+    assert.equals(util.previous_day(now), os.time { year = 2025, month = 4, day = 26 })
+  end)
+end)
+
+describe("util.next_day", function()
+  it("returns the day after", function()
+    local now = os.time { year = 2025, month = 4, day = 27 }
+
+    assert.equals(util.next_day(now), os.time { year = 2025, month = 4, day = 28 })
+  end)
+end)
+
+describe("util.working_day_before", function()
+  it("returns the last working day", function()
+    local now = os.time { year = 2025, month = 4, day = 27 }
+
+    assert.equals(util.working_day_before(now), os.time { year = 2025, month = 4, day = 25 })
+  end)
+end)
+
+describe("util.working_day_after", function()
+  it("returns the last working day", function()
+    local now = os.time { year = 2025, month = 4, day = 25 }
+
+    assert.equals(util.working_day_after(now), os.time { year = 2025, month = 4, day = 28 })
+  end)
+end)
+
 describe("util.cursor_on_markdown_link()", function()
   it("should correctly find if coursor is on markdown/wiki link", function()
     --           0    5    10   15   20   25   30   35   40    45  50   55


### PR DESCRIPTION
This pull request adds support for weekend daily notes. This does not default the behavior, as I'm not sure who might be impacted by this. However, this behavior differs from that of Obsidian's app.

By default:

| Command | Day of week invoked | Note Returned |
| --- | --- | --- |
| `:ObsidianYesterday` | Sunday | Previous Friday |
| `:ObsidianYesterday` | Saturday | Previous Friday |
| `:ObsidianTomorrow` | Friday | Next Monday |
| `:ObsidianTomorrow` | Saturday | Next Monday |

When a user specifies `opts.daily_notes.workweek_only = false`:

| Command | Day of week invoked | Note Returned |
| --- | --- | --- |
| `:ObsidianYesterday` | Sunday | Saturday |
| `:ObsidianYesterday` | Saturday | Friday |
| `:ObsidianTomorrow` | Friday | Saturday |
| `:ObsidianTomorrow` | Saturday | Sunday |