### PR TITLE
feat: Add config option to avoid duplicate completion items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added configuration option `completion.match_case`, allowing removal of duplicates when note case does not match search string case. Defaults to true for non-breaking behavior.
 - Added default `image_name_func` similar to Obsidian's.
 - Added support `text/uri-list` to `ObsidianPasteImg`.
 - Added support for obsidian style `%%` comment.
@@ -46,7 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default to not activate ui render when `render-markdown.nvim` or `markview.nvim` is present
 - `smart_action` shows picker for tags (`ObsidianTag`) when cursor is on a tag
 - `ObsidianToggleCheckbox` now works with numbered lists
+
 - # `Makefile` is friendlier: self-documenting and automatically gets dependencies
+
 - Default to not activate ui render when `render-markdown.nvim` or `markview.nvim` is present.
 
 ### Fixed

--- a/lua/obsidian/completion/sources/base/refs.lua
+++ b/lua/obsidian/completion/sources/base/refs.lua
@@ -217,6 +217,7 @@ function RefsSourceBase:process_search_results(cc, results)
           alias_case_matched ~= nil
           and alias_case_matched ~= alias
           and not util.tbl_contains(note.aliases, alias_case_matched)
+          and cc.client.opts.completion.match_case
         then
           self:update_completion_options(cc, alias_case_matched, nil, matching_anchors, matching_blocks, note)
         end

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -289,6 +289,7 @@ config.LinkStyle = {
 ---@field nvim_cmp boolean
 ---@field blink boolean
 ---@field min_chars integer
+---@field match_case boolean
 config.CompletionOpts = {}
 
 --- Get defaults.
@@ -299,6 +300,7 @@ config.CompletionOpts.default = function()
   return {
     nvim_cmp = has_nvim_cmp,
     min_chars = 2,
+    match_case = true,
   }
 end
 


### PR DESCRIPTION
This adds config option `completion.match_case`, which prevents the plugin from adding an additional completion entry when a match is found but with the wrong case. E.g. searching for `foo` when the note's file name is `FooBar.md`.

Closes #90

Changes to be committed:
- modified:   lua/obsidian/completion/sources/base/refs.lua
- modified:   lua/obsidian/config.lua
- modified:   lua/obsidian/util.lua