### PR TITLE
feat(ObsidianNewFromTemplate): accept template argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved type annotations for user commands: add `CommandArgs` type.
 - `follow_url_func` and `follow_img_func` defaults to `vim.ui.open`
 - `smart_action` now can also toggle heading folds.
+- `Obsidian new_from_template` accepts an optional `TEMPLATE` argument.
 
 ### Fixed
 
@@ -51,9 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default to not activate ui render when `render-markdown.nvim` or `markview.nvim` is present
 - `smart_action` shows picker for tags (`ObsidianTag`) when cursor is on a tag
 - `ObsidianToggleCheckbox` now works with numbered lists
-
-- # `Makefile` is friendlier: self-documenting and automatically gets dependencies
-
+- `Makefile` is friendlier: self-documenting and automatically gets dependencies
 - Default to not activate ui render when `render-markdown.nvim` or `markview.nvim` is present.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <div align="center">
 <a href="https://github.com/obsidian-nvim/obsidian.nvim/releases/latest">
   <img alt="Latest release" src="https://img.shields.io/github/v/release/obsidian-nvim/obsidian.nvim?style=for-the-badge&logo=starship&logoColor=D9E0EE&labelColor=302D41&&color=d9b3ff&include_prerelease&sort=semver" />
-</a> 
+</a>
 <a href="https://github.com/obsidian-nvim/obsidian.nvim/pulse">
-  <img alt="Last commit" src="https://img.shields.io/github/last-commit/obsidian-nvim/obsidian.nvim?style=for-the-badge&logo=github&logoColor=D9E0EE&labelColor=302D41&color=9fdf9f"/></a> 
+  <img alt="Last commit" src="https://img.shields.io/github/last-commit/obsidian-nvim/obsidian.nvim?style=for-the-badge&logo=github&logoColor=D9E0EE&labelColor=302D41&color=9fdf9f"/></a>
 <a href="https://github.com/neovim/neovim/releases/latest">
   <img alt="Latest Neovim" src="https://img.shields.io/github/v/release/neovim/neovim?style=for-the-badge&logo=neovim&logoColor=D9E0EE&label=Neovim&labelColor=302D41&color=99d6ff&sort=semver" />
 </a>
@@ -15,7 +15,7 @@
   <img alt="Made with Lua" src="https://img.shields.io/badge/Built%20with%20Lua-grey?style=for-the-badge&logo=lua&logoColor=D9E0EE&label=Lua&labelColor=302D41&color=b3b3ff">
 </a>
 <a href="https://dotfyle.com/plugins/obsidian-nvim/obsidian.nvim">
-	<img src="https://dotfyle.com/plugins/obsidian-nvim/obsidian.nvim/shield?style=for-the-badge" />
+ <img src="https://dotfyle.com/plugins/obsidian-nvim/obsidian.nvim/shield?style=for-the-badge" />
 </a>
 </div>
 <hr>
@@ -83,7 +83,8 @@ These default keymaps will only be set if you are in a valid workspace and a mar
 - `:Obsidian new [TITLE]` to create a new note.
   One optional argument: the title of the new note.
 
-- `:Obsidian new_from_template [TITLE]` to create a new note from a template in the templates folder. Selecting from a list using your preferred picker.
+- `:Obsidian new_from_template [TITLE] [TEMPLATE]` to create a new note with `TITLE` from a template with the name `TEMPLATE`.
+  Both arguments are optional. If not given, the template will be selected from a list using your preferred picker.
 
 - `:Obsidian open [QUERY]` to open a note in the Obsidian app.
   One optional argument: a query used to resolve the note to open by ID, path, or alias. If not given, the current buffer is used.

--- a/lua/obsidian/commands/init-legacy.lua
+++ b/lua/obsidian/commands/init-legacy.lua
@@ -153,7 +153,7 @@ M.register("ObsidianSearch", { opts = { nargs = "?", desc = "Search vault" } })
 
 M.register("ObsidianTemplate", { opts = { nargs = "?", desc = "Insert a template" } })
 
-M.register("ObsidianNewFromTemplate", { opts = { nargs = "?", desc = "Create a new note from a template" } })
+M.register("ObsidianNewFromTemplate", { opts = { nargs = "*", desc = "Create a new note from a template" } })
 
 M.register("ObsidianQuickSwitch", { opts = { nargs = "?", desc = "Switch notes" } })
 

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -221,7 +221,7 @@ M.register("search", { nargs = "?" })
 
 M.register("template", { nargs = "?" })
 
-M.register("new_from_template", { nargs = "?" })
+M.register("new_from_template", { nargs = "*" })
 
 M.register("quick_switch", { nargs = "?" })
 

--- a/lua/obsidian/commands/new_from_template.lua
+++ b/lua/obsidian/commands/new_from_template.lua
@@ -4,33 +4,33 @@ local log = require "obsidian.log"
 ---@param client obsidian.Client
 ---@param data CommandArgs
 return function(client, data)
-  if not client:templates_dir() then
-    log.err "Templates folder is not defined or does not exist"
-    return
-  end
-
   local picker = client:picker()
   if not picker then
     log.err "No picker configured"
     return
   end
 
-  ---@type obsidian.Note
-  local note
-  if data.args and data.args:len() > 0 then
-    note = client:create_note { title = data.args, no_write = true }
-  else
-    local title = util.input("Enter title or path (optional): ", { completion = "file" })
+  local title = data.fargs[1]
+  local template = data.fargs[2]
+
+  if title ~= nil and template ~= nil then
+    local note = client:create_note { title = title, template = template, no_write = false }
+    client:open_note(note, { sync = true })
+    return
+  end
+
+  if title == nil or title == "" then
+    title = util.input("Enter title or path (optional): ", { completion = "file" })
     if not title then
       log.warn "Aborted"
       return
     elseif title == "" then
       title = nil
     end
-    note = client:create_note { title = title, no_write = true }
   end
 
-  -- Open the note in a new buffer.
+  ---@type obsidian.Note
+  local note = client:create_note { title = title, no_write = true }
   client:open_note(note, { sync = true })
 
   picker:find_templates {

--- a/lua/obsidian/commands/new_from_template.lua
+++ b/lua/obsidian/commands/new_from_template.lua
@@ -29,13 +29,15 @@ return function(client, data)
     end
   end
 
-  ---@type obsidian.Note
-  local note = client:create_note { title = title, no_write = true }
-  client:open_note(note, { sync = true })
-
   picker:find_templates {
     callback = function(name)
-      client:write_note_to_buffer(note, { template = name })
+      if name == nil or name == "" then
+        log.warn "Aborted"
+        return
+      end
+      ---@type obsidian.Note
+      local note = client:create_note { title = title, template = name, no_write = false }
+      client:open_note(note, { sync = false })
     end,
   }
 end


### PR DESCRIPTION
I adjusted the implementation of the logic a bit.

The check for the `template_dir()` already happens in another place of the code. I removed the redundancy. 

(Note: this is an alternative version  of #34.)

(Side note: it's a bit annoying to maintain both new command and legacy commands.)