### PR TITLE
fix(commands): drop complete=file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `<C-x>` not working after command merging
 - Fixed `blink.cmp` new notes source completion not working properly
 - Fixed `blink.cmp` off by one insert start position
+- Fixed `ObsidianNew`, `ObsidianRename`, and `ObsidianPasteImg` not to evaluate backticked substrings in its arguments, disabling `-complete=file`
 
 ## [v3.10.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.10.0) - 2025-04-12
 

--- a/lua/obsidian/commands/init-legacy.lua
+++ b/lua/obsidian/commands/init-legacy.lua
@@ -138,7 +138,7 @@ M.register("ObsidianTomorrow", { opts = { nargs = 0, desc = "Open the daily note
 
 M.register("ObsidianDailies", { opts = { nargs = "*", desc = "Open a picker with daily notes" } })
 
-M.register("ObsidianNew", { opts = { nargs = "?", complete = "file", desc = "Create a new note" } })
+M.register("ObsidianNew", { opts = { nargs = "?", desc = "Create a new note" } })
 
 M.register(
   "ObsidianOpen",
@@ -174,12 +174,12 @@ M.register("ObsidianWorkspace", { opts = { nargs = "?", desc = "Check or switch 
 
 M.register(
   "ObsidianRename",
-  { opts = { nargs = "?", complete = "file", desc = "Rename note and update all references to it" } }
+  { opts = { nargs = "?", desc = "Rename note and update all references to it" } }
 )
 
 M.register(
   "ObsidianPasteImg",
-  { opts = { nargs = "?", complete = "file", desc = "Paste an image from the clipboard" } }
+  { opts = { nargs = "?", desc = "Paste an image from the clipboard" } }
 )
 
 M.register(

--- a/lua/obsidian/commands/init-legacy.lua
+++ b/lua/obsidian/commands/init-legacy.lua
@@ -172,15 +172,9 @@ M.register("ObsidianToggleCheckbox", { opts = { nargs = 0, desc = "Toggle checkb
 
 M.register("ObsidianWorkspace", { opts = { nargs = "?", desc = "Check or switch workspace" } })
 
-M.register(
-  "ObsidianRename",
-  { opts = { nargs = "?", desc = "Rename note and update all references to it" } }
-)
+M.register("ObsidianRename", { opts = { nargs = "?", desc = "Rename note and update all references to it" } })
 
-M.register(
-  "ObsidianPasteImg",
-  { opts = { nargs = "?", desc = "Paste an image from the clipboard" } }
-)
+M.register("ObsidianPasteImg", { opts = { nargs = "?", desc = "Paste an image from the clipboard" } })
 
 M.register(
   "ObsidianExtractNote",

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -209,7 +209,7 @@ M.register("tomorrow", { nargs = 0 })
 
 M.register("dailies", { nargs = "*" })
 
-M.register("new", { nargs = "?", complete = "file" })
+M.register("new", { nargs = "?" })
 
 M.register("open", { nargs = "?", complete = M.note_complete })
 
@@ -237,9 +237,9 @@ M.register("toggle_checkbox", { nargs = 0, range = true })
 
 M.register("workspace", { nargs = "?" })
 
-M.register("rename", { nargs = "?", complete = "file" })
+M.register("rename", { nargs = "?" })
 
-M.register("paste_img", { nargs = "?", complete = "file" })
+M.register("paste_img", { nargs = "?" })
 
 M.register("extract_note", { nargs = "?", range = true })
 


### PR DESCRIPTION
With `complete=file`, Ex command evaluates substrings quoted by backticks in its args before the args are passed to their callback functions via `data`. This should not be an ideal behavior for `:ObsidianNew` and `ObsidianRename`, and `ObsidianPasteImg`.

Addition to that, the `complete=file` settings do not make sense because the commands do not expect unique ID of which filename is composed as arguments, but a title in natural language.