### PR TITLE
feat: user autocmd events instead of callback manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow users to have a period in the note ID as in a [Johnny.Decimal](https://johnnydecimal.com/) format
 - Added `backlinks` config table with the associated `obsidian.config.BacklinkOpts`
 - Added `parse_headers` toggle that disables markdown header parsing for `ObsidianBacklinks`.
+- Added autocmd events for user scripting, see https://github.com/obsidian-nvim/obsidian.nvim/wiki/Autocmds
 
 ### Changed
 

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -137,7 +137,7 @@ Client.set_workspace = function(self, workspace, opts)
 
   self.callback_manager:post_set_workspace(workspace)
   vim.api.nvim_exec_autocmds("User", {
-    pattern = "ObsidianSetWorkpspacePost",
+    pattern = "ObsidianWorkpspaceSet",
     data = { workspace = workspace },
   })
 end

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -135,7 +135,12 @@ Client.set_workspace = function(self, workspace, opts)
     self.current_workspace:lock()
   end
 
-  self.callback_manager:post_set_workspace(workspace)
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "ObsidianPostSetWorkpspace",
+    data = {
+      workspace = workspace,
+    },
+  })
 end
 
 --- Get the normalize opts for a given workspace.

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -135,11 +135,10 @@ Client.set_workspace = function(self, workspace, opts)
     self.current_workspace:lock()
   end
 
+  self.callback_manager:post_set_workspace(workspace)
   vim.api.nvim_exec_autocmds("User", {
-    pattern = "ObsidianPostSetWorkpspace",
-    data = {
-      workspace = workspace,
-    },
+    pattern = "ObsidianSetWorkpspacePost",
+    data = { workspace = workspace },
   })
 end
 

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -163,17 +163,6 @@ obsidian.setup = function(opts)
         require("obsidian.completion.plugin_initializers.blink").inject_sources()
       end
 
-      local win = vim.api.nvim_get_current_win()
-
-      vim.treesitter.start(ev.buf, "markdown") -- for when user don't use nvim-treesitter
-
-      vim.wo[win].foldmethod = "expr"
-      vim.wo[win].foldexpr = "v:lua.vim.treesitter.foldexpr()"
-      vim.wo[win].fillchars = "foldopen:,foldclose:,fold: ,foldsep: "
-      vim.wo[win].foldtext = ""
-      vim.wo[win].foldlevel = 99
-      vim.wo[win].smoothscroll = true
-
       -- Run enter-note callback.
       client.callback_manager:enter_note(function()
         return obsidian.Note.from_buffer(ev.buf)

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -121,7 +121,6 @@ obsidian.setup = function(opts)
   local function exec_autocmds(pattern, buf)
     vim.api.nvim_exec_autocmds("User", {
       pattern = pattern,
-      group = group,
       data = {
         note = require("obsidian.note").from_buffer(buf),
       },


### PR DESCRIPTION
A draft to see what it feels like to have a autocmd system

Advantages:
1. allow any number of callbacks called from different places
2. no need to have callbacks in config
3. better for user scripting and other plugin to integrate.

Some very mature plugins in the community all supports this: 
https://github.com/nvim-telescope/telescope.nvim?tab=readme-ov-file#autocmds
https://github.com/OXY2DEV/markview.nvim?tab=readme-ov-file#-autocmds

- [x] Wiki section with examples
