### PR TITLE
fix: remove `plenary.job` and `plenary.scandir`usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,8 +63,8 @@ jobs:
 
           - os: windows-latest
             nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip
-            manager: choco
             packages: ripgrep
+            manager: choco
             task:
               name: Test
               run: |
@@ -82,7 +82,9 @@ jobs:
         if: matrix.os == 'windows-latest' && matrix.packages
         shell: powershell
         run: |
-          Set-ExecutionPolicy Bypass -Scope Process -Force iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) choco install ${{ matrix.packages }} -y
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+          choco install ${{ matrix.packages }} -y
 
       - name: Install neovim (nix)
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,8 @@ jobs:
 
           - os: windows-latest
             nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip
+            manager: choco
+            packages: ripgrep
             task:
               name: Test
               run: |
@@ -75,6 +77,12 @@ jobs:
       - name: Install packages
         if: ${{ matrix.packages }}
         run: ${{ matrix.manager }} install ${{ matrix.packages }}
+
+      - name: Install packages (windows)
+        if: matrix.os == 'windows-latest' && matrix.packages
+        shell: powershell
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) choco install ${{ matrix.packages }} -y
 
       - name: Install neovim (nix)
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Stylua version from 0.15.1 → 2.1.0.
 - Use `vim.deprecate` to show deprecate warnings.
 - Deprecate `open_app_foreground`.
+- Remove most `plenary.nvim` usage.
 
 ### Fixed
 

--- a/lua/obsidian/async.lua
+++ b/lua/obsidian/async.lua
@@ -347,14 +347,14 @@ local init_job = function(cmd, args, on_stdout, on_exit, sync)
     end
   end
 
+  on_stdout = util.buffer_fn(on_stdout)
+
   local function stdout(err, data)
     if err ~= nil then
       return log.err("Error running command '%s' with args '%s'\n:%s", cmd, args, err)
     end
-    if on_stdout ~= nil and data ~= nil then
-      for line in vim.gsplit(data, "\n", { trimempty = true }) do
-        on_stdout(line)
-      end
+    if data ~= nil then
+      on_stdout(data)
     end
   end
 

--- a/lua/obsidian/async.lua
+++ b/lua/obsidian/async.lua
@@ -3,8 +3,7 @@ local async = require "plenary.async"
 local channel = require("plenary.async.control").channel
 local log = require "obsidian.log"
 local util = require "obsidian.util"
-local iter = vim.iter
-local uv = vim.loop
+local iter, uv = vim.iter, vim.uv
 
 local M = {}
 
@@ -412,11 +411,11 @@ M.throttle = function(fn, timeout)
       timer:stop()
     end
 
-    local ms_remaining = timeout - (vim.loop.now() - last_call)
+    local ms_remaining = timeout - (vim.uv.now() - last_call)
 
     if ms_remaining > 0 then
       if timer == nil then
-        timer = assert(vim.loop.new_timer())
+        timer = assert(vim.uv.new_timer())
       end
 
       local args = { ... }
@@ -431,12 +430,12 @@ M.throttle = function(fn, timeout)
             timer = nil
           end
 
-          last_call = vim.loop.now()
+          last_call = vim.uv.now()
           fn(unpack(args))
         end)
       )
     else
-      last_call = vim.loop.now()
+      last_call = vim.uv.now()
       fn(...)
     end
   end

--- a/lua/obsidian/async.lua
+++ b/lua/obsidian/async.lua
@@ -334,7 +334,7 @@ end
 local init_job = function(cmd, args, on_stdout, on_exit, sync)
   local stderr_lines = false
 
-  local on_exit = function(obj)
+  local on_obj = function(obj)
     --- NOTE: commands like `rg` return a non-zero exit code when there are no matches, which is okay.
     --- So we only log no-zero exit codes as errors when there's also stderr lines.
     if obj.code > 0 and stderr_lines then
@@ -377,19 +377,11 @@ local init_job = function(cmd, args, on_stdout, on_exit, sync)
     vim.list_extend(cmds, args)
 
     if sync then
-      local obj = vim
-        .system(cmds, {
-          stdout = stdout,
-          stderr = stderr,
-        })
-        :wait()
-      on_exit(obj)
+      local obj = vim.system(cmds, { stdout = stdout, stderr = stderr }):wait()
+      on_obj(obj)
       return obj
     else
-      vim.system(cmds, {
-        stdout = stdout,
-        stderr = stderr,
-      }, on_exit)
+      vim.system(cmds, { stdout = stdout, stderr = stderr }, on_obj)
     end
   end
 end

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1545,14 +1545,18 @@ end
 ---  - `pattern`: A Lua search pattern. Defaults to ".*%.md".
 Client.apply_async_raw = function(self, on_path, opts)
   opts = opts or {}
-  local skip_dir = self:templates_dir()
-
-  --- TODO: test depth, skip
-  for path in vim.fs.dir(tostring(self.dir)) do
+  for path in
+    vim.fs.dir(tostring(self.dir), {
+      depth = 10,
+      skip = function(dir)
+        return not vim.startswith(dir, ".") and dir ~= vim.fs.basename(tostring(self:templates_dir()))
+      end,
+      follow = true,
+    })
+  do
     local absolute_path = vim.fs.joinpath(tostring(self.dir), path)
-    local skip = skip_dir and skip_dir:is_parent_of(absolute_path)
 
-    if not skip and vim.endswith(absolute_path, ".md") then
+    if vim.endswith(absolute_path, ".md") then
       on_path(absolute_path)
     end
   end

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1541,19 +1541,18 @@ end
 ---
 --- Options:
 ---  - `on_done`: A function to call when all paths have been processed.
----  - `timeout`: An optional timeout.
----  - `pattern`: A Lua search pattern. Defaults to ".*%.md".
 Client.apply_async_raw = function(self, on_path, opts)
   opts = opts or {}
-  for path in
-    vim.fs.dir(tostring(self.dir), {
-      depth = 10,
-      skip = function(dir)
-        return not vim.startswith(dir, ".") and dir ~= vim.fs.basename(tostring(self:templates_dir()))
-      end,
-      follow = true,
-    })
-  do
+
+  local dir_opts = {
+    depth = 10,
+    skip = function(dir)
+      return not vim.startswith(dir, ".") and dir ~= vim.fs.basename(tostring(self:templates_dir()))
+    end,
+    follow = true,
+  }
+
+  for path in vim.fs.dir(tostring(self.dir), dir_opts) do
     local absolute_path = vim.fs.joinpath(tostring(self.dir), path)
 
     if vim.endswith(absolute_path, ".md") then
@@ -1561,7 +1560,9 @@ Client.apply_async_raw = function(self, on_path, opts)
     end
   end
 
-  opts.on_done()
+  if opts.on_done then
+    opts.on_done()
+  end
 end
 
 --- Generate a unique ID for a new note. This respects the user's `note_id_func` if configured,

--- a/lua/obsidian/commands/check.lua
+++ b/lua/obsidian/commands/check.lua
@@ -5,14 +5,14 @@ local iter = vim.iter
 ---@param client obsidian.Client
 ---@param _ CommandArgs
 return function(client, _)
-  local start_time = vim.loop.hrtime()
+  local start_time = vim.uv.hrtime()
   local count = 0
   local errors = {}
   local warnings = {}
   local opts = {
     timeout = 5000,
     on_done = function()
-      local runtime = math.floor((vim.loop.hrtime() - start_time) / 1000000)
+      local runtime = math.floor((vim.uv.hrtime() - start_time) / 1000000)
       local messages = { "Checked " .. tostring(count) .. " notes in " .. runtime .. "ms" }
       local log_level = vim.log.levels.INFO
 

--- a/lua/obsidian/commands/check.lua
+++ b/lua/obsidian/commands/check.lua
@@ -38,7 +38,7 @@ return function(client, _)
 
   client:apply_async_raw(function(path)
     local relative_path = client:vault_relative_path(path, { strict = true })
-    local ok, res = pcall(Note.from_file_async, path)
+    local ok, res = pcall(Note.from_file, path)
 
     if not ok then
       errors[#errors + 1] = string.format("Failed to parse note '%s': ", relative_path, res)

--- a/lua/obsidian/path.lua
+++ b/lua/obsidian/path.lua
@@ -479,32 +479,9 @@ Path.rmdir = function(self)
   end
 end
 
+-- TODO: not implemented and not used, after we get to 0.11 we can simply use vim.fs.rm
 --- Recursively remove an entire directory and its contents.
-Path.rmtree = function(self)
-  local scan = require "plenary.scandir"
-
-  local resolved = self:resolve { strict = true }
-  if not resolved:is_dir() then
-    error("NotADirectoryError: " .. resolved.filename)
-  end
-
-  -- First unlink all files.
-  scan.scan_dir(resolved.filename, {
-    hidden = true,
-    on_insert = function(file)
-      Path.new(file):unlink()
-    end,
-  })
-
-  -- Now iterate backwards to clean up remaining dirs.
-  local dirs = scan.scan_dir(resolved.filename, { add_dirs = true, hidden = true })
-  for i = #dirs, 1, -1 do
-    Path.new(dirs[i]):rmdir()
-  end
-
-  -- And finally remove the top level dir.
-  resolved:rmdir()
-end
+Path.rmtree = function(self) end
 
 --- Create a file at this given path.
 ---

--- a/lua/obsidian/path.lua
+++ b/lua/obsidian/path.lua
@@ -194,11 +194,11 @@ Path.temp = function(opts)
   return Path.new(tmpname)
 end
 
---- Get a path corresponding to the current working directory as given by `vim.loop.cwd()`.
+--- Get a path corresponding to the current working directory as given by `vim.uv.cwd()`.
 ---
 ---@return obsidian.Path
 Path.cwd = function()
-  return assert(Path.new(vim.loop.cwd()))
+  return assert(Path.new(vim.uv.cwd()))
 end
 
 --- Get a path corresponding to a buffer.
@@ -390,7 +390,7 @@ end
 Path.stat = function(self)
   local realpath = self:abspath()
   if realpath then
-    local stat, _ = vim.loop.fs_stat(realpath)
+    local stat, _ = vim.uv.fs_stat(realpath)
     return stat
   end
 end
@@ -447,7 +447,7 @@ Path.mkdir = function(self, opts)
     end
   end
 
-  if vim.loop.fs_mkdir(self.filename, mode) then
+  if vim.uv.fs_mkdir(self.filename, mode) then
     return
   end
 
@@ -473,7 +473,7 @@ Path.rmdir = function(self)
     return
   end
 
-  local ok, err_name, err_msg = vim.loop.fs_rmdir(resolved.filename)
+  local ok, err_name, err_msg = vim.uv.fs_rmdir(resolved.filename)
   if not ok then
     error(err_name .. ": " .. err_msg)
   end
@@ -493,7 +493,7 @@ Path.touch = function(self, opts)
   local resolved = self:resolve { strict = false }
   if resolved:exists() then
     local new_time = os.time()
-    vim.loop.fs_utime(resolved.filename, new_time, new_time)
+    vim.uv.fs_utime(resolved.filename, new_time, new_time)
     return
   end
 
@@ -502,11 +502,11 @@ Path.touch = function(self, opts)
     error("FileNotFoundError: " .. parent.filename)
   end
 
-  local fd, err_name, err_msg = vim.loop.fs_open(resolved.filename, "w", mode)
+  local fd, err_name, err_msg = vim.uv.fs_open(resolved.filename, "w", mode)
   if not fd then
     error(err_name .. ": " .. err_msg)
   end
-  vim.loop.fs_close(fd)
+  vim.uv.fs_close(fd)
 end
 
 --- Rename this file or directory to the given target.
@@ -518,7 +518,7 @@ Path.rename = function(self, target)
   local resolved = self:resolve { strict = false }
   target = Path.new(target)
 
-  local ok, err_name, err_msg = vim.loop.fs_rename(resolved.filename, target.filename)
+  local ok, err_name, err_msg = vim.uv.fs_rename(resolved.filename, target.filename)
   if not ok then
     error(err_name .. ": " .. err_msg)
   end
@@ -541,7 +541,7 @@ Path.unlink = function(self, opts)
     return
   end
 
-  local ok, err_name, err_msg = vim.loop.fs_unlink(resolved.filename)
+  local ok, err_name, err_msg = vim.uv.fs_unlink(resolved.filename)
   if not ok then
     error(err_name .. ": " .. err_msg)
   end

--- a/lua/obsidian/search.lua
+++ b/lua/obsidian/search.lua
@@ -1,5 +1,4 @@
 local Deque = require("plenary.async.structs").Deque
-local scan = require "plenary.scandir"
 
 local Path = require "obsidian.path"
 local abc = require "obsidian.abc"
@@ -569,44 +568,6 @@ M.find_async = function(dir, term, opts, on_match, on_exit)
       on_exit(code)
     end
   end)
-end
-
---- Find all notes with the given file_name recursively in a directory.
----
----@param dir string|obsidian.Path
----@param note_file_name string
----@param callback fun(paths: obsidian.Path[])
-M.find_notes_async = function(dir, note_file_name, callback)
-  if not vim.endswith(note_file_name, ".md") then
-    note_file_name = note_file_name .. ".md"
-  end
-
-  local notes = {}
-  local root_dir = Path.new(dir):resolve { strict = true }
-
-  local visit_dir = function(entry)
-    ---@type obsidian.Path
-    ---@diagnostic disable-next-line: assign-type-mismatch
-    local note_path = Path:new(entry) / note_file_name
-    if note_path:is_file() then
-      notes[#notes + 1] = note_path
-    end
-  end
-
-  -- We must separately check the vault's root dir because scan_dir will
-  -- skip it, but Obsidian does allow root-level notes.
-  visit_dir(root_dir)
-
-  scan.scan_dir_async(root_dir.filename, {
-    hidden = false,
-    add_dirs = false,
-    only_dirs = true,
-    respect_gitignore = true,
-    on_insert = visit_dir,
-    on_exit = function(_)
-      callback(notes)
-    end,
-  })
 end
 
 return M

--- a/lua/obsidian/search.lua
+++ b/lua/obsidian/search.lua
@@ -468,7 +468,7 @@ end
 ---@param on_exit fun(exit_code: integer)|?
 M.search_async = function(dir, term, opts, on_match, on_exit)
   local cmd = M.build_search_cmd(dir, term, opts)
-  run_job_async(cmd[1], { unpack(cmd, 2) }, function(line)
+  run_job_async(cmd, function(line)
     local data = vim.json.decode(line)
     if data["type"] == "match" then
       local match_data = data.data
@@ -491,7 +491,7 @@ end
 M.find_async = function(dir, term, opts, on_match, on_exit)
   local norm_dir = Path.new(dir):resolve { strict = true }
   local cmd = M.build_find_cmd(tostring(norm_dir), term, opts)
-  run_job_async(cmd[1], { unpack(cmd, 2) }, on_match, function(code)
+  run_job_async(cmd, on_match, function(code)
     if on_exit ~= nil then
       on_exit(code)
     end

--- a/lua/obsidian/search.lua
+++ b/lua/obsidian/search.lua
@@ -1,5 +1,3 @@
-local Deque = require("plenary.async.structs").Deque
-
 local Path = require "obsidian.path"
 local abc = require "obsidian.abc"
 local util = require "obsidian.util"
@@ -461,41 +459,7 @@ end
 ---@field absolute_offset integer
 ---@field submatches SubMatch[]
 
---- Search markdown files in a directory for a given term. Return an iterator
---- over `MatchData`.
----
----@param dir string|obsidian.Path
----@param term string
----@param opts obsidian.search.SearchOpts|?
----
----@return function
-M.search = function(dir, term, opts)
-  local matches = Deque.new()
-  local done = false
-
-  M.search_async(dir, term, opts, function(match_data)
-    matches:pushright(match_data)
-  end, function(_)
-    done = true
-  end)
-
-  ---Iterator over matches.
-  ---
-  ---@return MatchData|?
-  return function()
-    while true do
-      if not matches:is_empty() then
-        return matches:popleft()
-      elseif matches:is_empty() and done then
-        return nil
-      else
-        vim.wait(100)
-      end
-    end
-  end
-end
-
---- An async version of `.search()`. Each match is passed to the `on_match` callback.
+--- Search markdown files in a directory for a given term. Each match is passed to the `on_match` callback.
 ---
 ---@param dir string|obsidian.Path
 ---@param term string|string[]
@@ -517,41 +481,7 @@ M.search_async = function(dir, term, opts, on_match, on_exit)
   end)
 end
 
---- Find markdown files in a directory matching a given term. Return an iterator
---- over file names.
----
----@param dir string|obsidian.Path
----@param term string
----@param opts obsidian.search.SearchOpts|?
----
----@return function
-M.find = function(dir, term, opts)
-  local paths = Deque.new()
-  local done = false
-
-  M.find_async(dir, term, opts, function(path)
-    paths:pushright(path)
-  end, function(_)
-    done = true
-  end)
-
-  --- Iterator over matches.
-  ---
-  ---@return MatchData|?
-  return function()
-    while true do
-      if not paths:is_empty() then
-        return paths:popleft()
-      elseif paths:is_empty() and done then
-        return nil
-      else
-        vim.wait(100)
-      end
-    end
-  end
-end
-
---- An async version of `.find()`. Each matching path is passed to the `on_match` callback.
+--- Find markdown files in a directory matching a given term. Each matching path is passed to the `on_match` callback.
 ---
 ---@param dir string|obsidian.Path
 ---@param term string

--- a/lua/obsidian/search.lua
+++ b/lua/obsidian/search.lua
@@ -561,9 +561,7 @@ end
 M.find_async = function(dir, term, opts, on_match, on_exit)
   local norm_dir = Path.new(dir):resolve { strict = true }
   local cmd = M.build_find_cmd(tostring(norm_dir), term, opts)
-  run_job_async(cmd[1], { unpack(cmd, 2) }, function(line)
-    on_match(line)
-  end, function(code)
+  run_job_async(cmd[1], { unpack(cmd, 2) }, on_match, function(code)
     if on_exit ~= nil then
       on_exit(code)
     end

--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -486,7 +486,7 @@ end
 ---@param bufnr integer
 ---@param ui_opts obsidian.config.UIOpts
 local function update_extmarks(bufnr, ns_id, ui_opts)
-  local start_time = vim.loop.hrtime()
+  local start_time = vim.uv.hrtime()
   local n_marks_added = 0
   local n_marks_cleared = 0
 
@@ -548,7 +548,7 @@ local function update_extmarks(bufnr, ns_id, ui_opts)
     end
   end
 
-  local runtime = math.floor((vim.loop.hrtime() - start_time) / 1000000)
+  local runtime = math.floor((vim.uv.hrtime() - start_time) / 1000000)
   log.debug("Added %d new marks, cleared %d old marks in %dms", n_marks_added, n_marks_cleared, runtime)
 end
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -524,8 +524,8 @@ util.get_os = function()
   if vim.fn.has "win32" == 1 then
     this_os = util.OSType.Windows
   else
-    local sysname = vim.loop.os_uname().sysname
-    local release = vim.loop.os_uname().release:lower()
+    local sysname = vim.uv.os_uname().sysname
+    local release = vim.uv.os_uname().release:lower()
     if sysname:lower() == "linux" and string.find(release, "microsoft") then
       this_os = util.OSType.Wsl
     else

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -5,6 +5,18 @@ local compat = require "obsidian.compat"
 local util = {}
 
 -------------------
+--- File tools ----
+-------------------
+
+---@param file string
+---@param contents string
+util.write_file = function(file, contents)
+  local fd = assert(io.open(file, "w+"))
+  fd:write(contents)
+  fd:close()
+end
+
+-------------------
 --- Iter tools ----
 -------------------
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -894,17 +894,10 @@ util.get_plugin_info = function(name)
   end
 
   local out = { path = src_root }
+  local obj = vim.system({ "git", "rev-parse", "HEAD" }, { cwd = src_root }):wait(1000)
 
-  local Job = require "plenary.job"
-  local output, exit_code = Job:new({ ---@diagnostic disable-line: missing-fields
-    command = "git",
-    args = { "rev-parse", "HEAD" },
-    cwd = src_root,
-    enable_recording = true,
-  }):sync(1000)
-
-  if exit_code == 0 then
-    out.commit = output[1]
+  if obj.code == 0 then
+    out.commit = vim.trim(obj.stdout)
   end
 
   return out
@@ -913,15 +906,13 @@ end
 ---@param cmd string
 ---@return string|?
 util.get_external_dependency_info = function(cmd)
-  local Job = require "plenary.job"
-  local output, exit_code = Job:new({ ---@diagnostic disable-line: missing-fields
-    command = cmd,
-    args = { "--version" },
-    enable_recording = true,
-  }):sync(1000)
+  local obj = vim.system({ cmd, "--version" }, {}):wait(1000)
 
-  if exit_code == 0 then
-    return output[1]
+  if obj.code == 0 then
+    local version = vim.version.parse(obj.stdout)
+    if version then
+      return ("%d.%d.%d"):format(version.major, version.minor, version.patch)
+    end
   end
 end
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -1467,4 +1467,24 @@ util.isNan = function(v)
   return tostring(v) == tostring(0 / 0)
 end
 
+---Higher order function, make sure a function is called with complete lines
+---@param fn fun(string)?
+---@return fun(string)
+util.buffer_fn = function(fn)
+  if not fn then
+    return function() end
+  end
+  local buffer = ""
+  return function(data)
+    buffer = buffer .. data
+    local lines = vim.split(buffer, "\n")
+    if #lines > 1 then
+      for i = 1, #lines - 1 do
+        fn(lines[i])
+      end
+      buffer = lines[#lines] -- Store remaining partial line
+    end
+  end
+end
+
 return util

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,0 +1,41 @@
+local Path = require "obsidian.path"
+local obsidian = require "obsidian"
+
+local M = {}
+
+---Get a client in a temporary directory.
+---
+---@param run fun(client: obsidian.Client)
+M.with_tmp_client = function(run, dir)
+  local tmp
+  if not dir then
+    tmp = true
+    dir = dir or Path.temp { suffix = "-obsidian" }
+    dir:mkdir { parents = true }
+  end
+
+  local client = obsidian.new_from_dir(tostring(dir))
+  client.opts.note_id_func = function(title)
+    local id = ""
+    if title ~= nil then
+      id = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
+    else
+      for _ = 1, 4 do
+        id = id .. string.char(math.random(65, 90))
+      end
+    end
+    return id
+  end
+
+  local ok, err = pcall(run, client)
+
+  if tmp then
+    vim.fn.delete(tostring(dir), "rf")
+  end
+
+  if not ok then
+    error(err)
+  end
+end
+
+return M

--- a/tests/test_async.lua
+++ b/tests/test_async.lua
@@ -12,7 +12,7 @@ describe("AsyncExecutor.map()", function()
 
     executor:map(
       function(id)
-        local uv = vim.loop
+        local uv = vim.uv
         uv.sleep(100)
         return id
       end,
@@ -36,7 +36,7 @@ describe("AsyncExecutor.map()", function()
 
     executor:map(
       function(id)
-        local uv = vim.loop
+        local uv = vim.uv
         uv.sleep(100)
         return id
       end,
@@ -57,7 +57,7 @@ describe("ThreadPoolExecutor.map()", function()
 
     executor:map(
       function(id)
-        local uv = vim.loop
+        local uv = vim.uv
         uv.sleep(100)
         return id
       end,
@@ -81,7 +81,7 @@ describe("ThreadPoolExecutor.map()", function()
 
     executor:map(
       function(id)
-        local uv = vim.loop
+        local uv = vim.uv
         uv.sleep(100)
         return id
       end,

--- a/tests/test_client.lua
+++ b/tests/test_client.lua
@@ -24,7 +24,7 @@ local with_tmp_client = function(run)
 
   local ok, err = pcall(run, client)
 
-  dir:rmtree()
+  vim.fn.delete(tostring(dir), "rf")
 
   if not ok then
     error(err)

--- a/tests/test_client.lua
+++ b/tests/test_client.lua
@@ -2,7 +2,7 @@ local Path = require "obsidian.path"
 local Note = require "obsidian.note"
 local obsidian = require "obsidian"
 
-local fixtures = vim.fs.joinpath(vim.uv.cwd(), "test", "fixtures", "notes")
+local fixtures = vim.fs.joinpath(vim.uv.cwd(), "tests", "fixtures", "notes")
 
 ---Get a client in a temporary directory.
 ---
@@ -264,11 +264,11 @@ describe("Client:apply_async_raw", function()
     local c = 0
     with_tmp_client(function(client)
       client:apply_async_raw(function(path)
-        assert.equals(true, vim.endswith(path, ".md"))
+        MiniTest.expect.equality(true, vim.endswith(path, ".md"))
         c = c + 1
       end, {
         on_done = function()
-          assert.equal(11, c)
+          MiniTest.expect.equality(11, c)
         end,
       })
     end, fixtures)

--- a/tests/test_client_mini.lua
+++ b/tests/test_client_mini.lua
@@ -1,0 +1,23 @@
+local h = dofile "tests/helpers.lua"
+
+local new_set, eq = MiniTest.new_set, MiniTest.expect.equality
+
+local fixtures = vim.fs.joinpath(vim.uv.cwd(), "tests", "fixtures", "notes")
+
+local T = new_set()
+
+T["Client:apply_async_raw"] = function()
+  local c = 0
+  h.with_tmp_client(function(client)
+    client:apply_async_raw(function(path)
+      eq(true, vim.endswith(path, ".md"))
+      c = c + 1
+    end, {
+      on_done = function()
+        eq(11, c)
+      end,
+    })
+  end, fixtures)
+end
+
+return T

--- a/tests/test_path.lua
+++ b/tests/test_path.lua
@@ -198,19 +198,19 @@ end)
 describe("Path.resolve()", function()
   it("should always resolve to the absolute path when it exists", function()
     MiniTest.expect.equality(
-      vim.fs.normalize(assert(vim.loop.fs_realpath "README.md")),
+      vim.fs.normalize(assert(vim.uv.fs_realpath "README.md")),
       Path.new("README.md"):resolve().filename
     )
   end)
 
   it("should always resolve to an absolute path if a parent exists", function()
     MiniTest.expect.equality(
-      vim.fs.normalize(assert(vim.loop.fs_realpath ".")) .. "/tmp/dne.md",
+      vim.fs.normalize(assert(vim.uv.fs_realpath ".")) .. "/tmp/dne.md",
       Path.new("tmp/dne.md"):resolve().filename
     )
 
     MiniTest.expect.equality(
-      vim.fs.normalize(assert(vim.loop.fs_realpath ".")) .. "/dne.md",
+      vim.fs.normalize(assert(vim.uv.fs_realpath ".")) .. "/dne.md",
       Path.new("dne.md"):resolve().filename
     )
   end)

--- a/tests/test_search.lua
+++ b/tests/test_search.lua
@@ -1,42 +1,7 @@
-local async = require "plenary.async"
-local channel = require("plenary.async.control").channel
 local search = require "obsidian.search"
-local Path = require "obsidian.path"
-
 local RefTypes = search.RefTypes
 local SearchOpts = search.SearchOpts
 local Patterns = search.Patterns
-
-describe("search.find_notes_async()", function()
-  it("should recursively find notes in a directory given a file name", function()
-    async.util.block_on(function()
-      local tx, rx = channel.oneshot()
-      search.find_notes_async(".", "foo.md", function(matches)
-        MiniTest.expect.equality(#matches, 1)
-        MiniTest.expect.equality(
-          tostring(matches[1]),
-          tostring(Path.new("./test/fixtures/notes/foo.md"):resolve { strict = true })
-        )
-        tx()
-      end)
-      rx()
-    end, 2000)
-  end)
-  it("should recursively find notes in a directory given a partial path", function()
-    async.util.block_on(function()
-      local tx, rx = channel.oneshot()
-      search.find_notes_async(".", "notes/foo.md", function(matches)
-        MiniTest.expect.equality(#matches, 1)
-        MiniTest.expect.equality(
-          tostring(matches[1]),
-          tostring(Path.new("./test/fixtures/notes/foo.md"):resolve { strict = true })
-        )
-        tx()
-      end)
-      rx()
-    end, 2000)
-  end)
-end)
 
 describe("search.find_refs()", function()
   it("should find positions of all refs", function()

--- a/tests/test_search.lua
+++ b/tests/test_search.lua
@@ -5,7 +5,7 @@ local Patterns = search.Patterns
 
 describe("search.find_async", function()
   it("should find files with search term in name", function()
-    local fixtures = vim.fs.joinpath(vim.uv.cwd(), "test", "fixtures", "notes")
+    local fixtures = vim.fs.joinpath(vim.uv.cwd(), "tests", "fixtures", "notes")
     local match_counter = 0
 
     search.find_async(fixtures, "foo", {}, function(match)
@@ -20,7 +20,7 @@ end)
 
 describe("search.search_async", function()
   it("should find files with search term in content", function()
-    local fixtures = vim.fs.joinpath(vim.uv.cwd(), "test", "fixtures", "notes")
+    local fixtures = vim.fs.joinpath(vim.uv.cwd(), "tests", "fixtures", "notes")
     local match_counter = 0
     search.search_async(fixtures, "foo", {}, function(match)
       MiniTest.expect.equality("foo", match.submatches[1].match.text)

--- a/tests/test_search.lua
+++ b/tests/test_search.lua
@@ -3,6 +3,35 @@ local RefTypes = search.RefTypes
 local SearchOpts = search.SearchOpts
 local Patterns = search.Patterns
 
+describe("search.find_async", function()
+  it("should find files with search term in name", function()
+    local fixtures = vim.fs.joinpath(vim.uv.cwd(), "test", "fixtures", "notes")
+    local match_counter = 0
+
+    search.find_async(fixtures, "foo", {}, function(match)
+      MiniTest.expect.equality(true, match:find "foo" ~= nil)
+      match_counter = match_counter + 1
+    end, function(exit_code)
+      MiniTest.expect.equality(0, exit_code)
+      MiniTest.expect.equality(2, match_counter)
+    end)
+  end)
+end)
+
+describe("search.search_async", function()
+  it("should find files with search term in content", function()
+    local fixtures = vim.fs.joinpath(vim.uv.cwd(), "test", "fixtures", "notes")
+    local match_counter = 0
+    search.search_async(fixtures, "foo", {}, function(match)
+      MiniTest.expect.equality("foo", match.submatches[1].match.text)
+      match_counter = match_counter + 1
+    end, function(exit_code)
+      MiniTest.expect.equality(0, exit_code)
+      MiniTest.expect.equality(8, match_counter)
+    end)
+  end)
+end)
+
 describe("search.find_refs()", function()
   it("should find positions of all refs", function()
     local s = "[[Foo]] [[foo|Bar]]"


### PR DESCRIPTION
First step in removing plenary.

1. removed all `plenary.job` usage
Functionality impacted: find notes, backlinks, tags. **Try these out when reviewing this.**

2. removed `plenary.scandir` usage

- in `Path:rmtree`, not used anywhere except as a test helper
- in `search.find_notes_async`, literally not used anywhere in the code, but it has two tests lol. We shall write a pure lua version similar to this, not depending on `rg` or `plenary`, so this can be deleted as well.
- in `client:apply_async_raw`, it should be nicely replaced by `vim.fs.dir`, needs more test. It is only used by `Obsidian check` and result is now 30 times faster on my vault :)

3. removed `plenary.context_manager` uasge, sometime the code uses an `File` class that only runs in async context, some times uses the context manger.  Iterators are good enough. even lazy.nvim just uses simple `read_file` `write_file` helpers with lua builtin function.

4. removed `plenary.deque` usage, it is for two find/search functions that returns iterators, which is not used anywhere, we can introduce similar capability if later needed.

5. use `mini.test` to test async functions, plenary just don't support it to my knowledge, should be applied after #169 

TODO:
- [x] test for `client:apply_async_raw`
- [x] fix the line output issue.
