### PR TITLE
feat: configure `foldmethod` and `foldexpr` in ftplugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove `itertools.lua` in favor of `vim.iter`
+- Configure `foldmethod`, `foldexpr`, and `foldlevel` in ftplugin instead of the BufEnter event. This allows user overrides of these configurations.
+- Remove `fillchars`, `foldtext`, and `smoothscroll` configurations.
 
 ### Fixed
 

--- a/after/ftplugin/markdown.lua
+++ b/after/ftplugin/markdown.lua
@@ -11,7 +11,9 @@ end
 
 vim.o.commentstring = "%%%s%%"
 
+local win = vim.api.nvim_get_current_win()
+
 vim.treesitter.start(buf, "markdown") -- for when user don't use nvim-treesitter
-vim.opt_local.foldmethod = "expr"
-vim.opt_local.foldexpr = "v:lua.vim.treesitter.foldexpr()"
-vim.opt_local.foldlevel = 99
+vim.wo[win].foldmethod = "expr"
+vim.wo[win].foldexpr = "v:lua.vim.treesitter.foldexpr()"
+vim.wo[win].foldlevel = 99

--- a/after/ftplugin/markdown.lua
+++ b/after/ftplugin/markdown.lua
@@ -14,3 +14,4 @@ vim.o.commentstring = "%%%s%%"
 vim.treesitter.start(buf, "markdown") -- for when user don't use nvim-treesitter
 vim.opt_local.foldmethod = "expr"
 vim.opt_local.foldexpr = "v:lua.vim.treesitter.foldexpr()"
+vim.opt_local.foldlevel = 99

--- a/after/ftplugin/markdown.lua
+++ b/after/ftplugin/markdown.lua
@@ -10,3 +10,7 @@ if not workspace then
 end
 
 vim.o.commentstring = "%%%s%%"
+
+vim.treesitter.start(buf, "markdown") -- for when user don't use nvim-treesitter
+vim.opt_local.foldmethod = "expr"
+vim.opt_local.foldexpr = "v:lua.vim.treesitter.foldexpr()"

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -151,17 +151,6 @@ obsidian.setup = function(opts)
         require("obsidian.completion.plugin_initializers.blink").inject_sources()
       end
 
-      local win = vim.api.nvim_get_current_win()
-
-      vim.treesitter.start(ev.buf, "markdown") -- for when user don't use nvim-treesitter
-
-      vim.wo[win].foldmethod = "expr"
-      vim.wo[win].foldexpr = "v:lua.vim.treesitter.foldexpr()"
-      vim.wo[win].fillchars = "foldopen:,foldclose:,fold: ,foldsep: "
-      vim.wo[win].foldtext = ""
-      vim.wo[win].foldlevel = 99
-      vim.wo[win].smoothscroll = true
-
       -- Run enter-note callback.
       client.callback_manager:enter_note(function()
         return obsidian.Note.from_buffer(ev.bufnr)


### PR DESCRIPTION
- Placed in `ftplugin/markdown.lua` so that users can override it later.
- Remove settings for `fillchars`, `foldtext`, `foldlevel`, or `smoothscroll`, as these are not necessary for obsidian.nvim.
- Resolves [issue #136](https://github.com/obsidian-nvim/obsidian.nvim/issues/136)