### PR TITLE
Fixes #137: Pass substitution functions context information about how/why it's being called

### DIFF
--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1834,7 +1834,6 @@ Client.write_note = function(self, note, opts)
     if opts.template ~= nil then
       note = clone_template {
         client = self,
-        cursor_location = util.get_active_window_cursor_location(),
         template_name = opts.template,
         note_override = note,
         path_override = path,

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1832,7 +1832,13 @@ Client.write_note = function(self, note, opts)
   else
     verb = "Created"
     if opts.template ~= nil then
-      note = clone_template { template_name = opts.template, path = path, client = self, note = note }
+      note = clone_template {
+        client = self,
+        cursor_location = util.get_active_window_cursor_location(),
+        template_name = opts.template,
+        note_override = note,
+        path_override = path,
+      }
     end
   end
 
@@ -1869,10 +1875,10 @@ Client.write_note_to_buffer = function(self, note, opts)
 
   if opts.template and util.buffer_is_empty(opts.bufnr) then
     note = insert_template {
-      note = note,
-      template_name = opts.template,
       client = self,
-      location = util.get_active_window_cursor_location(),
+      cursor_location = util.get_active_window_cursor_location(),
+      template_name = opts.template,
+      note_override = note,
     }
   end
 

--- a/lua/obsidian/commands/template.lua
+++ b/lua/obsidian/commands/template.lua
@@ -1,5 +1,5 @@
-local templates = require "obsidian.templates"
 local log = require "obsidian.log"
+local templates = require "obsidian.templates"
 local util = require "obsidian.util"
 
 ---@param client obsidian.Client
@@ -11,13 +11,14 @@ return function(client, data)
   end
 
   -- We need to get this upfront before the picker hijacks the current window.
-  local insert_location = util.get_active_window_cursor_location()
+  local cursor_location = util.get_active_window_cursor_location()
 
-  local function insert_template(name)
+  local function insert_template(template_path)
     templates.insert_template {
+      action = "insert_template",
       client = client,
-      template_name = name,
-      cursor_location = insert_location,
+      template_path = template_path,
+      target_location = cursor_location,
     }
   end
 

--- a/lua/obsidian/commands/template.lua
+++ b/lua/obsidian/commands/template.lua
@@ -14,7 +14,11 @@ return function(client, data)
   local insert_location = util.get_active_window_cursor_location()
 
   local function insert_template(name)
-    templates.insert_template { template_name = name, client = client, location = insert_location }
+    templates.insert_template {
+      client = client,
+      template_name = name,
+      cursor_location = insert_location,
+    }
   end
 
   if string.len(data.args) > 0 then

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -412,7 +412,7 @@ end
 ---@field folder string|obsidian.Path|?
 ---@field date_format string|?
 ---@field time_format string|?
----@field substitutions table<string, function|string>|?
+---@field substitutions table<string, string|obsidian.SubstitutionFunction>|?
 config.TemplateOpts = {}
 
 --- Get defaults.

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -86,6 +86,21 @@ Note.new = function(id, aliases, tags, path)
   return self
 end
 
+--- Clone an existing note object.
+---
+---@return obsidian.Note copy clone of the current note object.
+Note.clone = function(self)
+  local copy = Note.init()
+  copy.id = self.id
+  copy.aliases = self.aliases and vim.deepcopy(self.aliases) or nil
+  copy.tags = self.tags and vim.deepcopy(self.tags) or nil
+  copy.path = self.path and Path.new(self.path) or nil
+  copy.metadata = vim.deepcopy(self.metadata)
+  copy.has_frontmatter = self.has_frontmatter
+  copy.frontmatter_end_line = self.frontmatter_end_line
+  return copy
+end
+
 --- Get markdown display info about the note.
 ---
 ---@param opts { label: string|?, anchor: obsidian.note.HeaderAnchor|?, block: obsidian.note.Block|? }|?

--- a/lua/obsidian/subst.lua
+++ b/lua/obsidian/subst.lua
@@ -1,28 +1,96 @@
+local Path = require "obsidian.path"
 local log = require "obsidian.log"
 local util = require "obsidian.util"
 
 --- Metadata surrounding a request to substitute template variables.
 ---
 ---@class obsidian.SubstitutionContext
+---@field action obsidian.SubstitutionContext.Action
 ---@field client obsidian.Client
----@field cursor_location [number, number, number, number]|?
----@field template_name string|?
----@field note_override obsidian.Note|?
----@field path_override obsidian.Path|?
+---@field template_path obsidian.Path|string|?
+---@field target_location [number, number, number, number]|?
+---@field target_note obsidian.Note|?
+---
+---@alias obsidian.SubstitutionContext.Action "clone_template" | "insert_template"
 
---- Provides a value for the corresponding variable placeholder.
+--- Provides a value for the corresponding placeholder variable.
 ---
---- NOTE: Non-nil return values are coerced into strings with neovim's tostring() function.
----
---- @alias obsidian.SubstitutionFunction fun(ctx: obsidian.SubstitutionContext): any|?
+--- @alias obsidian.SubstitutionFunction fun(ctx: obsidian.SubstitutionContext): string|?
 
 local M = {}
+
+--- Resolve a template name to a path.
+---
+---@param template_path string|obsidian.Path
+---@param client obsidian.Client
+---
+---@return obsidian.Path
+local resolve_template_path = function(template_path, client)
+  local templates_dir = client:templates_dir()
+  if templates_dir == nil then
+    error "Templates folder is not defined or does not exist"
+  end
+
+  ---@type obsidian.Path|?
+  local resolved_path
+  local paths_to_check = { templates_dir / tostring(template_path), Path:new(template_path) }
+  for _, path in ipairs(paths_to_check) do
+    if path:is_file() then
+      resolved_path = path
+      break
+    elseif not vim.endswith(tostring(path), ".md") then
+      local path_with_suffix = Path:new(tostring(path) .. ".md")
+      if path_with_suffix:is_file() then
+        resolved_path = path_with_suffix
+        break
+      end
+    end
+  end
+
+  if resolved_path == nil then
+    error(string.format("Template '%s' not found", template_path))
+  end
+
+  return resolved_path
+end
+
+--- Returns a validated context, otherwise returns nil and an error message.
+---
+---@param expected_action obsidian.SubstitutionContext.Action
+---@param ctx obsidian.SubstitutionContext
+---@return obsidian.SubstitutionContext
+M.assert_valid_context = function(ctx, expected_action)
+  assert(ctx.action == expected_action, string.format("unexpected substitution action: %s", ctx.action))
+  assert(ctx.client, "obsidian.nvim client is required")
+  assert(ctx.template_path, "template name is required")
+  local template_path = assert(
+    resolve_template_path(ctx.template_path, ctx.client),
+    string.format("template does not exist: %s", ctx.template_path)
+  )
+
+  if ctx.action == "clone_template" then
+    assert(ctx.target_note, "target note is required to clone templates")
+  elseif ctx.action == "insert_template" then
+    assert(ctx.target_location, "cursor location is required to insert templates")
+  else
+    error(string.format("unrecognized substitution action: %s", ctx.action))
+  end
+
+  ---@type obsidian.SubstitutionContext
+  return {
+    action = ctx.action,
+    client = ctx.client,
+    template_path = template_path,
+    target_note = ctx.target_note,
+    target_location = ctx.target_location,
+  }
+end
 
 ---@param var_name string
 ---@param subst obsidian.SubstitutionFunction|string
 ---@param ctx obsidian.SubstitutionContext
 ---@return string|?
-local function get_subst_value(var_name, subst, ctx)
+local function substitute_variable_safely(var_name, subst, ctx)
   if type(subst) == "string" then
     return subst
   elseif vim.is_callable(subst) then
@@ -40,8 +108,6 @@ local function get_subst_value(var_name, subst, ctx)
     log.error('"%s" substitution error: ignoring value=%s (not a string or callable)', var_name, tostring(subst))
     log.debug('"%s" substitution context: %s', var_name, tostring(ctx))
   end
-  -- Fallback to user input
-  return util.input(string.format("Enter value for '%s' (<cr> to skip): ", var_name))
 end
 
 --- Substitute variables inside the given text.
@@ -64,20 +130,31 @@ M.substitute_template_variables = function(text, ctx)
   end
 
   if not methods["title"] then
-    methods["title"] = ctx.note_override.title or ctx.note_override:display_name()
+    methods["title"] = ctx.target_note.title or ctx.target_note:display_name()
   end
 
   if not methods["id"] then
-    methods["id"] = tostring(ctx.note_override.id)
+    methods["id"] = tostring(ctx.target_note.id)
   end
 
-  if not methods["path"] and ctx.note_override.path then
-    methods["path"] = tostring(ctx.note_override.path)
+  if not methods["path"] and ctx.target_note.path then
+    methods["path"] = tostring(ctx.target_note.path)
   end
 
+  -- Replace known variables.
+  for key, subst in pairs(methods) do
+    for m_start, m_end in util.gfind(text, "{{" .. key .. "}}", nil, true) do
+      local value = substitute_variable_safely(key, subst, ctx)
+      if value then
+        text = string.sub(text, 1, m_start - 1) .. value .. string.sub(text, m_end + 1)
+      end
+    end
+  end
+
+  -- Find unknown variables and prompt for them.
   for m_start, m_end in util.gfind(text, "{{[^}]+}}") do
     local key = util.strip_whitespace(string.sub(text, m_start + 2, m_end - 2))
-    local value = get_subst_value(key, methods[key], ctx)
+    local value = util.input(string.format("Enter value for '%s' (<cr> to skip): ", key))
     if value and string.len(value) > 0 then
       text = string.sub(text, 1, m_start - 1) .. value .. string.sub(text, m_end + 1)
     end

--- a/lua/obsidian/subst.lua
+++ b/lua/obsidian/subst.lua
@@ -1,0 +1,77 @@
+local util = require "obsidian.util"
+
+--- Provides context about the request to substitute a template variable.
+---
+---@class obsidian.SubstitutionContext
+---@field client obsidian.Client
+---@field cursor_location [number, number, number, number]|?
+---@field template_name string|?
+---@field note_override obsidian.Note|?
+---@field path_override obsidian.Path|?
+
+local M = {}
+
+--- Substitute variables inside the given text.
+---
+---@param text string
+---@param ctx obsidian.SubstitutionContext
+---
+---@return string
+M.substitute_template_variables = function(text, ctx)
+  local methods = vim.deepcopy(ctx.client.opts.templates.substitutions or {})
+
+  if not methods["date"] then
+    methods["date"] = function()
+      local date_format = ctx.client.opts.templates.date_format or "%Y-%m-%d"
+      return tostring(os.date(date_format))
+    end
+  end
+
+  if not methods["time"] then
+    methods["time"] = function()
+      local time_format = ctx.client.opts.templates.time_format or "%H:%M"
+      return tostring(os.date(time_format))
+    end
+  end
+
+  if not methods["title"] then
+    methods["title"] = ctx.note_override.title or ctx.note_override:display_name()
+  end
+
+  if not methods["id"] then
+    methods["id"] = tostring(ctx.note_override.id)
+  end
+
+  if not methods["path"] and ctx.note_override.path then
+    methods["path"] = tostring(ctx.note_override.path)
+  end
+
+  -- Replace known variables.
+  for key, subst in pairs(methods) do
+    for m_start, m_end in util.gfind(text, "{{" .. key .. "}}", nil, true) do
+      ---@type string
+      local value
+      if type(subst) == "string" then
+        value = subst
+      else
+        value = subst()
+        -- cache the result
+        methods[key] = value
+      end
+      text = string.sub(text, 1, m_start - 1) .. value .. string.sub(text, m_end + 1)
+    end
+  end
+
+  -- Find unknown variables and prompt for them.
+  for m_start, m_end in util.gfind(text, "{{[^}]+}}") do
+    local key = util.strip_whitespace(string.sub(text, m_start + 2, m_end - 2))
+    local value = util.input(string.format("Enter value for '%s' (<cr> to skip): ", key))
+    if value and string.len(value) > 0 then
+      text = string.sub(text, 1, m_start - 1) .. value .. string.sub(text, m_end + 1)
+    end
+  end
+
+  return text
+end
+
+return M

--- a/lua/obsidian/templates.lua
+++ b/lua/obsidian/templates.lua
@@ -1,5 +1,6 @@
 local Path = require "obsidian.path"
 local Note = require "obsidian.note"
+local subst = require "obsidian.subst"
 local util = require "obsidian.util"
 
 local M = {}
@@ -39,80 +40,16 @@ local resolve_template = function(template_name, client)
   return template_path
 end
 
---- Substitute variables inside the given text.
----
----@param text string
----@param client obsidian.Client
----@param note obsidian.Note
----
----@return string
-M.substitute_template_variables = function(text, client, note)
-  local methods = vim.deepcopy(client.opts.templates.substitutions or {})
-
-  if not methods["date"] then
-    methods["date"] = function()
-      local date_format = client.opts.templates.date_format or "%Y-%m-%d"
-      return tostring(os.date(date_format))
-    end
-  end
-
-  if not methods["time"] then
-    methods["time"] = function()
-      local time_format = client.opts.templates.time_format or "%H:%M"
-      return tostring(os.date(time_format))
-    end
-  end
-
-  if not methods["title"] then
-    methods["title"] = note.title or note:display_name()
-  end
-
-  if not methods["id"] then
-    methods["id"] = tostring(note.id)
-  end
-
-  if not methods["path"] and note.path then
-    methods["path"] = tostring(note.path)
-  end
-
-  -- Replace known variables.
-  for key, subst in pairs(methods) do
-    for m_start, m_end in util.gfind(text, "{{" .. key .. "}}", nil, true) do
-      ---@type string
-      local value
-      if type(subst) == "string" then
-        value = subst
-      else
-        value = subst()
-        -- cache the result
-        methods[key] = value
-      end
-      text = string.sub(text, 1, m_start - 1) .. value .. string.sub(text, m_end + 1)
-    end
-  end
-
-  -- Find unknown variables and prompt for them.
-  for m_start, m_end in util.gfind(text, "{{[^}]+}}") do
-    local key = util.strip_whitespace(string.sub(text, m_start + 2, m_end - 2))
-    local value = util.input(string.format("Enter value for '%s' (<cr> to skip): ", key))
-    if value and string.len(value) > 0 then
-      text = string.sub(text, 1, m_start - 1) .. value .. string.sub(text, m_end + 1)
-    end
-  end
-
-  return text
-end
-
 --- Clone template to a new note.
 ---
----@param opts { template_name: string|obsidian.Path, path: obsidian.Path|string, client: obsidian.Client, note: obsidian.Note } Options.
+---@param ctx obsidian.SubstitutionContext
 ---
 ---@return obsidian.Note
-M.clone_template = function(opts)
-  local note_path = Path.new(opts.path)
+M.clone_template = function(ctx)
+  local note_path = Path.new(ctx.path_override)
   assert(note_path:parent()):mkdir { parents = true, exist_ok = true }
 
-  local template_path = resolve_template(opts.template_name, opts.client)
+  local template_path = resolve_template(ctx.template_name, ctx.client)
 
   local template_file, read_err = io.open(tostring(template_path), "r")
   if not template_file then
@@ -125,7 +62,7 @@ M.clone_template = function(opts)
   end
 
   for line in template_file:lines "L" do
-    line = M.substitute_template_variables(line, opts.client, opts.note)
+    line = subst.substitute_template_variables(line, ctx)
     note_file:write(line)
   end
 
@@ -135,14 +72,14 @@ M.clone_template = function(opts)
   local new_note = Note.from_file(note_path)
 
   -- Transfer fields from `opts.note`.
-  new_note.id = opts.note.id
+  new_note.id = ctx.note_override.id
   if new_note.title == nil then
-    new_note.title = opts.note.title
+    new_note.title = ctx.note_override.title
   end
-  for _, alias in ipairs(opts.note.aliases) do
+  for _, alias in ipairs(ctx.note_override.aliases) do
     new_note:add_alias(alias)
   end
-  for _, tag in ipairs(opts.note.tags) do
+  for _, tag in ipairs(ctx.note_override.tags) do
     new_note:add_tag(tag)
   end
 
@@ -151,23 +88,23 @@ end
 
 ---Insert a template at the given location.
 ---
----@param opts { note: obsidian.Note|?, template_name: string|obsidian.Path, client: obsidian.Client, location: { [1]: integer, [2]: integer, [3]: integer, [4]: integer } } Options.
+---@param ctx obsidian.SubstitutionContext
 ---
 ---@return obsidian.Note
-M.insert_template = function(opts)
-  local buf, win, row, _ = unpack(opts.location)
-  if opts.note == nil then
-    opts.note = Note.from_buffer(buf)
+M.insert_template = function(ctx)
+  local buf, win, row, _ = unpack(ctx.cursor_location)
+  if ctx.note_override == nil then
+    ctx.note_override = Note.from_buffer(buf)
   end
 
-  local template_path = resolve_template(opts.template_name, opts.client)
+  local template_path = resolve_template(ctx.template_name, ctx.client)
 
   local insert_lines = {}
   local template_file = io.open(tostring(template_path), "r")
   if template_file then
     local lines = template_file:lines()
     for line in lines do
-      local new_lines = M.substitute_template_variables(line, opts.client, opts.note)
+      local new_lines = subst.substitute_template_variables(line, ctx)
       if string.find(new_lines, "[\r\n]") then
         local line_start = 1
         for line_end in util.gfind(new_lines, "[\r\n]") do
@@ -192,7 +129,7 @@ M.insert_template = function(opts)
   local new_cursor_row, _ = unpack(vim.api.nvim_win_get_cursor(win))
   vim.api.nvim_win_set_cursor(0, { new_cursor_row, 0 })
 
-  opts.client:update_ui(0)
+  ctx.client:update_ui(0)
 
   return Note.from_buffer(buf)
 end

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -651,13 +651,12 @@ util.working_day_after = function(time)
   end
 end
 
----@return table - tuple containing {bufnr, winnr, row, col}
+---@return [number, number, number, number] location values are: `{ buffer_id, window_id, cursor_row, cursor_col }`
 util.get_active_window_cursor_location = function()
-  local buf = vim.api.nvim_win_get_buf(0)
-  local win = vim.api.nvim_get_current_win()
-  local row, col = unpack(vim.api.nvim_win_get_cursor(win))
-  local location = { buf, win, row, col }
-  return location
+  local buffer_id = vim.api.nvim_win_get_buf(0)
+  local window_id = vim.api.nvim_get_current_win()
+  local cursor_row, cursor_col = unpack(vim.api.nvim_win_get_cursor(window_id))
+  return { buffer_id, window_id, cursor_row, cursor_col }
 end
 
 ---Determines if cursor is currently inside markdown link.

--- a/test/obsidian/subst_spec.lua
+++ b/test/obsidian/subst_spec.lua
@@ -1,7 +1,8 @@
 local obsidian = require "obsidian"
 local Path = require "obsidian.path"
 local Note = require "obsidian.note"
-local templates = require "obsidian.templates"
+local subst = require "obsidian.subst"
+local util = require "obsidian.util"
 
 ---Get a client in a temporary directory.
 ---
@@ -18,13 +19,16 @@ local tmp_client = function()
   return obsidian.new_from_dir(tostring(dir))
 end
 
-describe("templates.substitute_template_variables()", function()
+describe("subst.substitute_template_variables()", function()
   it("should substitute built-in variables", function()
     local client = tmp_client()
     local text = "today is {{date}} and the title of the note is {{title}}"
     assert.equal(
       string.format("today is %s and the title of the note is %s", os.date "%Y-%m-%d", "FOO"),
-      templates.substitute_template_variables(text, client, Note.new("FOO", { "FOO" }, {}))
+      subst.substitute_template_variables(text, {
+        client = client,
+        note_override = Note.new("FOO", { "FOO" }, {}),
+      })
     )
   end)
 
@@ -36,7 +40,13 @@ describe("templates.substitute_template_variables()", function()
       end,
     }
     local text = "today is {{weekday}}"
-    assert.equal("today is Monday", templates.substitute_template_variables(text, client, Note.new("foo", {}, {})))
+    assert.equal(
+      "today is Monday",
+      subst.substitute_template_variables(text, {
+        client = client,
+        note_override = Note.new("foo", {}, {}),
+      })
+    )
 
     -- Make sure the client opts has not been modified.
     assert.equal(1, vim.tbl_count(client.opts.templates.substitutions))

--- a/test/obsidian/subst_spec.lua
+++ b/test/obsidian/subst_spec.lua
@@ -2,7 +2,6 @@ local obsidian = require "obsidian"
 local Path = require "obsidian.path"
 local Note = require "obsidian.note"
 local subst = require "obsidian.subst"
-local util = require "obsidian.util"
 
 ---Get a client in a temporary directory.
 ---
@@ -26,8 +25,9 @@ describe("subst.substitute_template_variables()", function()
     assert.equal(
       string.format("today is %s and the title of the note is %s", os.date "%Y-%m-%d", "FOO"),
       subst.substitute_template_variables(text, {
+        action = "clone_template",
         client = client,
-        note_override = Note.new("FOO", { "FOO" }, {}),
+        target_note = Note.new("FOO", { "FOO" }, {}),
       })
     )
   end)
@@ -43,8 +43,9 @@ describe("subst.substitute_template_variables()", function()
     assert.equal(
       "today is Monday",
       subst.substitute_template_variables(text, {
+        action = "clone_template",
         client = client,
-        note_override = Note.new("foo", {}, {}),
+        target_note = Note.new("foo", {}, {}),
       })
     )
 


### PR DESCRIPTION
Fixes #137 

Thanks for taking a look at my feature request! I've gone ahead and attempted to implement it. I'd like to gather feedback about the implementation before I start writing unit tests, so please let me know what you think.

## Key Changes
1. `obsidian.SubstitutionContext` is a new interface/object used for context values. Specifically:
  - `obsidian.SubstitutionContext.action`: `"clone_template" | "insert_template"`.
    - Used as a "discriminated union" field to decide which values are required/optional.
  - `obsidian.SubstitutionContext.client`: `obsidian.Client`
  - `obsidian.SubstitutionContext.template_path`: `obsidian.Path`
  - `obsidian.SubstitutionContext.target_note`: `obsidian.Note`
    - **ONLY USED/REQUIRED IF `action == "clone_template"`**
  - `obsidian.SubstitutionContext.cursor_location`: `[integer, integer, integer, integer]`
    - **ONLY USED/REQUIRED IF `action == "insert_template"`**

2. Substitution logic and functions have been moved to a new lua module: `subst.lua`
  - The module also introduces `assert_valid_context` to do the common checks shared by the `insert_template` and `clone_template` functions
  - The unit tests for `templates.lua` have been renamed to `subst.lua`, since that's the new home of the functions under test.

3. Introduced alias types to help users write substitution functions

4. Manually tested in my own vault :)