### PR TITLE
feat: toggle header parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `makefile types` target to check types via lua-ls
 - Added `.github/pull_request_template.md` to make contributing simpler
+<<<<<<< HEAD
 - Allow users to have a period in the note ID as in a [Johnny.Decimal](https://johnnydecimal.com/) format
 - Added `backlinks` config table with the associated `obsidian.config.BacklinkOpts`
 - Added `parse_headers` toggle that disables markdown header parsing for `ObsidianBacklinks`.
+||||||| parent of 6190c38 (review: update CHANGELOG.md)
+- Added `parse_headers` toggle that disables markdown header parsing for `ObsidianBacklinks`.
+=======
+- Added `parse_headers` toggle that disables markdown header parsing for `Obsidian backlinks`.
+>>>>>>> 6190c38 (review: update CHANGELOG.md)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `.github/pull_request_template.md` to make contributing simpler
 - Allow users to have a period in the note ID as in a [Johnny.Decimal](https://johnnydecimal.com/) format
 - Added `backlinks` config table with the associated `obsidian.config.BacklinkOpts`
+- Added `parse_headers` toggle that disables markdown header parsing for `ObsidianBacklinks`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `makefile types` target to check types via lua-ls
 - Added `.github/pull_request_template.md` to make contributing simpler
-<<<<<<< HEAD
 - Allow users to have a period in the note ID as in a [Johnny.Decimal](https://johnnydecimal.com/) format
 - Added `backlinks` config table with the associated `obsidian.config.BacklinkOpts`
 - Added `parse_headers` toggle that disables markdown header parsing for `ObsidianBacklinks`.
-||||||| parent of 6190c38 (review: update CHANGELOG.md)
-- Added `parse_headers` toggle that disables markdown header parsing for `ObsidianBacklinks`.
-=======
-- Added `parse_headers` toggle that disables markdown header parsing for `Obsidian backlinks`.
->>>>>>> 6190c38 (review: update CHANGELOG.md)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -486,6 +486,11 @@ require("obsidian").setup {
     },
   },
 
+  -- Optional, by default, `:ObsidianBacklinks` parses the header under
+  -- the cursor. Setting to `false` will get the backlinks for the current
+  -- note instead. Doesn't affect other link behaviour.
+  parse_headers = true
+
   -- Optional, sort search results by "path", "modified", "accessed", or "created".
   -- The recommend value is "modified" and `true` for `sort_reversed`, which means, for example,
   -- that `:Obsidian quick_switch` will show the notes sorted by latest modified time

--- a/README.md
+++ b/README.md
@@ -489,7 +489,9 @@ require("obsidian").setup {
   -- Optional, by default, `:ObsidianBacklinks` parses the header under
   -- the cursor. Setting to `false` will get the backlinks for the current
   -- note instead. Doesn't affect other link behaviour.
-  parse_headers = true
+  backlinks = {
+    parse_headers = true
+  }
 
   -- Optional, sort search results by "path", "modified", "accessed", or "created".
   -- The recommend value is "modified" and `true` for `sort_reversed`, which means, for example,

--- a/doc/obsidian.txt
+++ b/doc/obsidian.txt
@@ -515,6 +515,11 @@ Click to see configuration options ~
         },
       },
     
+      -- Optional, by default, `:ObsidianBacklinks` parses the header under
+      -- the cursor. Setting to `false` will get the backlinks for the current
+      -- note instead. Doesn't affect other link behaviour.
+      parse_headers = true
+
       -- Optional, sort search results by "path", "modified", "accessed", or "created".
       -- The recommend value is "modified" and `true` for `sort_reversed`, which means, for example,
       -- that `:Obsidian quick_switch` will show the notes sorted by latest modified time

--- a/doc/obsidian.txt
+++ b/doc/obsidian.txt
@@ -518,7 +518,9 @@ Click to see configuration options ~
       -- Optional, by default, `:ObsidianBacklinks` parses the header under
       -- the cursor. Setting to `false` will get the backlinks for the current
       -- note instead. Doesn't affect other link behaviour.
-      parse_headers = true
+      backlinks = {
+	parse_headers = true
+      }
 
       -- Optional, sort search results by "path", "modified", "accessed", or "created".
       -- The recommend value is "modified" and `true` for `sort_reversed`, which means, for example,

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -122,7 +122,7 @@ return function(client)
     local note = client:current_note(0, load_opts)
 
     -- Check if cursor is on a header, if so, use that anchor.
-    if client.opts.parse_headers then
+    if client.opts.backlinks.parse_headers then
       local header_match = util.parse_header(vim.api.nvim_get_current_line())
       if header_match then
         opts.anchor = header_match.anchor

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -121,7 +121,7 @@ return function(client)
 
     local note = client:current_note(0, load_opts)
 
-    -- Check if cursor is on a header, if so, use that anchor.
+    -- Check if cursor is on a header, if so and header parsing is enabled, use that anchor.
     if client.opts.backlinks.parse_headers then
       local header_match = util.parse_header(vim.api.nvim_get_current_line())
       if header_match then

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -122,9 +122,11 @@ return function(client)
     local note = client:current_note(0, load_opts)
 
     -- Check if cursor is on a header, if so, use that anchor.
-    local header_match = util.parse_header(vim.api.nvim_get_current_line())
-    if header_match then
-      opts.anchor = header_match.anchor
+    if client.opts.parse_headers then
+      local header_match = util.parse_header(vim.api.nvim_get_current_line())
+      if header_match then
+        opts.anchor = header_match.anchor
+      end
     end
 
     if note == nil then

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -63,7 +63,6 @@ config.ClientOpts.default = function()
     daily_notes = config.DailyNotesOpts.default(),
     use_advanced_uri = nil,
     open_app_foreground = false,
-    parse_headers = true,
     sort_by = "modified",
     sort_reversed = true,
     search_max_lines = 1000,

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -26,6 +26,7 @@ local config = {}
 ---@field daily_notes obsidian.config.DailyNotesOpts
 ---@field use_advanced_uri boolean|?
 ---@field open_app_foreground boolean|?
+---@field parse_headers boolean|?
 ---@field sort_by obsidian.config.SortBy|?
 ---@field sort_reversed boolean|?
 ---@field search_max_lines integer
@@ -63,6 +64,7 @@ config.ClientOpts.default = function()
     daily_notes = config.DailyNotesOpts.default(),
     use_advanced_uri = nil,
     open_app_foreground = false,
+    parse_headers = true,
     sort_by = "modified",
     sort_reversed = true,
     search_max_lines = 1000,

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -196,11 +196,6 @@ config.ClientOpts.normalize = function(opts, defaults)
     opts.overwrite_mappings = nil
   end
 
-  if opts.backlinks ~= nil then
-    log.warn_once "The 'backlinks' config option is deprecated and no longer has any affect."
-    opts.backlinks = nil
-  end
-
   if opts.tags ~= nil then
     log.warn_once "The 'tags' config option is deprecated and no longer has any affect."
     opts.tags = nil
@@ -240,6 +235,7 @@ config.ClientOpts.normalize = function(opts, defaults)
   ---@type obsidian.config.ClientOpts
   opts = tbl_override(defaults, opts)
 
+  opts.backlinks = tbl_override(defaults.backlinks, opts.backlinks)
   opts.completion = tbl_override(defaults.completion, opts.completion)
   opts.mappings = opts.mappings and opts.mappings or defaults.mappings
   opts.picker = tbl_override(defaults.picker, opts.picker)

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -26,7 +26,6 @@ local config = {}
 ---@field daily_notes obsidian.config.DailyNotesOpts
 ---@field use_advanced_uri boolean|?
 ---@field open_app_foreground boolean|?
----@field parse_headers boolean|?
 ---@field sort_by obsidian.config.SortBy|?
 ---@field sort_reversed boolean|?
 ---@field search_max_lines integer
@@ -299,12 +298,15 @@ config.LinkStyle = {
 }
 
 ---@class obsidian.config.BacklinkOpts
+---@field parse_headers boolean
 config.BacklinkOpts = {}
 
 --- Get defaults.
 ---@return obsidian.config.BacklinkOpts
 config.BacklinkOpts.default = function()
-  return {}
+  return {
+    parse_headers = true,
+  }
 end
 
 ---@class obsidian.config.CompletionOpts


### PR DESCRIPTION
# Extend config, to toggle header parsing

By default, `ObsidianBacklinks` tries to parse header titles as links for look up.
This isn't desirable if 1) titles don't follow a structure that `ObsidianBacklinks` expects; 2) you just don't want it, and prefer to look up the current note, or wiki-link under the current cursor.

This PR just adds an extra config field to customise this behaviour.

## Screenshots

N/A

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
