### PR TITLE
feat: add backlinks config module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `makefile types` target to check types via lua-ls
 - Added `.github/pull_request_template.md` to make contributing simpler
+- Added `backlinks` config table with the associated `obsidian.config.BacklinkOpts`
 
 ### Changed
 

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -297,7 +297,6 @@ config.LinkStyle = {
 }
 
 ---@class obsidian.config.BacklinkOpts
----@field parse_headers boolean
 config.BacklinkOpts = {}
 
 --- Get defaults.

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -19,6 +19,7 @@ local config = {}
 ---@field follow_img_func fun(img: string)|?
 ---@field note_frontmatter_func (fun(note: obsidian.Note): table)|?
 ---@field disable_frontmatter (fun(fname: string?): boolean)|boolean|?
+---@field backlinks obsidian.config.BacklinkOpts
 ---@field completion obsidian.config.CompletionOpts
 ---@field mappings obsidian.config.MappingOpts
 ---@field picker obsidian.config.PickerOpts
@@ -55,6 +56,7 @@ config.ClientOpts.default = function()
     follow_img_func = vim.ui.open,
     note_frontmatter_func = nil,
     disable_frontmatter = false,
+    backlinks = config.BacklinkOpts.default(),
     completion = config.CompletionOpts.default(),
     mappings = config.MappingOpts.default(),
     picker = config.PickerOpts.default(),
@@ -293,6 +295,16 @@ config.LinkStyle = {
   wiki = "wiki",
   markdown = "markdown",
 }
+
+---@class obsidian.config.BacklinkOpts
+---@field parse_headers boolean
+config.BacklinkOpts = {}
+
+--- Get defaults.
+---@return obsidian.config.BacklinkOpts
+config.BacklinkOpts.default = function()
+  return {}
+end
 
 ---@class obsidian.config.CompletionOpts
 ---


### PR DESCRIPTION
# Add a table for backlinks config options

As per #81 and #154, we want to have a `backlinks` table added for future config options.
Specifically, `parse_headers` that I'm adding in #154.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
