### PR TITLE
fix #160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed types in `_snacks.lua`
+- Fixed command documentation
 
 ## [v3.11.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.11.0) - 2025-05-04
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ These default keymaps will only be set if you are in a valid workspace and a mar
 
 - `:Obsidian dailies [OFFSET ...]` to open a picker list of daily notes. For example, `:Obsidian dailies -2 1` to list daily notes from 2 days ago until tomorrow.
 
+- `:ObsidianExtractNote [TITLE]` to extract the visually selected text into a new note and link to it.
+
 - `:Obsidian follow_link [vsplit|hsplit]` to follow a note reference under the cursor, optionally opening it in a vertical or horizontal split.
 
 - `:Obsidian link [QUERY]` to link an inline visual selection of text to a note.
@@ -91,6 +93,8 @@ These default keymaps will only be set if you are in a valid workspace and a mar
 
 - `:Obsidian open [QUERY]` to open a note in the Obsidian app.
   One optional argument: a query used to resolve the note to open by ID, path, or alias. If not given, the current buffer is used.
+
+- `:Obsidian paste_img [IMGNAME]` to paste an image from the clipboard into the note at the cursor position by saving it to the vault and adding a markdown image link. You can configure the default folder to save images to with the `attachments.img_folder` option.
 
 - `:Obsidian quick_switch` to quickly switch to another note in your vault, searching by its name with a picker.
 

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -308,7 +308,7 @@ end
 
 --- Run an obsidian command directly.
 ---
----@usage `client:command("ObsidianNew", { args = "Foo" })`
+---@usage `client:command("new", { args = "Foo" })`
 ---
 ---@param cmd_name string The name of the command.
 ---@param cmd_data table|? The payload for the command.

--- a/lua/obsidian/commands/init-legacy.lua
+++ b/lua/obsidian/commands/init-legacy.lua
@@ -114,11 +114,11 @@ M.complete_args_search = function(client, _, cmd_line, _)
   for note in iter(client:find_notes(query, { search = { sort = true } })) do
     local note_path = assert(client:vault_relative_path(note.path, { strict = true }))
     if string.find(string.lower(note:display_name()), query_lower, 1, true) then
-      table.insert(completions, note:display_name() .. "  " .. note_path)
+      table.insert(completions, note:display_name() .. "  " .. tostring(note_path))
     else
       for _, alias in pairs(note.aliases) do
         if string.find(string.lower(alias), query_lower, 1, true) then
-          table.insert(completions, alias .. "  " .. note_path)
+          table.insert(completions, alias .. "  " .. tostring(note_path))
           break
         end
       end

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -63,7 +63,7 @@ obsidian.info = function()
   end
 
   local client = obsidian.get_client()
-  client:command("ObsidianDebug", { raw_print = true })
+  client:command("debug", { raw_print = true })
 end
 
 ---Create a new Obsidian client without additional setup.


### PR DESCRIPTION
fix: command concat issue in legacy_commands
fix: wrong usage of client:command in `obsidian.info`
doc: add back missing commands

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
