### PR TITLE
`Obsidian open` refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `backlinks` config table with the associated `obsidian.config.BacklinkOpts`
 - Added `parse_headers` toggle that disables markdown header parsing for `ObsidianBacklinks`.
 - Added autocmd events for user scripting, see https://github.com/obsidian-nvim/obsidian.nvim/wiki/Autocmds
+- Added `open` module for `Obsidian open` related options
 
 ### Changed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relaxed yaml dump quoting condition so that dates are not quoted
 - Update Stylua version from 0.15.1 → 2.1.0
 - Use `vim.deprecate` to show deprecate warnings
+- Deprecate `open_app_foreground`
 
 ### Fixed
 

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -7,7 +7,7 @@ local function open_in_app(client, path)
   if not path then
     return client.opts.open.func("obsidian://open?vault=" .. util.urlencode(client:vault_name()))
   end
-  path = tostring(client:vault_relative_path(path, { strict = true }))
+  path = tostring(path)
   local vault_name = client:vault_name()
   local this_os = util.get_os()
 
@@ -26,6 +26,8 @@ local function open_in_app(client, path)
   else
     uri = ("obsidian://open?vault=%s&file=%s"):format(encoded_vault, encoded_path)
   end
+
+  uri = vim.fn.shellescape(uri)
 
   client.opts.open.func(uri)
 end

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -18,7 +18,7 @@ local function open_in_app(client, path)
   local encoded_path = util.urlencode(path)
 
   local uri
-  if client.opts.use_advanced_uri then
+  if client.opts.open.use_advanced_uri then
     local line = vim.api.nvim_win_get_cursor(0)[1] or 1
     uri = ("obsidian://advanced-uri?vault=%s&filepath=%s&line=%i"):format(encoded_vault, encoded_path, line)
   else

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -25,50 +25,7 @@ local function open_in_app(client, path)
     uri = ("obsidian://open?vault=%s&file=%s"):format(encoded_vault, encoded_path)
   end
 
-  uri = vim.fn.shellescape(uri)
-  ---@type string, string[]
-  local cmd, args
-  local run_in_shell = true
-  if this_os == util.OSType.Linux or this_os == util.OSType.FreeBSD then
-    cmd = "xdg-open"
-    args = { uri }
-  elseif this_os == util.OSType.Wsl then
-    cmd = "wsl-open"
-    args = { uri }
-  elseif this_os == util.OSType.Windows then
-    run_in_shell = false
-    cmd = "powershell"
-    args = { "Start-Process", uri }
-  elseif this_os == util.OSType.Darwin then
-    cmd = "open"
-    if client.opts.open_app_foreground then
-      args = { "-a", "/Applications/Obsidian.app", uri }
-    else
-      args = { "-a", "/Applications/Obsidian.app", "--background", uri }
-    end
-  else
-    log.err("open command does not support OS type '" .. this_os .. "'")
-    return
-  end
-
-  assert(cmd)
-  assert(args)
-
-  ---@type string|string[]
-  local cmd_with_args
-  if run_in_shell then
-    cmd_with_args = cmd .. " " .. table.concat(args, " ")
-  else
-    cmd_with_args = { cmd, unpack(args) }
-  end
-
-  vim.fn.jobstart(cmd_with_args, {
-    on_exit = function(_, exit_code)
-      if exit_code ~= 0 then
-        log.err("open command failed with exit code '%s': %s", exit_code, cmd_with_args)
-      end
-    end,
-  })
+  vim.ui.open(uri)
 end
 
 ---@param client obsidian.Client

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -1,10 +1,12 @@
 local util = require "obsidian.util"
-local log = require "obsidian.log"
 local RefTypes = require("obsidian.search").RefTypes
 
 ---@param client obsidian.Client
----@param path string|obsidian.Path
+---@param path? string|obsidian.Path
 local function open_in_app(client, path)
+  if not path then
+    return client.opts.open.func("obsidian://open?vault=" .. util.urlencode(client:vault_name()))
+  end
   path = tostring(client:vault_relative_path(path, { strict = true }))
   local vault_name = client:vault_name()
   local this_os = util.get_os()
@@ -54,12 +56,7 @@ return function(client, data)
   else
     -- Otherwise use the path of the current buffer.
     local bufname = vim.api.nvim_buf_get_name(0)
-    local path = client:vault_relative_path(bufname, { strict = true })
-    if path == nil then
-      log.err("Current buffer '%s' does not appear to be inside the vault", bufname)
-      return
-    else
-      return open_in_app(client, path)
-    end
+    local path = client:vault_relative_path(bufname)
+    open_in_app(client, path)
   end
 end

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -25,7 +25,7 @@ local function open_in_app(client, path)
     uri = ("obsidian://open?vault=%s&file=%s"):format(encoded_vault, encoded_path)
   end
 
-  vim.ui.open(uri)
+  client.opts.open.func(uri)
 end
 
 ---@param client obsidian.Client

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -77,7 +77,6 @@ config.ClientOpts.default = function()
       enabled = true,
     },
     ---@class obsidian.config.OpenOpts
-    ---@field foreground boolean only effects MacOs
     ---@field use_advanced_uri boolean opens the file with current line number
     ---@field func fun(uri: string) default to vim.ui.open
     open = {

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -25,7 +25,6 @@ local config = {}
 ---@field picker obsidian.config.PickerOpts
 ---@field daily_notes obsidian.config.DailyNotesOpts
 ---@field use_advanced_uri boolean|?
----@field open_app_foreground boolean|?
 ---@field sort_by obsidian.config.SortBy|?
 ---@field sort_reversed boolean|?
 ---@field search_max_lines integer
@@ -35,6 +34,8 @@ local config = {}
 ---@field callbacks obsidian.config.CallbackConfig
 ---@field legacy_commands boolean
 ---@field statusline obsidian.config.StatuslineOpts
+---@field open obsidian.config.OpenOpts
+
 config.ClientOpts = {}
 
 --- Get defaults.
@@ -62,7 +63,6 @@ config.ClientOpts.default = function()
     picker = config.PickerOpts.default(),
     daily_notes = config.DailyNotesOpts.default(),
     use_advanced_uri = nil,
-    open_app_foreground = false,
     sort_by = "modified",
     sort_reversed = true,
     search_max_lines = 1000,
@@ -77,6 +77,14 @@ config.ClientOpts.default = function()
     statusline = {
       format = "{{backlinks}} backlinks  {{properties}} properties  {{words}} words  {{chars}} chars",
       enabled = true,
+    },
+    ---@class obsidian.config.OpenOpts
+    ---@field foreground boolean only effects MacOs
+    ---@field use_advanced_uri boolean opens the file with current line number
+    ---@field func fun(uri: string) default to vim.ui.open
+    open = {
+      use_advanced_uri = false,
+      func = vim.ui.open,
     },
   }
 end
@@ -193,6 +201,21 @@ config.ClientOpts.normalize = function(opts, defaults)
       "The 'detect_cwd' field is deprecated and no longer has any affect.\n"
         .. "See https://github.com/epwalsh/obsidian.nvim/pull/366 for more details."
     )
+  end
+
+  if opts.open_app_foreground ~= nil then
+    opts.open_app_foreground = nil
+    log.warn_once [[The config option 'open_app_foreground' is deprecated, please use the `func` field in `open` module:
+
+```lua
+{
+  open = {
+    func = function(uri)
+      vim.ui.open(uri, { cmd = { "open", "-a", "/Applications/Obsidian.app" } })
+    end
+  }
+}
+```]]
   end
 
   if opts.overwrite_mappings ~= nil then

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -24,7 +24,6 @@ local config = {}
 ---@field mappings obsidian.config.MappingOpts
 ---@field picker obsidian.config.PickerOpts
 ---@field daily_notes obsidian.config.DailyNotesOpts
----@field use_advanced_uri boolean|?
 ---@field sort_by obsidian.config.SortBy|?
 ---@field sort_reversed boolean|?
 ---@field search_max_lines integer
@@ -62,7 +61,6 @@ config.ClientOpts.default = function()
     mappings = config.MappingOpts.default(),
     picker = config.PickerOpts.default(),
     daily_notes = config.DailyNotesOpts.default(),
-    use_advanced_uri = nil,
     sort_by = "modified",
     sort_reversed = true,
     search_max_lines = 1000,
@@ -216,6 +214,11 @@ config.ClientOpts.normalize = function(opts, defaults)
   }
 }
 ```]]
+  end
+
+  if opts.use_advanced_uri ~= nil then
+    opts.use_advanced_uri = nil
+    log.warn_once [[The config option 'use_advanced_uri' is deprecated, please use in `open` module instead]]
   end
 
   if opts.overwrite_mappings ~= nil then


### PR DESCRIPTION
# `Obsidian open` refactor

- use `opts.open.func` to customize opening, fixes #164 and generalizes `open_app_foreground`
- deprecated `open_app_foreground`, and move `use_advanced_uri` to new module `open`
- fallback to just opening current vault if not in a note.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
