### PR TITLE
More Configuration for Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `backlinks` config table with the associated `obsidian.config.BacklinkOpts`
 - Added `parse_headers` toggle that disables markdown header parsing for `ObsidianBacklinks`.
 - Added autocmd events for user scripting, see https://github.com/obsidian-nvim/obsidian.nvim/wiki/Autocmds
+- Allow custom directory and ID logic for templates
 
 ### Changed
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed types in `_snacks.lua`
 - Fixed command documentation
+- Fixed improper tmp-file creation during template tests
 
 ## [v3.11.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.11.0) - 2025-05-04
 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,9 @@ require("obsidian").setup {
     time_format = "%H:%M",
     -- A map for custom variables, the key should be the variable and the value a function
     substitutions = {},
+
+    -- A map for configuring unique directories and paths for specific templates
+    customizations = {},
   },
 
   -- Sets how you follow URLs

--- a/lua/obsidian/commands/new_from_template.lua
+++ b/lua/obsidian/commands/new_from_template.lua
@@ -1,5 +1,6 @@
 local util = require "obsidian.util"
 local log = require "obsidian.log"
+local templates = require "obsidian.templates"
 
 ---@param client obsidian.Client
 ---@param data CommandArgs
@@ -12,32 +13,41 @@ return function(client, data)
 
   local title = data.fargs[1]
   local template = data.fargs[2]
-
   if title ~= nil and template ~= nil then
+    templates.load_template_customizations(template, client)
     local note = client:create_note { title = title, template = template, no_write = false }
     client:open_note(note, { sync = true })
+    templates.restore_client_configurations(client)
     return
-  end
-
-  if title == nil or title == "" then
-    title = util.input("Enter title or path (optional): ", { completion = "file" })
-    if not title then
-      log.warn "Aborted"
-      return
-    elseif title == "" then
-      title = nil
-    end
   end
 
   picker:find_templates {
     callback = function(name)
+      templates.load_template_customizations(name, client)
+      if title == nil or title == "" then
+        -- Must use pcall in case of KeyboardInterrupt
+        -- We cannot place `title` where `safe_title` is because it would be redeclaring it
+        local success, safe_title = pcall(util.input, "Enter title or path (optional): ", { completion = "file" })
+        title = safe_title
+        if not success or not safe_title then
+          log.warn "Aborted"
+          templates.restore_client_configurations(client)
+          return
+        elseif safe_title == "" then
+          title = nil
+        end
+      end
+
       if name == nil or name == "" then
         log.warn "Aborted"
+        templates.restore_client_configurations(client)
         return
       end
+
       ---@type obsidian.Note
       local note = client:create_note { title = title, template = name, no_write = false }
       client:open_note(note, { sync = false })
+      templates.restore_client_configurations(client)
     end,
   }
 end

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -427,6 +427,7 @@ end
 ---@field date_format string|?
 ---@field time_format string|?
 ---@field substitutions table<string, function|string>|?
+---@field customizations table<string, obsidian.config.CustomTemplateOpts>
 config.TemplateOpts = {}
 
 --- Get defaults.
@@ -438,8 +439,14 @@ config.TemplateOpts.default = function()
     date_format = nil,
     time_format = nil,
     substitutions = {},
+    customizations = {},
   }
 end
+
+---@class obsidian.config.CustomTemplateOpts
+---
+---@field dir string|?
+---@field note_id_func function|?
 
 ---@class obsidian.config.UIOpts
 ---

--- a/lua/test_utils.lua
+++ b/lua/test_utils.lua
@@ -1,0 +1,29 @@
+local M = {}
+
+local obsidian = require "obsidian"
+
+---Get a client in a temporary directory.
+---@param testid string A unique ID for the tests which prevents directory collision
+---@param templates_dir string The template directory
+---@return obsidian.Client
+M.get_tmp_client = function(testid, templates_dir)
+  templates_dir = templates_dir or "templates"
+
+  local tmpdir = "tmp-vault-" .. testid
+
+  vim.loop.fs_mkdir(tmpdir, 448) -- <-- octal representation of 700 (RWX)
+  vim.loop.fs_mkdir(tmpdir .. "/" .. templates_dir, 448)
+
+  local client = obsidian.new_from_dir(tmpdir)
+  client.opts.templates.folder = "templates"
+  return client
+end
+
+--- Clean up a client, removing any resources created during `get_tmp_client`
+--- @param client obsidian.Client The Client
+M.cleanup_tmp_client = function(client)
+  local path = client.dir:resolve()
+  vim.fs.rm(tostring(path), { recursive = true, force = true })
+end
+
+return M

--- a/test/obsidian/commands/new_from_template_spec.lua
+++ b/test/obsidian/commands/new_from_template_spec.lua
@@ -1,0 +1,84 @@
+local get_tmp_client = require("test_utils").get_tmp_client
+local cleanup_tmp_client = require("test_utils").cleanup_tmp_client
+local new_from_template = require "obsidian.commands.new_from_template"
+local spy = require "luassert.spy"
+
+local templates_dir = "templates"
+
+--- @type obsidian.config.CustomTemplateOpts
+local zettelConfig = {
+  dir = "31 Atomic",
+  note_id_func = function(title)
+    return "31.01 - " .. title
+  end,
+}
+
+describe("new_from_template", function()
+  --- @type obsidian.Client
+  local client = nil
+
+  before_each(function()
+    client = get_tmp_client("new_from_template", templates_dir)
+    vim.loop.fs_mkdir(tostring(client.dir) .. "/" .. zettelConfig.dir, 448)
+    client.picker = function(_)
+      return {
+        find_templates = function(_, opts)
+          opts.callback()
+        end,
+      }
+    end
+    client.opts.templates.customizations = {
+      Zettel = zettelConfig,
+    }
+    client.opts.new_notes_location = "notes_subdir"
+  end)
+
+  after_each(function()
+    if client then
+      cleanup_tmp_client(client)
+    end
+  end)
+
+  it("should always try to load and restore template configurations", function()
+    -- Arrange
+    local templates = require "obsidian.templates"
+    client:create_note { dir = templates_dir, id = "zettel" }
+    spy.on(templates, "load_template_customizations")
+    spy.on(templates, "restore_client_configurations")
+
+    -- Act
+    ---@diagnostic disable-next-line: missing-fields
+    new_from_template(client, { fargs = { "Special Title", "Zettel" } })
+
+    -- Assert
+    assert.spy(templates.load_template_customizations).was.called()
+    assert.spy(templates.restore_client_configurations).was.called()
+  end)
+
+  it("should place matched templates in the custom directory", function()
+    -- Arrange
+    client:create_note { dir = templates_dir, id = "zettel" }
+    local expectedDir = client.dir / zettelConfig.dir
+    local title = "The Big Bang"
+    local id = zettelConfig.note_id_func(title)
+    local expected = string.format("%s/%s.md", expectedDir, id)
+    client.picker = function(_)
+      return {
+        find_templates = function(_, opts)
+          opts.callback "zettel"
+        end,
+      }
+    end
+
+    -- Act
+    ---@diagnostic disable-next-line: missing-fields
+
+    -- Must pass path here because we mock the fuzzy finder
+    new_from_template(client, { fargs = { title, "Zettel" } })
+    local f = io.open(expected, "r")
+
+    -- Assert
+    assert.truthy(f)
+    io.close(f)
+  end)
+end)

--- a/test/obsidian/commands/new_from_template_spec.lua
+++ b/test/obsidian/commands/new_from_template_spec.lua
@@ -48,7 +48,7 @@ describe("new_from_template", function()
 
     -- Act
     ---@diagnostic disable-next-line: missing-fields
-    new_from_template(client, { fargs = { "Special Title", "Zettel" } })
+    new_from_template(client, { fargs = { "Special Title", "zettel" } })
 
     -- Assert
     assert.spy(templates.load_template_customizations).was.called()
@@ -71,10 +71,9 @@ describe("new_from_template", function()
     end
 
     -- Act
-    ---@diagnostic disable-next-line: missing-fields
 
-    -- Must pass path here because we mock the fuzzy finder
-    new_from_template(client, { fargs = { title, "Zettel" } })
+    ---@diagnostic disable-next-line: missing-fields
+    new_from_template(client, { fargs = { title, "zettel" } })
     local f = io.open(expected, "r")
 
     -- Assert

--- a/test/obsidian/templates_spec.lua
+++ b/test/obsidian/templates_spec.lua
@@ -1,5 +1,5 @@
-local obsidian = require "obsidian"
-local Path = require "obsidian.path"
+local get_tmp_client = require("test_utils").get_tmp_client
+local cleanup_tmp_client = require("test_utils").cleanup_tmp_client
 local Note = require "obsidian.note"
 local templates = require "obsidian.templates"
 

--- a/test/obsidian/templates_spec.lua
+++ b/test/obsidian/templates_spec.lua
@@ -2,44 +2,139 @@ local get_tmp_client = require("test_utils").get_tmp_client
 local cleanup_tmp_client = require("test_utils").cleanup_tmp_client
 local Note = require "obsidian.note"
 local templates = require "obsidian.templates"
+local NewNotesLocation = require("obsidian.config").NewNotesLocation
 
----Get a client in a temporary directory.
----
----@return obsidian.Client
-local tmp_client = function()
-  -- This gives us a tmp file name, but we really want a directory.
-  -- So we delete that file immediately.
-  local tmpname = os.tmpname()
-  os.remove(tmpname)
+local templates_dir = "templates"
 
-  local dir = Path:new(tmpname .. "-obsidian/")
-  dir:mkdir { parents = true }
+--- @type obsidian.config.CustomTemplateOpts
+local zettelConfig = {
+  dir = "/custom/path/to/zettels",
+  note_id_func = function()
+    return "hummus"
+  end,
+}
 
-  return obsidian.new_from_dir(tostring(dir))
-end
+describe("template", function()
+  --- @type obsidian.Client|?
+  local client = nil
 
-describe("templates.substitute_template_variables()", function()
-  it("should substitute built-in variables", function()
-    local client = tmp_client()
-    local text = "today is {{date}} and the title of the note is {{title}}"
-    assert.equal(
-      string.format("today is %s and the title of the note is %s", os.date "%Y-%m-%d", "FOO"),
-      templates.substitute_template_variables(text, client, Note.new("FOO", { "FOO" }, {}))
-    )
+  before_each(function()
+    client = get_tmp_client("templates", templates_dir)
   end)
 
-  it("should substitute custom variables", function()
-    local client = tmp_client()
-    client.opts.templates.substitutions = {
-      weekday = function()
-        return "Monday"
-      end,
-    }
-    local text = "today is {{weekday}}"
-    assert.equal("today is Monday", templates.substitute_template_variables(text, client, Note.new("foo", {}, {})))
+  after_each(function()
+    if client then
+      cleanup_tmp_client(client)
+    end
+  end)
 
-    -- Make sure the client opts has not been modified.
-    assert.equal(1, vim.tbl_count(client.opts.templates.substitutions))
-    assert.equal("function", type(client.opts.templates.substitutions.weekday))
+  describe("templates.load_template_customizations()", function()
+    before_each(function()
+      client.opts.templates.customizations = {
+        Zettel = zettelConfig,
+      }
+    end)
+
+    after_each(function()
+      client.opts.templates.customizations = nil
+    end)
+
+    it("should not load customizations for non-existant templates", function()
+      -- Arrange
+      local old_id_func = client.opts.note_id_func
+
+      -- Act
+      templates.load_template_customizations("Zettel", client)
+
+      -- Assert
+      assert.falsy(client.opts.notes_subdir)
+      assert.are_not.equal(zettelConfig.note_id_func, client.opts.note_id_func)
+      assert.equal(old_id_func, client.opts.note_id_func)
+    end)
+
+    it("should load customizations for existing template", function()
+      -- Arrange
+      client:create_note { dir = templates_dir, id = "zettel" }
+
+      -- Act
+      templates.load_template_customizations("Zettel", client)
+
+      -- Assert
+      assert.equal(zettelConfig.dir, client.opts.notes_subdir)
+      assert.equal(zettelConfig.note_id_func, client.opts.note_id_func)
+    end)
+
+    it("should load customizations case-insensitively if template exists", function()
+      -- Arrange
+      client:create_note { dir = templates_dir, id = "zettel" }
+
+      -- Act
+      templates.load_template_customizations("zettel", client)
+
+      -- Assert
+      assert.equal(zettelConfig.dir, client.opts.notes_subdir)
+      assert.equal(zettelConfig.note_id_func, client.opts.note_id_func)
+    end)
+  end)
+
+  describe("templates.restore_client_configurations()", function()
+    it("should do nothing if no configuration is cached", function()
+      -- Arrange
+      local old_id_func = client.opts.note_id_func
+      local notes_subdir = client.opts.notes_subdir
+
+      -- Act
+      templates.restore_client_configurations(client)
+
+      -- Assert
+      assert.equal(old_id_func, client.opts.note_id_func)
+      assert.equal(notes_subdir, client.opts.notes_subdir)
+    end)
+
+    it("should reload client configuration after successfully loading previously", function()
+      -- Arrange
+      client:create_note { dir = templates_dir, id = "zettel" }
+      local old_id_func = client.opts.note_id_func
+      local notes_subdir = client.opts.notes_subdir
+      client.opts.templates.customizations = {
+        Zettel = zettelConfig,
+      }
+
+      -- Act
+      templates.load_template_customizations("Zettel", client)
+      assert.equal(zettelConfig.dir, client.opts.notes_subdir)
+      assert.equal(NewNotesLocation.notes_subdir, client.opts.new_notes_location)
+      assert.equal(zettelConfig.note_id_func, client.opts.note_id_func)
+      templates.restore_client_configurations(client)
+
+      -- Assert
+      assert.equal(old_id_func, client.opts.note_id_func)
+      assert.equal(NewNotesLocation.current_dir, client.opts.new_notes_location)
+      assert.equal(notes_subdir, client.opts.notes_subdir)
+    end)
+  end)
+
+  describe("templates.substitute_template_variables()", function()
+    it("should substitute built-in variables", function()
+      local text = "today is {{date}} and the title of the note is {{title}}"
+      assert.equal(
+        string.format("today is %s and the title of the note is %s", os.date "%Y-%m-%d", "FOO"),
+        templates.substitute_template_variables(text, client, Note.new("FOO", { "FOO" }, {}))
+      )
+    end)
+
+    it("should substitute custom variables", function()
+      client.opts.templates.substitutions = {
+        weekday = function()
+          return "Monday"
+        end,
+      }
+      local text = "today is {{weekday}}"
+      assert.equal("today is Monday", templates.substitute_template_variables(text, client, Note.new("foo", {}, {})))
+
+      -- Make sure the client opts has not been modified.
+      assert.equal(1, vim.tbl_count(client.opts.templates.substitutions))
+      assert.equal("function", type(client.opts.templates.substitutions.weekday))
+    end)
   end)
 end)

--- a/test/obsidian/templates_spec.lua
+++ b/test/obsidian/templates_spec.lua
@@ -44,7 +44,7 @@ describe("template", function()
       local old_id_func = client.opts.note_id_func
 
       -- Act
-      templates.load_template_customizations("Zettel", client)
+      templates.load_template_customizations("zettel", client)
 
       -- Assert
       assert.falsy(client.opts.notes_subdir)
@@ -57,7 +57,7 @@ describe("template", function()
       client:create_note { dir = templates_dir, id = "zettel" }
 
       -- Act
-      templates.load_template_customizations("Zettel", client)
+      templates.load_template_customizations("zettel", client)
 
       -- Assert
       assert.equal(zettelConfig.dir, client.opts.notes_subdir)
@@ -101,7 +101,7 @@ describe("template", function()
       }
 
       -- Act
-      templates.load_template_customizations("Zettel", client)
+      templates.load_template_customizations("zettel", client)
       assert.equal(zettelConfig.dir, client.opts.notes_subdir)
       assert.equal(NewNotesLocation.notes_subdir, client.opts.new_notes_location)
       assert.equal(zettelConfig.note_id_func, client.opts.note_id_func)


### PR DESCRIPTION
# Custom Directories and `note_id_func`s for templates

This PR implements the features discussed by #165.

In short, it:

1. Allows notes created using templates to automatically be placed in a specific directory
2. Allows such notes to have their own `note_id_func` for naming themselves specially

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)

## Testing the Behavior

1. Create a template and put it in the template folder
  - For this example, I'm using "zettel" as the template ID
2. Create a configuration for that template, example:

```
--[[ In configuration ]]
templates = {
  customization = {
     zettel = {
       dir = "existing/path/to/directory,
       note_id_func = function(title)
         return "my-cool-id+" .. title
       end
    }
  }
}
```

> [!NOTE]
> Although some logic is case insensitive, testing on Linux revealed that not all of it is. For this reason,
> the case of template specified in the customization ("zettel" in this example") should match the name
> **and case** of the template id