### PR TITLE
feat: add an UI option to ignore conceal warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added `opts.ui.ignore_conceal_warn` option to ignore conceal-related warnings.
+
 ### Added
 
 - Added `makefile types` target to check types via lua-ls

--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ require("obsidian").setup {
   -- This requires you have `conceallevel` set to 1 or 2. See `:help conceallevel` for more details.
   ui = {
     enable = true, -- set to false to disable all additional syntax features
+    ignore_conceal_warn = false, -- set to true to disable conceallevel specific warning
     update_debounce = 200, -- update delay after a text change (in milliseconds)
     max_file_length = 5000, -- disable UI features for files with more than this many lines
     -- Define how various check-boxes are displayed

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -444,6 +444,7 @@ end
 ---@class obsidian.config.UIOpts
 ---
 ---@field enable boolean
+---@field ignore_conceal_warn boolean
 ---@field update_debounce integer
 ---@field max_file_length integer|?
 ---@field checkboxes table<string, obsidian.config.CheckboxSpec>
@@ -475,6 +476,7 @@ config.UIOpts = {}
 config.UIOpts.default = function()
   return {
     enable = true,
+    ignore_conceal_warn = false,
     update_debounce = 200,
     max_file_length = 5000,
     checkboxes = {

--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -624,7 +624,7 @@ M.setup = function(workspace, ui_opts)
     callback = function()
       local conceallevel = vim.opt_local.conceallevel:get()
 
-      if conceallevel < 1 or conceallevel > 2 then
+      if (conceallevel < 1 or conceallevel > 2) and not ui_opts.ignore_conceal_warn then
         log.warn_once(
           "Obsidian additional syntax features require 'conceallevel' to be set to 1 or 2, "
             .. "but you have 'conceallevel' set to '%s'.\n"


### PR DESCRIPTION
In https://github.com/epwalsh/obsidian.nvim/issues/286#issuecomment-2048334358 it was suggested that a new config could be added to specifically not warn if the conceal level is 0 and the UI is enabled.

This commit does this and guard against the conceal warning when the option is set.

cc https://github.com/epwalsh/obsidian.nvim/issues/492
cc https://github.com/epwalsh/obsidian.nvim/pull/778


## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
