### PR TITLE
fix: added multiword support to new_from_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Added `opts.ui.ignore_conceal_warn` option to ignore conceal-related warnings.
+- Added support for multiword note title in new_from_template.
 
 ### Added
 

--- a/lua/obsidian/commands/new_from_template.lua
+++ b/lua/obsidian/commands/new_from_template.lua
@@ -10,8 +10,8 @@ return function(client, data)
     return
   end
 
-  local title = data.fargs[1]
-  local template = data.fargs[2]
+  local title = table.concat(data.fargs, " ", 1, #data.fargs - 1)
+  local template = data.fargs[#data.fargs]
 
   if title ~= nil and template ~= nil then
     local note = client:create_note { title = title, template = template, no_write = false }


### PR DESCRIPTION
# TODO Fill in Title

Now you can create note titled `test note` from template using new_from_template.

## Screenshots



## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
