### PR TITLE
Pass note path into `note_id_func`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Pass the note path to `note_id_func`
+
+### Changed
+
+### Fixed
+
 ## [v3.12.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.12.0) - 2025-06-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -371,8 +371,9 @@ require("obsidian").setup {
 
   -- Optional, customize how note IDs are generated given an optional title.
   ---@param title string|?
+  ---@param path obsidian.Path|?
   ---@return string
-  note_id_func = function(title)
+  note_id_func = function(title, path)
     -- Create note IDs in a Zettelkasten format with a timestamp and a suffix.
     -- In this case a note with the title 'My new note' will be given an ID that looks
     -- like '1657296016-my-new-note', and therefore the file name '1657296016-my-new-note.md'.

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1596,7 +1596,7 @@ Client.new_note_id = function(self, title)
     if new_id == nil or string.len(new_id) == 0 then
       error(string.format("Your 'note_id_func' must return a non-empty string, got '%s'!", tostring(new_id)))
     end
-    -- Remote '.md' suffix if it's there (we add that later).
+    -- Remove '.md' suffix if it's there (we add that later).
     new_id = new_id:gsub("%.md$", "", 1)
     return new_id
   else

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1588,11 +1588,12 @@ end
 --- otherwise falls back to generated a Zettelkasten style ID.
 ---
 ---@param title string|?
+---@param path obsidian.Path|?
 ---
 ---@return string
-Client.new_note_id = function(self, title)
+Client.new_note_id = function(self, title, path)
   if self.opts.note_id_func ~= nil then
-    local new_id = self.opts.note_id_func(title)
+    local new_id = self.opts.note_id_func(title, path)
     if new_id == nil or string.len(new_id) == 0 then
       error(string.format("Your 'note_id_func' must return a non-empty string, got '%s'!", tostring(new_id)))
     end

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -10,7 +10,7 @@ local config = {}
 ---@field notes_subdir string|?
 ---@field templates obsidian.config.TemplateOpts
 ---@field new_notes_location obsidian.config.NewNotesLocation
----@field note_id_func (fun(title: string|?): string)|?
+---@field note_id_func (fun(title: string|?, path: obsidian.Path|?): string)|?
 ---@field note_path_func (fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path)|?
 ---@field wiki_link_func (fun(opts: {path: string, label: string, id: string|?}): string)
 ---@field markdown_link_func (fun(opts: {path: string, label: string, id: string|?}): string)

--- a/tests/test_client.lua
+++ b/tests/test_client.lua
@@ -61,6 +61,35 @@ describe("Client", function()
   end)
 end)
 
+describe("Client:new_note_id()", function()
+  it("should generate default Zettelkasten-style ID when `note_id_func` is unset", function()
+    with_tmp_client(function(client)
+      client.opts.note_id_func = nil
+      local expectedMatch = "^%d+-[A-Z][A-Z][A-Z][A-Z]"
+      local actual = client:new_note_id "My Cool Title"
+      MiniTest.expect.no_equality(string.find(actual, expectedMatch), nil)
+    end)
+  end)
+
+  it("should allow users to use the path of the note in their `note_id_func`", function()
+    with_tmp_client(function(client)
+      client.opts.note_id_func = function(title, path)
+        local id = ""
+        for str in string.gmatch(path.filename, "([^/]+)") do
+          id = id .. str .. "-"
+        end
+        -- Separate the path components by dashes instead of slashes
+        return id .. title
+      end
+
+      local path = Path:new() / "path" / "to" / "note"
+      local expected = "path-to-note-My Cool Title"
+      local actual = client:new_note_id("My Cool Title", path)
+      MiniTest.expect.no_equality(string.find(actual, expected, 0, true), nil)
+    end)
+  end)
+end)
+
 describe("Client:new_note_path()", function()
   it('should only append one ".md" at the end of the path', function()
     with_tmp_client(function(client)


### PR DESCRIPTION
# Pass the Note Path into `note_id_func`

Title. This is useful for allowing per-directory configurations for notes which will blend nicely with #184 .

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
