### PR TITLE
Add option to define function to customize dailies

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,12 @@ require("obsidian").setup {
     template = nil,
     -- Optional, if you want `Obsidian yesterday` to return the last work day or `Obsidian tomorrow` to return the next work day.
     workdays_only = true,
+    -- Optional, a function for more complex customization.
+    -- If defined, it is called with datetime (integer) as its only argument. 
+    -- The return value must be a tuple (string, string|nil) which represents note path and alias where alias is optional.
+    -- The note path must be relative and is treated as a sub path of the vault! Don't forget to add ".md" at the end if desired.
+    -- If this function is defined, it's returned values are used instead of folder, date_format and alias_format.
+    func = nil,
   },
 
   -- Optional, completion of wiki links, local markdown links, and tags using nvim-cmp.

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -431,6 +431,7 @@ end
 ---@field template string|?
 ---@field default_tags string[]|?
 ---@field workdays_only boolean
+---@field func? fun(datetime: integer): (string, string|?) default to nil
 config.DailyNotesOpts = {}
 
 --- Get defaults.
@@ -443,6 +444,7 @@ config.DailyNotesOpts.default = function()
     alias_format = nil,
     default_tags = { "daily-notes" },
     workdays_only = true,
+    func = nil,
   }
 end
 

--- a/tests/test_client.lua
+++ b/tests/test_client.lua
@@ -40,6 +40,18 @@ describe("Client", function()
     end)
   end)
 
+  it("should be able to initialize a daily note with custom func", function()
+    with_tmp_client(function(client)
+      client.opts.daily_notes.func = function(datetime)
+				local note = os.date("%Y/%m-%B/%Y-%m-%d", datetime)
+				return "journal/" .. note .. ".md"
+			end
+      local note = client:today()
+      MiniTest.expect.equality(true, note.path ~= nil)
+      MiniTest.expect.equality(true, note:exists())
+    end)
+  end)
+
   it("should not add frontmatter for today when disabled", function()
     with_tmp_client(function(client)
       client.opts.disable_frontmatter = true


### PR DESCRIPTION
# Add option to define function to customize dailies

Adds an option `func` to the daily notes options that allows for more advanced customization of where dailies are located. The function gets the time and can return the path and optionally the alias.

Here is an example of how it could be defined:

```lua
daily_notes = {
  alias_format = "%B %-d, %Y",
  workdays_only = false,
  func = function(datetime)
    local note = os.date("%Y/%m-%B/%Y-%m-%d", datetime)
    return "journal/" .. note .. ".md"
  end,
},
```

This would result in the following daily notes structure:

```
journal
└── 2025
    ├── 05-May
    │   └── 2025-05-08.md
    └── 06-June
        ├── 2025-06-06.md
        └── 2025-06-07.md
```

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
