### PR TITLE
fix(templates): text corrupted when custom variables appear more than once in a template file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor the `util` module.
 
+### Fixed
+
+- Fixed corrupted text when custom variables appear more than once in a template file (#198)
+
 ## [v3.12.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.12.0) - 2025-06-05
 
 ### Added

--- a/lua/obsidian/templates.lua
+++ b/lua/obsidian/templates.lua
@@ -73,7 +73,11 @@ M.substitute_template_variables = function(text, ctx)
 
   -- Replace known variables.
   for key, subst in pairs(methods) do
-    for m_start, m_end in util.gfind(text, "{{" .. key .. "}}", nil, true) do
+    while true do
+      local m_start, m_end = string.find(text, "{{" .. key .. "}}", nil, true)
+      if not m_start or not m_end then
+        break
+      end
       ---@type string
       local value
       if type(subst) == "string" then

--- a/tests/test_templates.lua
+++ b/tests/test_templates.lua
@@ -47,6 +47,18 @@ T["substitute_template_variables()"]["should substitute custom variables"] = fun
   end)
 end
 
+T["substitute_template_variables()"]["should substitute consecutive custom variables"] = function()
+  h.with_tmp_client(function(client)
+    client.opts.templates.substitutions = {
+      value = function()
+        return "VALUE"
+      end,
+    }
+    local text = "{{value}} and then {{value}} and then {{value}}"
+    eq("VALUE and then VALUE and then VALUE", M.substitute_template_variables(text, tmp_template_context(client)))
+  end)
+end
+
 T["substitute_template_variables()"]["should provide substitution functions with template context"] = function()
   h.with_tmp_client(function(client)
     client.opts.templates.substitutions = {


### PR DESCRIPTION
Fixes #198

## Root Cause

The indexes returned by `gfind()` are relative to the initial template string _**before**_ any substitutions take place. In the loop, however, we're using those same indexes to slice the string _**after**_ substitutions take place. As a consequence, the code keeps accumulating errors, unless the value happens to match the length of `{{var}}` _exactly_.

## Proposed Fix

I've inlined the call to `string.find()` so that the indexes stay relative to the _current_ reference to `text`, rather than to the _initial_ reference to `text`. To make the diff as small as possible, I've changed the loop into a simple `while true` loop, but I'm open to ideas for a better implementation.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] ~~The changes are documented in the `README.md` file~~
- [x] The code complies with `make chores` (for style, lint, types, and tests)
