### PR TITLE
fix: avoid tag false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When filling out a template with user-provided substitution functions, pass a "context" object to each invocation so that users can respond accordingly.
   - Added `obsidian.InsertTemplateContext` and `obsidian.CloneTemplateContext` as these new "context" objects.
 
+### Fixed
+
+- Add further checks to void false positives when finding tags
+
 ## [v3.12.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.12.0) - 2025-06-05
 
 ### Added

--- a/lua/obsidian/search.lua
+++ b/lua/obsidian/search.lua
@@ -182,8 +182,9 @@ M.find_tags = function(s)
   -- NOTE: we search over all reference types to make sure we're not including anchor links within
   -- references, which otherwise look just like tags.
   for match in iter(M.find_refs(s, { include_naked_urls = true, include_tags = true })) do
-    local _, _, m_type = unpack(match)
-    if m_type == M.RefTypes.Tag then
+    local st, ed, m_type = unpack(match)
+    local match_string = s:sub(st, ed)
+    if m_type == M.RefTypes.Tag and not util.is_hex_color(match_string) then
       matches[#matches + 1] = match
     end
   end

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -191,6 +191,11 @@ util.urldecode = function(str)
   return str
 end
 
+util.is_hex_color = function(s)
+  return (s:match "^#%x%x%x$" or s:match "^#%x%x%x%x$" or s:match "^#%x%x%x%x%x%x$" or s:match "^#%x%x%x%x%x%x%x%x$")
+    ~= nil
+end
+
 ---Match the case of 'key' to the given 'prefix' of the key.
 ---
 ---@param prefix string

--- a/tests/test_search.lua
+++ b/tests/test_search.lua
@@ -61,25 +61,6 @@ describe("search.find_refs()", function()
   end)
 end)
 
-describe("search.find_tags()", function()
-  it("should find positions of all tags", function()
-    local s = "I have a #meeting at noon"
-    MiniTest.expect.equality({ { 10, 17, RefTypes.Tag } }, search.find_tags(s))
-  end)
-
-  it("should ignore escaped tags", function()
-    local s = "I have a #meeting at noon \\#not-a-tag"
-    MiniTest.expect.equality({ { 10, 17, RefTypes.Tag } }, search.find_tags(s))
-    s = [[\#notatag]]
-    MiniTest.expect.equality({}, search.find_tags(s))
-  end)
-
-  it("should ignore anchor links that look like tags", function()
-    local s = "[readme](README#installation)"
-    MiniTest.expect.equality({}, search.find_tags(s))
-  end)
-end)
-
 describe("search.find_and_replace_refs()", function()
   it("should find and replace all refs", function()
     local s, indices = search.find_and_replace_refs "[[Foo]] [[foo|Bar]]"

--- a/tests/test_search_mini.lua
+++ b/tests/test_search_mini.lua
@@ -17,4 +17,38 @@ T["find_matches"] = function()
   eq(2, #matches)
 end
 
+T["find_tags"] = new_set()
+
+T["find_tags"]["should find positions of all tags"] = function()
+  local s = "I have a #meeting at noon"
+  eq({ { 10, 17, RefTypes.Tag } }, M.find_tags(s))
+end
+
+T["find_tags"]["should ignore escaped tags"] = function()
+  local s = "I have a #meeting at noon \\#not-a-tag"
+  eq({ { 10, 17, RefTypes.Tag } }, M.find_tags(s))
+  s = [[\#notatag]]
+  eq({}, M.find_tags(s))
+end
+
+T["find_tags"]["should ignore anchor links that look like tags"] = function()
+  local s = "[readme](README#installation)"
+  eq({}, M.find_tags(s))
+end
+
+T["find_tags"]["should ignore section in urls"] = function()
+  local s = "https://example.com/page#section"
+  eq({}, M.find_tags(s))
+end
+
+T["find_tags"]["should ignore issue numbers"] = function()
+  local s = "#100 is something"
+  eq({}, M.find_tags(s))
+end
+
+T["find_tags"]["should ignore hexcolors"] = function()
+  local s = "backgroud: #f0f0f0"
+  eq({}, M.find_tags(s))
+end
+
 return T

--- a/tests/test_util_mini.lua
+++ b/tests/test_util_mini.lua
@@ -1,0 +1,29 @@
+local M = require "obsidian.util"
+
+local new_set, eq = MiniTest.new_set, MiniTest.expect.equality
+
+local T = new_set()
+
+T["is_hex_color"] = new_set()
+
+T["is_hex_color"]["recognizes valid hex colors"] = function()
+  eq(M.is_hex_color "#abc", true)
+  eq(M.is_hex_color "#abcd", true)
+  eq(M.is_hex_color "#aabbcc", true)
+  eq(M.is_hex_color "#aabbccdd", true)
+end
+
+T["is_hex_color"]["rejects invalid hex colors"] = function()
+  eq(M.is_hex_color "#ab", false)
+  eq(M.is_hex_color "#abcde", false)
+  eq(M.is_hex_color "#aabbccfg", false)
+  eq(M.is_hex_color "#aabbccdde", false)
+end
+
+T["is_hex_color"]["rejects invalid chars"] = function()
+  eq(M.is_hex_color "#ggg", false)
+  eq(M.is_hex_color "#12345z", false)
+  eq(M.is_hex_color "#xyzxyz", false)
+end
+
+return T


### PR DESCRIPTION
resolves #205 

patterns to avoid:
- [x] css hex colors
- [x] url fragments
- [x] issue numbers

what else?

## PR Checklist

- [ ] The PR contains a description of the changes
- [ ] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
