### PR TITLE
feat: use _G.Obsidian to hold state, instead of client

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -22,6 +22,7 @@ ignore = {
 
 -- Global objects defined by the C code
 read_globals = {
+  "Obsidian",
   "vim",
   "MiniDoc",
   "MiniTest",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `api.insert_text`, use `vim.api.nvim_put`
 - change `clipboard_is_img` to use `vim.fn.system` instead of `io.popen` to get the output of the command with awareness of the shell variables.
 - use `run_job` wrap with `bash` to run `save_clipboard_image` async for Wayland sessions to avoid data corruption.
+- Use a `Obsidian` global variable to hold the state instead of client.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -564,30 +564,29 @@ require("obsidian").setup {
     },
   },
 
-  -- Specify how to handle attachments.
+  ---@class obsidian.config.AttachmentsOpts
+  ---
+  ---Default folder to save images to, relative to the vault root.
+  ---@field img_folder? string
+  ---
+  ---Default name for pasted images
+  ---@field img_name_func? fun(): string
+  ---
+  ---Default text to insert for pasted images
+  ---@field img_text_func? fun(client: obsidian.Client, path: obsidian.Path): string
+  ---
+  ---Whether to confirm the paste or not. Defaults to true.
+  ---@field confirm_img_paste? boolean
   attachments = {
-    -- The default folder to place images in via `:Obsidian paste_img`.
-    -- If this is a relative path it will be interpreted as relative to the vault root.
-    -- You can always override this per image by passing a full path to the command instead of just a filename.
-    img_folder = "assets/imgs", -- This is the default
-
-    -- A function that determines default name or prefix when pasting images via `:Obsidian paste_img`.
-    ---@return string
+    img_folder = "assets/imgs",
+    img_text_func = function(client, path)
+      local encoded_path = require("obsidian.util").urlencode(path:vault_relative_path() or tostring(path))
+      return string.format("![%s](%s)", path.name, encoded_path)
+    end,
     img_name_func = function()
-      -- Prefix image names with timestamp.
       return string.format("Pasted image %s", os.date "%Y%m%d%H%M%S")
     end,
-
-    -- A function that determines the text to insert in the note when pasting an image.
-    -- It takes two arguments, the `obsidian.Client` and an `obsidian.Path` to the image file.
-    -- This is the default implementation.
-    ---@param client obsidian.Client
-    ---@param path obsidian.Path the absolute path to the image file
-    ---@return string
-    img_text_func = function(client, path)
-      path = client:vault_relative_path(path) or path
-      return string.format("![%s](%s)", path.name, path)
-    end,
+    confirm_img_paste = true,
   },
 
   -- See https://github.com/obsidian-nvim/obsidian.nvim/wiki/Notes-on-configuration#statusline-component

--- a/after/ftplugin/markdown.lua
+++ b/after/ftplugin/markdown.lua
@@ -2,9 +2,7 @@ local obsidian = require "obsidian"
 local buf = vim.api.nvim_get_current_buf()
 local buf_dir = vim.fs.dirname(vim.api.nvim_buf_get_name(buf))
 
-local client = obsidian.get_client()
-
-local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, client.opts.workspaces)
+local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, Obsidian.opts.workspaces)
 if not workspace then
   return -- if not in any workspace.
 end

--- a/doc/obsidian_api.txt
+++ b/doc/obsidian_api.txt
@@ -35,13 +35,6 @@ in Lua. To get the client instance, run:
 Class ~
 {obsidian.Client} : obsidian.ABC
 
-Fields ~
-{current_workspace} `(obsidian.Workspace)` The current workspace.
-{dir} `(obsidian.Path)` The root of the vault for the current workspace.
-{opts} `(obsidian.config.ClientOpts)` The client config.
-{buf_dir} `(obsidian.Path|? The)` parent directory of the current buffer.
-{_default_opts} `(obsidian.config.ClientOpts)`
-
 ------------------------------------------------------------------------------
                                                          *obsidian.Client.new()*
                               `Client.new`({opts})
@@ -66,7 +59,7 @@ Parameters ~
 
 ------------------------------------------------------------------------------
                                           *obsidian.Client.opts_for_workspace()*
-                `Client.opts_for_workspace`({self}, {workspace})
+                 `Client.opts_for_workspace`({_}, {workspace})
 Get the normalize opts for a given workspace.
 
 Parameters ~
@@ -98,7 +91,7 @@ Return ~
 
 ------------------------------------------------------------------------------
                                                   *obsidian.Client.vault_root()*
-                    `Client.vault_root`({self}, {workspace})
+                     `Client.vault_root`({_}, {workspace})
 Get the absolute path to the root of the Obsidian vault for the given workspace or the
 current workspace.
 
@@ -278,7 +271,7 @@ Parameters ~
 
 ------------------------------------------------------------------------------
                                                    *obsidian.Client.open_note()*
-               `Client.open_note`({self}, {note_or_path}, {opts})
+                `Client.open_note`({_}, {note_or_path}, {opts})
 Open a note in a buffer.
 
 Parameters ~
@@ -421,7 +414,7 @@ Options:
 
 ------------------------------------------------------------------------------
                                                  *obsidian.Client.new_note_id()*
-                     `Client.new_note_id`({self}, {title})
+                       `Client.new_note_id`({_}, {title})
 Generate a unique ID for a new note. This respects the user's `note_id_func` if configured,
 otherwise falls back to generated a Zettelkasten style ID.
 
@@ -433,7 +426,7 @@ Return ~
 
 ------------------------------------------------------------------------------
                                                *obsidian.Client.new_note_path()*
-                     `Client.new_note_path`({self}, {spec})
+                      `Client.new_note_path`({_}, {spec})
 Generate the file path for a new note given its ID, parent directory, and title.
 This respects the user's `note_path_func` if configured, otherwise essentially falls back to
 `spec.dir / (spec.id .. ".md")`.
@@ -956,29 +949,6 @@ Initialize a new 'Workspace' object from a workspace spec.
 
 Parameters ~
 {spec} `(obsidian.workspace.WorkspaceSpec)`
-
-Return ~
-`(obsidian.Workspace)`
-
-------------------------------------------------------------------------------
-                                             *obsidian.Workspace.new_from_cwd()*
-                        `Workspace.new_from_cwd`({opts})
-Initialize a 'Workspace' object from the current working directory.
-
-Parameters ~
-{opts} `(obsidian.workspace.WorkspaceOpts|)`?
-
-Return ~
-`(obsidian.Workspace)`
-
-------------------------------------------------------------------------------
-                                             *obsidian.Workspace.new_from_buf()*
-                   `Workspace.new_from_buf`({bufnr}, {opts})
-Initialize a 'Workspace' object from the parent directory of the current buffer.
-
-Parameters ~
-{bufnr} `(integer|)`?
-{opts} `(obsidian.workspace.WorkspaceOpts|)`?
 
 Return ~
 `(obsidian.Workspace)`

--- a/doc/obsidian_api.txt
+++ b/doc/obsidian_api.txt
@@ -59,7 +59,7 @@ Parameters ~
 
 ------------------------------------------------------------------------------
                                           *obsidian.Client.opts_for_workspace()*
-                 `Client.opts_for_workspace`({_}, {workspace})
+                `Client.opts_for_workspace`({self}, {workspace})
 Get the normalize opts for a given workspace.
 
 Parameters ~
@@ -91,7 +91,7 @@ Return ~
 
 ------------------------------------------------------------------------------
                                                   *obsidian.Client.vault_root()*
-                     `Client.vault_root`({_}, {workspace})
+                    `Client.vault_root`({self}, {workspace})
 Get the absolute path to the root of the Obsidian vault for the given workspace or the
 current workspace.
 
@@ -271,7 +271,7 @@ Parameters ~
 
 ------------------------------------------------------------------------------
                                                    *obsidian.Client.open_note()*
-                `Client.open_note`({_}, {note_or_path}, {opts})
+               `Client.open_note`({self}, {note_or_path}, {opts})
 Open a note in a buffer.
 
 Parameters ~
@@ -414,7 +414,7 @@ Options:
 
 ------------------------------------------------------------------------------
                                                  *obsidian.Client.new_note_id()*
-                       `Client.new_note_id`({_}, {title})
+                     `Client.new_note_id`({self}, {title})
 Generate a unique ID for a new note. This respects the user's `note_id_func` if configured,
 otherwise falls back to generated a Zettelkasten style ID.
 
@@ -426,7 +426,7 @@ Return ~
 
 ------------------------------------------------------------------------------
                                                *obsidian.Client.new_note_path()*
-                      `Client.new_note_path`({_}, {spec})
+                     `Client.new_note_path`({self}, {spec})
 Generate the file path for a new note given its ID, parent directory, and title.
 This respects the user's `note_path_func` if configured, otherwise essentially falls back to
 `spec.dir / (spec.id .. ".md")`.
@@ -449,21 +449,6 @@ Parameters ~
 
 Return ~
 `(string| `(optional))``,string,obsidian.Path
-
-------------------------------------------------------------------------------
-                                                    *obsidian.Client.new_note()*
-           `Client.new_note`({self}, {title}, {id}, {dir}, {aliases})
-Create and save a new note.
-Deprecated: prefer `Client:create_note()` instead.
-
-Parameters ~
-{title} `(string|? The)` title for the note.
-{id} `(string|? An)` optional ID for the note. If not provided one will be generated.
-{dir} `(string|obsidian.Path|? An)` optional directory to place the note. If this is a relative path it will be interpreted relative the workspace / vault root.
-{aliases} `(string[]|? Additional)` aliases to assign to the note.
-
-Return ~
-`(obsidian.Note)`
 
 ------------------------------------------------------------------------------
 Class ~

--- a/lua/obsidian/builtin.lua
+++ b/lua/obsidian/builtin.lua
@@ -5,7 +5,7 @@ local util = require "obsidian.util"
 ---builtin functions that are default values for actions, and modules
 
 M.smart_action = function()
-  local legacy = require("obsidian").get_client().opts.legacy_commands
+  local legacy = Obsidian.opts.legacy_commands
   -- follow link if possible
   if api.cursor_on_markdown_link(nil, nil, true) then
     return legacy and "<cmd>ObsidianFollowLink<cr>" or "<cmd>Obsidian follow_link<cr>"

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1680,20 +1680,6 @@ Client.parse_title_id_path = function(self, title, id, dir)
   return title, id, path
 end
 
---- Create and save a new note.
---- Deprecated: prefer `Client:create_note()` instead.
----
----@param title string|? The title for the note.
----@param id string|? An optional ID for the note. If not provided one will be generated.
----@param dir string|obsidian.Path|? An optional directory to place the note. If this is a relative path it will be interpreted relative the workspace / vault root.
----@param aliases string[]|? Additional aliases to assign to the note.
----
----@return obsidian.Note
----@deprecated
-Client.new_note = function(self, title, id, dir, aliases)
-  return self:create_note { title = title, id = id, dir = dir, aliases = aliases }
-end
-
 ---@class obsidian.CreateNoteOpts
 ---
 ---@field title string|?

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -38,16 +38,7 @@ local iter = vim.iter
 ---@toc_entry obsidian.Client
 ---
 ---@class obsidian.Client : obsidian.ABC
----
----@field current_workspace obsidian.Workspace The current workspace.
----@field dir obsidian.Path The root of the vault for the current workspace.
----@field buf_dir obsidian.Path|? The parent directory of the current buffer.
----@field _default_opts obsidian.config.ClientOpts
-local Client = abc.new_class {
-  __tostring = function(self)
-    return string.format("obsidian.Client('%s')", Obsidian.dir)
-  end,
-}
+local Client = abc.new_class {}
 
 --- Create a new Obsidian client without additional setup.
 --- This is mostly used for testing. In practice you usually want to obtain the existing
@@ -61,7 +52,7 @@ local Client = abc.new_class {
 Client.new = function(opts)
   local self = Client.init()
 
-  self._default_opts = opts
+  Obsidian._opts = opts
 
   local workspace = Workspace.get_from_opts(opts)
   assert(workspace)
@@ -120,7 +111,7 @@ end
 ---@return obsidian.config.ClientOpts
 Client.opts_for_workspace = function(self, workspace)
   if workspace then
-    return config.normalize(workspace.overrides and workspace.overrides or {}, self._default_opts)
+    return config.normalize(workspace.overrides and workspace.overrides or {}, Obsidian._opts)
   else
     return Obsidian.opts
   end

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -9,7 +9,6 @@
 ---@toc
 
 local Path = require "obsidian.path"
-local abc = require "obsidian.abc"
 local async = require "plenary.async"
 local channel = require("plenary.async.control").channel
 local config = require "obsidian.config"
@@ -38,7 +37,29 @@ local iter = vim.iter
 ---@toc_entry obsidian.Client
 ---
 ---@class obsidian.Client : obsidian.ABC
-local Client = abc.new_class {}
+local Client = {}
+
+local depreacted_lookup = {
+  dir = "dir",
+  buf_dir = "buf_dir",
+  current_workspace = "workspace",
+  opts = "opts",
+}
+
+Client.__index = function(_, k)
+  if depreacted_lookup[k] then
+    local msg = string.format(
+      [[client.%s is depreacted, use Obsidian.%s instead.
+client is going to be removed in the future as well.]],
+      k,
+      depreacted_lookup[k]
+    )
+    log.warn(msg)
+    return Obsidian[depreacted_lookup[k]]
+  elseif rawget(Client, k) then
+    return rawget(Client, k)
+  end
+end
 
 --- Create a new Obsidian client without additional setup.
 --- This is mostly used for testing. In practice you usually want to obtain the existing
@@ -50,7 +71,7 @@ local Client = abc.new_class {}
 ---
 ---@return obsidian.Client
 Client.new = function(opts)
-  local self = Client.init()
+  local self = setmetatable({}, Client)
 
   Obsidian._opts = opts
 

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -123,7 +123,7 @@ return function(client)
     local note = client:current_note(0, load_opts)
 
     -- Check if cursor is on a header, if so and header parsing is enabled, use that anchor.
-    if client.opts.backlinks.parse_headers then
+    if Obsidian.opts.backlinks.parse_headers then
       local header_match = util.parse_header(vim.api.nvim_get_current_line())
       if header_match then
         opts.anchor = header_match.anchor

--- a/lua/obsidian/commands/check.lua
+++ b/lua/obsidian/commands/check.lua
@@ -1,4 +1,5 @@
 local Note = require "obsidian.note"
+local Path = require "obsidian.path"
 local log = require "obsidian.log"
 local iter = vim.iter
 
@@ -37,7 +38,7 @@ return function(client, _)
   }
 
   client:apply_async_raw(function(path)
-    local relative_path = client:vault_relative_path(path, { strict = true })
+    local relative_path = Path.new(path):vault_relative_path { strict = true }
     local ok, res = pcall(Note.from_file, path)
 
     if not ok then

--- a/lua/obsidian/commands/dailies.lua
+++ b/lua/obsidian/commands/dailies.lua
@@ -47,7 +47,7 @@ return function(client, data)
   local dailies = {}
   for offset = offset_end, offset_start, -1 do
     local datetime = os.time() + (offset * 3600 * 24)
-    local daily_note_path = daily.daily_note_path(datetime, Obsidian.opts)
+    local daily_note_path = daily.daily_note_path(datetime)
     local daily_note_alias = tostring(os.date(Obsidian.opts.daily_notes.alias_format or "%A %B %-d, %Y", datetime))
     if offset == 0 then
       daily_note_alias = daily_note_alias .. " @today"
@@ -70,7 +70,7 @@ return function(client, data)
   picker:pick(dailies, {
     prompt_title = "Dailies",
     callback = function(offset)
-      local note = daily.daily(offset, {}, Obsidian.opts)
+      local note = daily.daily(offset, {})
       client:open_note(note)
     end,
   })

--- a/lua/obsidian/commands/dailies.lua
+++ b/lua/obsidian/commands/dailies.lua
@@ -47,8 +47,8 @@ return function(client, data)
   local dailies = {}
   for offset = offset_end, offset_start, -1 do
     local datetime = os.time() + (offset * 3600 * 24)
-    local daily_note_path = daily.daily_note_path(datetime, client.opts)
-    local daily_note_alias = tostring(os.date(client.opts.daily_notes.alias_format or "%A %B %-d, %Y", datetime))
+    local daily_note_path = daily.daily_note_path(datetime, Obsidian.opts)
+    local daily_note_alias = tostring(os.date(Obsidian.opts.daily_notes.alias_format or "%A %B %-d, %Y", datetime))
     if offset == 0 then
       daily_note_alias = daily_note_alias .. " @today"
     elseif offset == -1 then
@@ -70,7 +70,7 @@ return function(client, data)
   picker:pick(dailies, {
     prompt_title = "Dailies",
     callback = function(offset)
-      local note = daily.daily(offset, {}, client.opts)
+      local note = daily.daily(offset, {}, Obsidian.opts)
       client:open_note(note)
     end,
   })

--- a/lua/obsidian/commands/init-legacy.lua
+++ b/lua/obsidian/commands/init-legacy.lua
@@ -111,7 +111,7 @@ M.complete_args_search = function(client, _, cmd_line, _)
   local completions = {}
   local query_lower = string.lower(query)
   for note in iter(client:find_notes(query, { search = { sort = true } })) do
-    local note_path = assert(client:vault_relative_path(note.path, { strict = true }))
+    local note_path = assert(note.path:vault_relative_path { strict = true })
     if string.find(string.lower(note:display_name()), query_lower, 1, true) then
       table.insert(completions, note:display_name() .. "  " .. tostring(note_path))
     else

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -194,7 +194,7 @@ M.note_complete = function(client, cmd_arg)
   local completions = {}
   local query_lower = string.lower(query)
   for note in iter(client:find_notes(query, { search = { sort = true } })) do
-    local note_path = assert(client:vault_relative_path(note.path, { strict = true }))
+    local note_path = assert(note.path:vault_relative_path { strict = true })
     if string.find(string.lower(note:display_name()), query_lower, 1, true) then
       table.insert(completions, note:display_name() .. "  " .. tostring(note_path))
     else

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -5,7 +5,7 @@ local RefTypes = require("obsidian.search").RefTypes
 ---@param path? string|obsidian.Path
 local function open_in_app(client, path)
   if not path then
-    return client.opts.open.func("obsidian://open?vault=" .. vim.uri_encode(client:vault_name()))
+    return Obsidian.opts.open.func("obsidian://open?vault=" .. vim.uri_encode(client:vault_name()))
   end
   path = tostring(path)
   local vault_name = client:vault_name()
@@ -20,14 +20,14 @@ local function open_in_app(client, path)
   local encoded_path = vim.uri_encode(path)
 
   local uri
-  if client.opts.open.use_advanced_uri then
+  if Obsidian.opts.open.use_advanced_uri then
     local line = vim.api.nvim_win_get_cursor(0)[1] or 1
     uri = ("obsidian://advanced-uri?vault=%s&filepath=%s&line=%i"):format(encoded_vault, encoded_path, line)
   else
     uri = ("obsidian://open?vault=%s&file=%s"):format(encoded_vault, encoded_path)
   end
 
-  client.opts.open.func(uri)
+  Obsidian.opts.open.func(uri)
 end
 
 ---@param client obsidian.Client

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -4,11 +4,11 @@ local RefTypes = require("obsidian.search").RefTypes
 ---@param client obsidian.Client
 ---@param path? string|obsidian.Path
 local function open_in_app(client, path)
+  local vault_name = vim.fs.basename(tostring(Obsidian.workspace.root))
   if not path then
-    return Obsidian.opts.open.func("obsidian://open?vault=" .. vim.uri_encode(client:vault_name()))
+    return Obsidian.opts.open.func("obsidian://open?vault=" .. vim.uri_encode(vault_name))
   end
   path = tostring(path)
-  local vault_name = client:vault_name()
   local this_os = api.get_os()
 
   -- Normalize path for windows.

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -1,5 +1,6 @@
 local api = require "obsidian.api"
 local RefTypes = require("obsidian.search").RefTypes
+local Path = require "obsidian.path"
 
 ---@param client obsidian.Client
 ---@param path? string|obsidian.Path
@@ -56,7 +57,7 @@ return function(client, data)
   else
     -- Otherwise use the path of the current buffer.
     local bufname = vim.api.nvim_buf_get_name(0)
-    local path = client:vault_relative_path(bufname)
+    local path = Path.new(bufname):vault_relative_path()
     open_in_app(client, path)
   end
 end

--- a/lua/obsidian/commands/paste_img.lua
+++ b/lua/obsidian/commands/paste_img.lua
@@ -4,25 +4,25 @@ local paste_img = require("obsidian.img_paste").paste_img
 ---@param client obsidian.Client
 ---@param data CommandArgs
 return function(client, data)
-  local img_folder = Path.new(client.opts.attachments.img_folder)
+  local img_folder = Path.new(Obsidian.opts.attachments.img_folder)
   if not img_folder:is_absolute() then
-    img_folder = client.dir / client.opts.attachments.img_folder
+    img_folder = Obsidian.dir / Obsidian.opts.attachments.img_folder
   end
 
   ---@type string|?
   local default_name
-  if client.opts.attachments.img_name_func then
-    default_name = client.opts.attachments.img_name_func()
+  if Obsidian.opts.attachments.img_name_func then
+    default_name = Obsidian.opts.attachments.img_name_func()
   end
 
   local path = paste_img {
     fname = data.args,
     default_dir = img_folder,
     default_name = default_name,
-    should_confirm = client.opts.attachments.confirm_img_paste,
+    should_confirm = Obsidian.opts.attachments.confirm_img_paste,
   }
 
   if path ~= nil then
-    vim.api.nvim_put({ client.opts.attachments.img_text_func(client, path) }, "c", true, false)
+    vim.api.nvim_put({ Obsidian.opts.attachments.img_text_func(client, path) }, "c", true, false)
   end
 end

--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -190,8 +190,8 @@ return function(client, data)
     log.info("Dry run: updating frontmatter of '" .. tostring(new_note_path) .. "'")
   end
 
-  local cur_note_rel_path = cur_note_path:vault_relative_path { strict = true }
-  local new_note_rel_path = new_note_path:vault_relative_path { strict = true }
+  local cur_note_rel_path = assert(cur_note_path:vault_relative_path { strict = true })
+  local new_note_rel_path = assert(new_note_path:vault_relative_path { strict = true })
 
   -- Search notes on disk for any references to `cur_note_id`.
   -- We look for the following forms of references:

--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -190,8 +190,8 @@ return function(client, data)
     log.info("Dry run: updating frontmatter of '" .. tostring(new_note_path) .. "'")
   end
 
-  local cur_note_rel_path = tostring(client:vault_relative_path(cur_note_path, { strict = true }))
-  local new_note_rel_path = tostring(client:vault_relative_path(new_note_path, { strict = true }))
+  local cur_note_rel_path = cur_note_path:vault_relative_path { strict = true }
+  local new_note_rel_path = new_note_path:vault_relative_path { strict = true }
 
   -- Search notes on disk for any references to `cur_note_id`.
   -- We look for the following forms of references:

--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -95,7 +95,7 @@ return function(client, data)
   local new_note_path
   if #parts > 1 then
     parts[#parts] = nil
-    new_note_path = client.dir:joinpath(unpack(compat.flatten { parts, new_note_id })):with_suffix ".md"
+    new_note_path = Obsidian.dir:joinpath(unpack(compat.flatten { parts, new_note_id })):with_suffix ".md"
   else
     new_note_path = (dirname / new_note_id):with_suffix ".md"
   end
@@ -286,7 +286,7 @@ return function(client, data)
   end
 
   search.search_async(
-    client.dir,
+    Obsidian.dir,
     reference_forms,
     { fixed_strings = true, max_count_per_file = 1 },
     on_search_match,

--- a/lua/obsidian/commands/template.lua
+++ b/lua/obsidian/commands/template.lua
@@ -18,7 +18,7 @@ return function(client, data)
     templates.insert_template {
       type = "insert_template",
       template_name = name,
-      template_opts = client.opts.templates,
+      template_opts = Obsidian.opts.templates,
       templates_dir = templates_dir,
       location = insert_location,
     }

--- a/lua/obsidian/commands/today.lua
+++ b/lua/obsidian/commands/today.lua
@@ -14,6 +14,6 @@ return function(client, data)
       offset_days = offset
     end
   end
-  local note = require("obsidian.daily").daily(offset_days, {}, Obsidian.opts)
+  local note = require("obsidian.daily").daily(offset_days, {})
   client:open_note(note)
 end

--- a/lua/obsidian/commands/today.lua
+++ b/lua/obsidian/commands/today.lua
@@ -14,6 +14,6 @@ return function(client, data)
       offset_days = offset
     end
   end
-  local note = require("obsidian.daily").daily(offset_days, {}, client.opts)
+  local note = require("obsidian.daily").daily(offset_days, {}, Obsidian.opts)
   client:open_note(note)
 end

--- a/lua/obsidian/commands/toggle_checkbox.lua
+++ b/lua/obsidian/commands/toggle_checkbox.lua
@@ -4,7 +4,7 @@ local toggle_checkbox = require("obsidian.api").toggle_checkbox
 ---@param data CommandArgs
 return function(client, data)
   local start_line, end_line
-  local checkboxes = client.opts.checkbox.order
+  local checkboxes = Obsidian.opts.checkbox.order
   start_line = data.line1
   end_line = data.line2
 

--- a/lua/obsidian/commands/tomorrow.lua
+++ b/lua/obsidian/commands/tomorrow.lua
@@ -1,6 +1,6 @@
 ---@param client obsidian.Client
 ---@param _ CommandArgs
 return function(client, _)
-  local note = require("obsidian.daily").tomorrow(Obsidian.opts)
+  local note = require("obsidian.daily").tomorrow()
   client:open_note(note)
 end

--- a/lua/obsidian/commands/tomorrow.lua
+++ b/lua/obsidian/commands/tomorrow.lua
@@ -1,6 +1,6 @@
 ---@param client obsidian.Client
 ---@param _ CommandArgs
 return function(client, _)
-  local note = require("obsidian.daily").tomorrow(client.opts)
+  local note = require("obsidian.daily").tomorrow(Obsidian.opts)
   client:open_note(note)
 end

--- a/lua/obsidian/commands/workspace.lua
+++ b/lua/obsidian/commands/workspace.lua
@@ -1,6 +1,25 @@
 local log = require "obsidian.log"
 local Workspace = require "obsidian.workspace"
 
+---@param workspace obsidian.Workspace|string The workspace object or the name of an existing workspace.
+---@param opts { lock: boolean|? }|?
+local switch_workspace = function(workspace, opts)
+  opts = opts and opts or {}
+
+  if workspace == Obsidian.workspace.name then
+    log.info("Already in workspace '%s' @ '%s'", workspace, Obsidian.workspace.path)
+    return
+  end
+
+  for _, ws in ipairs(Obsidian.opts.workspaces) do
+    if ws.name == workspace then
+      return Workspace.set(Workspace.new_from_spec(ws), opts)
+    end
+  end
+
+  error(string.format("Workspace '%s' not found", workspace))
+end
+
 ---@param client obsidian.Client
 ---@param data CommandArgs
 return function(client, data)
@@ -25,10 +44,10 @@ return function(client, data)
       prompt_title = "Workspaces",
       callback = function(workspace_str)
         local idx = tonumber(string.match(workspace_str, "%*?%[(%d+)]"))
-        client:switch_workspace(Obsidian.opts.workspaces[idx].name, { lock = true })
+        switch_workspace(Obsidian.opts.workspaces[idx].name, { lock = true })
       end,
     })
   else
-    client:switch_workspace(data.args, { lock = true })
+    switch_workspace(data.args, { lock = true })
   end
 end

--- a/lua/obsidian/commands/workspace.lua
+++ b/lua/obsidian/commands/workspace.lua
@@ -7,14 +7,14 @@ return function(client, data)
   if not data.args or string.len(data.args) == 0 then
     local picker = client:picker()
     if not picker then
-      log.info("Current workspace: '%s' @ '%s'", client.current_workspace.name, client.current_workspace.path)
+      log.info("Current workspace: '%s' @ '%s'", Obsidian.workspace.name, Obsidian.workspace.path)
       return
     end
 
     local options = {}
-    for i, spec in ipairs(client.opts.workspaces) do
+    for i, spec in ipairs(Obsidian.opts.workspaces) do
       local workspace = Workspace.new_from_spec(spec)
-      if workspace == client.current_workspace then
+      if workspace == Obsidian.workspace then
         options[#options + 1] = string.format("*[%d] %s @ '%s'", i, workspace.name, workspace.path)
       else
         options[#options + 1] = string.format("[%d] %s @ '%s'", i, workspace.name, workspace.path)
@@ -25,7 +25,7 @@ return function(client, data)
       prompt_title = "Workspaces",
       callback = function(workspace_str)
         local idx = tonumber(string.match(workspace_str, "%*?%[(%d+)]"))
-        client:switch_workspace(client.opts.workspaces[idx].name, { lock = true })
+        client:switch_workspace(Obsidian.opts.workspaces[idx].name, { lock = true })
       end,
     })
   else

--- a/lua/obsidian/commands/yesterday.lua
+++ b/lua/obsidian/commands/yesterday.lua
@@ -1,6 +1,6 @@
 ---@param client obsidian.Client
 ---@param _ CommandArgs
 return function(client, _)
-  local note = require("obsidian.daily").yesterday(Obsidian.opts)
+  local note = require("obsidian.daily").yesterday()
   client:open_note(note)
 end

--- a/lua/obsidian/commands/yesterday.lua
+++ b/lua/obsidian/commands/yesterday.lua
@@ -1,6 +1,6 @@
 ---@param client obsidian.Client
 ---@param _ CommandArgs
 return function(client, _)
-  local note = require("obsidian.daily").yesterday(client.opts)
+  local note = require("obsidian.daily").yesterday(Obsidian.opts)
   client:open_note(note)
 end

--- a/lua/obsidian/completion/plugin_initializers/blink.lua
+++ b/lua/obsidian/completion/plugin_initializers/blink.lua
@@ -50,8 +50,7 @@ local function should_return_if_not_in_workspace()
   local current_file_path = vim.api.nvim_buf_get_name(0)
   local buf_dir = vim.fs.dirname(current_file_path)
 
-  local obsidian_client = assert(obsidian.get_client())
-  local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, obsidian_client.opts.workspaces)
+  local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, Obsidian.opts.workspaces)
   if not workspace then
     return true
   else

--- a/lua/obsidian/completion/sources/base/new.lua
+++ b/lua/obsidian/completion/sources/base/new.lua
@@ -113,7 +113,7 @@ function NewNoteSourceBase:process_completion(cc)
       note = cc.client:daily(dt_offset.offset, { no_write = true })
       if not note:exists() then
         new_notes_opts[#new_notes_opts + 1] =
-          { label = dt_offset.macro, note = note, template = cc.client.opts.daily_notes.template }
+          { label = dt_offset.macro, note = note, template = cc.Obsidian.opts.daily_notes.template }
       end
     end
   end
@@ -185,7 +185,7 @@ function NewNoteSourceBase:can_complete_request(cc)
     cc.search = util.lstrip_whitespace(cc.search)
   end
 
-  if not (can_complete and cc.search ~= nil and #cc.search >= cc.client.opts.completion.min_chars) then
+  if not (can_complete and cc.search ~= nil and #cc.search >= cc.Obsidian.opts.completion.min_chars) then
     cc.completion_resolve_callback(self.incomplete_response)
     return false
   end

--- a/lua/obsidian/completion/sources/base/new.lua
+++ b/lua/obsidian/completion/sources/base/new.lua
@@ -110,10 +110,10 @@ function NewNoteSourceBase:process_completion(cc)
   -- Check for datetime macros.
   for _, dt_offset in ipairs(util.resolve_date_macro(cc.search)) do
     if dt_offset.cadence == "daily" then
-      note = cc.client:daily(dt_offset.offset, { no_write = true })
+      note = require("obsidian.daily").daily(dt_offset.offset, { no_write = true })
       if not note:exists() then
         new_notes_opts[#new_notes_opts + 1] =
-          { label = dt_offset.macro, note = note, template = cc.Obsidian.opts.daily_notes.template }
+          { label = dt_offset.macro, note = note, template = Obsidian.opts.daily_notes.template }
       end
     end
   end
@@ -185,7 +185,7 @@ function NewNoteSourceBase:can_complete_request(cc)
     cc.search = util.lstrip_whitespace(cc.search)
   end
 
-  if not (can_complete and cc.search ~= nil and #cc.search >= cc.Obsidian.opts.completion.min_chars) then
+  if not (can_complete and cc.search ~= nil and #cc.search >= Obsidian.opts.completion.min_chars) then
     cc.completion_resolve_callback(self.incomplete_response)
     return false
   end

--- a/lua/obsidian/completion/sources/base/refs.lua
+++ b/lua/obsidian/completion/sources/base/refs.lua
@@ -217,7 +217,7 @@ function RefsSourceBase:process_search_results(cc, results)
           alias_case_matched ~= nil
           and alias_case_matched ~= alias
           and not vim.list_contains(note.aliases, alias_case_matched)
-          and cc.Obsidian.opts.completion.match_case
+          and Obsidian.opts.completion.match_case
         then
           self:update_completion_options(cc, alias_case_matched, nil, matching_anchors, matching_blocks, note)
         end

--- a/lua/obsidian/completion/sources/base/refs.lua
+++ b/lua/obsidian/completion/sources/base/refs.lua
@@ -94,7 +94,7 @@ function RefsSourceBase:can_complete_request(cc)
   local can_complete
   can_complete, cc.search, cc.insert_start, cc.insert_end, cc.ref_type = completion.can_complete(cc.request)
 
-  if not (can_complete and cc.search ~= nil and #cc.search >= cc.client.opts.completion.min_chars) then
+  if not (can_complete and cc.search ~= nil and #cc.search >= Obsidian.opts.completion.min_chars) then
     cc.completion_resolve_callback(self.incomplete_response)
     return false
   end
@@ -217,7 +217,7 @@ function RefsSourceBase:process_search_results(cc, results)
           alias_case_matched ~= nil
           and alias_case_matched ~= alias
           and not vim.list_contains(note.aliases, alias_case_matched)
-          and cc.client.opts.completion.match_case
+          and cc.Obsidian.opts.completion.match_case
         then
           self:update_completion_options(cc, alias_case_matched, nil, matching_anchors, matching_blocks, note)
         end

--- a/lua/obsidian/completion/sources/base/tags.lua
+++ b/lua/obsidian/completion/sources/base/tags.lua
@@ -90,7 +90,7 @@ function TagsSourceBase:can_complete_request(cc)
   local can_complete
   can_complete, cc.search, cc.in_frontmatter = completion.can_complete(cc.request)
 
-  if not (can_complete and cc.search ~= nil and #cc.search >= cc.Obsidian.opts.completion.min_chars) then
+  if not (can_complete and cc.search ~= nil and #cc.search >= Obsidian.opts.completion.min_chars) then
     cc.completion_resolve_callback(self.incomplete_response)
     return false
   end

--- a/lua/obsidian/completion/sources/base/tags.lua
+++ b/lua/obsidian/completion/sources/base/tags.lua
@@ -90,7 +90,7 @@ function TagsSourceBase:can_complete_request(cc)
   local can_complete
   can_complete, cc.search, cc.in_frontmatter = completion.can_complete(cc.request)
 
-  if not (can_complete and cc.search ~= nil and #cc.search >= cc.client.opts.completion.min_chars) then
+  if not (can_complete and cc.search ~= nil and #cc.search >= cc.Obsidian.opts.completion.min_chars) then
     cc.completion_resolve_callback(self.incomplete_response)
     return false
   end

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -539,6 +539,8 @@ See: https://github.com/obsidian-nvim/obsidian.nvim/wiki/Keymaps]]
 
   if not util.islist(opts.workspaces) then
     error "Invalid obsidian.nvim config, the 'config.workspaces' should be an array/list."
+  elseif vim.tbl_isempty(opts.workspaces) then
+    error "At least one workspace is required!\nPlease specify a workspace "
   end
 
   for i, workspace in ipairs(opts.workspaces) do

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -281,8 +281,8 @@ config.default = {
   attachments = {
     img_folder = "assets/imgs",
     img_text_func = function(client, path)
-      path = client:vault_relative_path(path) or path
-      return string.format("![%s](%s)", path.name, require("obsidian.util").urlencode(tostring(path)))
+      local encoded_path = require("obsidian.util").urlencode(path:vault_relative_path() or tostring(path))
+      return string.format("![%s](%s)", path.name, encoded_path)
     end,
     img_name_func = function()
       return string.format("Pasted image %s", os.date "%Y%m%d%H%M%S")

--- a/lua/obsidian/daily/init.lua
+++ b/lua/obsidian/daily/init.lua
@@ -11,7 +11,7 @@ local daily_note_path = function(datetime)
   datetime = datetime and datetime or os.time()
 
   ---@type obsidian.Path
-  local path = Path:new(require("obsidian").get_client().dir)
+  local path = Path:new(Obsidian.dir)
 
   local options = Obsidian.opts
 

--- a/lua/obsidian/daily/init.lua
+++ b/lua/obsidian/daily/init.lua
@@ -5,28 +5,29 @@ local util = require "obsidian.util"
 --- Get the path to a daily note.
 ---
 ---@param datetime integer|?
----@param config obsidian.config.ClientOpts
 ---
 ---@return obsidian.Path, string (Path, ID) The path and ID of the note.
-local daily_note_path = function(datetime, config)
+local daily_note_path = function(datetime)
   datetime = datetime and datetime or os.time()
 
   ---@type obsidian.Path
   local path = Path:new(require("obsidian").get_client().dir)
 
-  if config.daily_notes.folder ~= nil then
+  local options = Obsidian.opts
+
+  if options.daily_notes.folder ~= nil then
     ---@type obsidian.Path
     ---@diagnostic disable-next-line: assign-type-mismatch
-    path = path / config.daily_notes.folder
-  elseif config.notes_subdir ~= nil then
+    path = path / options.daily_notes.folder
+  elseif options.notes_subdir ~= nil then
     ---@type obsidian.Path
     ---@diagnostic disable-next-line: assign-type-mismatch
-    path = path / config.notes_subdir
+    path = path / options.notes_subdir
   end
 
   local id
-  if config.daily_notes.date_format ~= nil then
-    id = tostring(os.date(config.daily_notes.date_format, datetime))
+  if options.daily_notes.date_format ~= nil then
+    id = tostring(os.date(options.daily_notes.date_format, datetime))
   else
     id = tostring(os.date("%Y-%m-%d", datetime))
   end
@@ -43,20 +44,21 @@ end
 ---
 ---@param datetime integer
 ---@param opts { no_write: boolean|?, load: obsidian.note.LoadOpts|? }|?
----@param config obsidian.config.ClientOpts
 ---
 ---@return obsidian.Note
 ---
 ---@private
-local _daily = function(datetime, opts, config)
+local _daily = function(datetime, opts)
   opts = opts or {}
 
-  local path, id = daily_note_path(datetime, config)
+  local path, id = daily_note_path(datetime)
+
+  local options = Obsidian.opts
 
   ---@type string|?
   local alias
-  if config.daily_notes.alias_format ~= nil then
-    alias = tostring(os.date(config.daily_notes.alias_format, datetime))
+  if options.daily_notes.alias_format ~= nil then
+    alias = tostring(os.date(options.daily_notes.alias_format, datetime))
   end
 
   ---@type obsidian.Note
@@ -64,7 +66,7 @@ local _daily = function(datetime, opts, config)
   if path:exists() then
     note = Note.from_file(path, opts.load)
   else
-    note = Note.new(id, {}, config.daily_notes.default_tags or {}, path)
+    note = Note.new(id, {}, options.daily_notes.default_tags or {}, path)
 
     if alias then
       note:add_alias(alias)
@@ -72,7 +74,7 @@ local _daily = function(datetime, opts, config)
     end
 
     if not opts.no_write then
-      require("obsidian").get_client():write_note(note, { template = config.daily_notes.template })
+      require("obsidian").get_client():write_note(note, { template = options.daily_notes.template })
     end
   end
 
@@ -81,55 +83,51 @@ end
 
 --- Open (or create) the daily note for today.
 ---
----@param config obsidian.config.ClientOpts
 ---@return obsidian.Note
-local today = function(config)
-  return _daily(os.time(), {}, config)
+local today = function()
+  return _daily(os.time(), {})
 end
 
 --- Open (or create) the daily note from the last day.
 ---
----@param config obsidian.config.ClientOpts
 ---@return obsidian.Note
-local yesterday = function(config)
+local yesterday = function()
   local now = os.time()
   local yesterday
 
-  if config.daily_notes.workdays_only then
+  if Obsidian.opts.daily_notes.workdays_only then
     yesterday = util.working_day_before(now)
   else
     yesterday = util.previous_day(now)
   end
 
-  return _daily(yesterday, {}, config)
+  return _daily(yesterday, {})
 end
 
 --- Open (or create) the daily note for the next day.
 ---
----@param config obsidian.config.ClientOpts
 ---@return obsidian.Note
-local tomorrow = function(config)
+local tomorrow = function()
   local now = os.time()
   local tomorrow
 
-  if config.daily_notes.workdays_only then
+  if Obsidian.opts.daily_notes.workdays_only then
     tomorrow = util.working_day_after(now)
   else
     tomorrow = util.next_day(now)
   end
 
-  return _daily(tomorrow, {}, config)
+  return _daily(tomorrow, {})
 end
 
 --- Open (or create) the daily note for today + `offset_days`.
 ---
 ---@param offset_days integer|?
 ---@param opts { no_write: boolean|?, load: obsidian.note.LoadOpts|? }|?
----@param config obsidian.config.ClientOpts
 ---
 ---@return obsidian.Note
-local daily = function(offset_days, opts, config)
-  return _daily(os.time() + (offset_days * 3600 * 24), opts, config)
+local daily = function(offset_days, opts)
+  return _daily(os.time() + (offset_days * 3600 * 24), opts)
 end
 
 return {

--- a/lua/obsidian/health.lua
+++ b/lua/obsidian/health.lua
@@ -100,7 +100,7 @@ function M.check()
   info("operating system: %s", os)
 
   start "Config"
-  info("dir: %s", require("obsidian").get_client().dir)
+  info("  • dir: %s", Obsidian.dir)
 
   start "Pickers"
 

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -76,8 +76,16 @@ end
 ---@return obsidian.Client
 obsidian.setup = function(opts)
   opts = obsidian.config.normalize(opts)
+
+  ---@class obsidian.state
+  ---@field workspace obsidian.Workspace The current workspace.
+  ---@field dir obsidian.Path The root of the vault for the current workspace.
+  ---@field buf_dir obsidian.Path|? The parent directory of the current buffer.
+  ---@field opts obsidian.config.ClientOpts
+  _G.Obsidian = {} -- init a state table
+
   local client = obsidian.new(opts)
-  log.set_level(client.opts.log_level)
+  log.set_level(Obsidian.opts.log_level)
 
   -- Install commands.
   -- These will be available across all buffers, not just note buffers in the vault.
@@ -120,17 +128,17 @@ obsidian.setup = function(opts)
       -- Set the current directory of the buffer.
       local buf_dir = vim.fs.dirname(ev.match)
       if buf_dir then
-        client.buf_dir = obsidian.Path.new(buf_dir)
+        Obsidian.buf_dir = obsidian.Path.new(buf_dir)
       end
 
       -- Check if we're in *any* workspace.
-      local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, client.opts.workspaces)
+      local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, Obsidian.opts.workspaces)
       if not workspace then
         return
       end
 
       -- Switch to the workspace and complete the workspace setup.
-      if not client.current_workspace.locked and workspace ~= client.current_workspace then
+      if not Obsidian.workspace.locked and workspace ~= Obsidian.workspace then
         log.debug("Switching to workspace '%s' @ '%s'", workspace.name, workspace.path)
         client:set_workspace(workspace)
         require("obsidian.ui").update(ev.buf)
@@ -152,7 +160,7 @@ obsidian.setup = function(opts)
 
       -- Run enter-note callback.
       local note = obsidian.Note.from_buffer(ev.buf)
-      obsidian.util.fire_callback("enter_note", client.opts.callbacks.enter_note, client, note)
+      obsidian.util.fire_callback("enter_note", Obsidian.opts.callbacks.enter_note, client, note)
 
       exec_autocmds("ObsidianNoteEnter", ev.buf)
     end,
@@ -163,7 +171,7 @@ obsidian.setup = function(opts)
     pattern = "*.md",
     callback = function(ev)
       -- Check if we're in *any* workspace.
-      local workspace = obsidian.Workspace.get_workspace_for_dir(vim.fs.dirname(ev.match), client.opts.workspaces)
+      local workspace = obsidian.Workspace.get_workspace_for_dir(vim.fs.dirname(ev.match), Obsidian.opts.workspaces)
       if not workspace then
         return
       end
@@ -175,7 +183,7 @@ obsidian.setup = function(opts)
 
       -- Run leave-note callback.
       local note = obsidian.Note.from_buffer(ev.buf)
-      obsidian.util.fire_callback("leave_note", client.opts.callbacks.leave_note, client, note)
+      obsidian.util.fire_callback("leave_note", Obsidian.opts.callbacks.leave_note, client, note)
 
       exec_autocmds("ObsidianNoteLeave", ev.buf)
     end,
@@ -189,7 +197,7 @@ obsidian.setup = function(opts)
       local buf_dir = vim.fs.dirname(ev.match)
 
       -- Check if we're in a workspace.
-      local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, client.opts.workspaces)
+      local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, Obsidian.opts.workspaces)
       if not workspace then
         return
       end
@@ -204,7 +212,7 @@ obsidian.setup = function(opts)
       local note = obsidian.Note.from_buffer(bufnr)
 
       -- Run pre-write-note callback.
-      obsidian.util.fire_callback("pre_write_note", client.opts.callbacks.pre_write_note, client, note)
+      obsidian.util.fire_callback("pre_write_note", Obsidian.opts.callbacks.pre_write_note, client, note)
 
       exec_autocmds("ObsidianNoteWritePre", ev.buf)
 
@@ -222,7 +230,7 @@ obsidian.setup = function(opts)
       local buf_dir = vim.fs.dirname(ev.match)
 
       -- Check if we're in a workspace.
-      local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, client.opts.workspaces)
+      local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, Obsidian.opts.workspaces)
       if not workspace then
         return
       end
@@ -242,7 +250,7 @@ obsidian.setup = function(opts)
   -- Call post-setup callback.
   -- client.callback_manager:post_setup()
 
-  obsidian.util.fire_callback("post_setup", client.opts.callbacks.post_setup, client)
+  obsidian.util.fire_callback("post_setup", Obsidian.opts.callbacks.post_setup, client)
 
   return client
 end

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -81,7 +81,8 @@ obsidian.setup = function(opts)
   ---@field workspace obsidian.Workspace The current workspace.
   ---@field dir obsidian.Path The root of the vault for the current workspace.
   ---@field buf_dir obsidian.Path|? The parent directory of the current buffer.
-  ---@field opts obsidian.config.ClientOpts
+  ---@field opts obsidian.config.ClientOpts current options
+  ---@field _opts obsidian.config.ClientOpts default options
   _G.Obsidian = {} -- init a state table
 
   local client = obsidian.new(opts)

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -141,7 +141,7 @@ obsidian.setup = function(opts)
       -- Switch to the workspace and complete the workspace setup.
       if not Obsidian.workspace.locked and workspace ~= Obsidian.workspace then
         log.debug("Switching to workspace '%s' @ '%s'", workspace.name, workspace.path)
-        client:set_workspace(workspace)
+        obsidian.Workspace.set(workspace)
         require("obsidian.ui").update(ev.buf)
       end
 
@@ -178,7 +178,7 @@ obsidian.setup = function(opts)
       end
 
       -- Check if current buffer is actually a note within the workspace.
-      if not client:path_is_note(ev.match, workspace) then
+      if not client:path_is_note(ev.match) then
         return
       end
 
@@ -204,7 +204,7 @@ obsidian.setup = function(opts)
       end
 
       -- Check if current buffer is actually a note within the workspace.
-      if not client:path_is_note(ev.match, workspace) then
+      if not client:path_is_note(ev.match) then
         return
       end
 
@@ -237,7 +237,7 @@ obsidian.setup = function(opts)
       end
 
       -- Check if current buffer is actually a note within the workspace.
-      if not client:path_is_note(ev.match, workspace) then
+      if not client:path_is_note(ev.match) then
         return
       end
 

--- a/lua/obsidian/path.lua
+++ b/lua/obsidian/path.lua
@@ -549,4 +549,29 @@ Path.unlink = function(self, opts)
   end
 end
 
+--- Make a path relative to the vault root, if possible, return a string
+---
+---@param opts { strict: boolean|? }|?
+---
+---@return string?
+Path.vault_relative_path = function(self, opts)
+  opts = opts or {}
+
+  -- NOTE: we don't try to resolve the `path` here because that would make the path absolute,
+  -- which may result in the wrong relative path if the current working directory is not within
+  -- the vault.
+
+  local ok, relative_path = pcall(function()
+    return self:relative_to(Obsidian.workspace.root)
+  end)
+
+  if ok and relative_path then
+    return tostring(relative_path)
+  elseif not self:is_absolute() then
+    return tostring(self)
+  elseif opts.strict then
+    error(string.format("failed to resolve '%s' relative to vault root '%s'", self, Obsidian.workspace.root))
+  end
+end
+
 return Path

--- a/lua/obsidian/pickers/_fzf.lua
+++ b/lua/obsidian/pickers/_fzf.lua
@@ -127,7 +127,7 @@ FzfPicker.find_files = function(self, opts)
   opts = opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir and Path.new(opts.dir) or self.client.dir
+  local dir = opts.dir and Path.new(opts.dir) or Obsidian.dir
 
   fzf.files {
     cwd = tostring(dir),
@@ -146,7 +146,7 @@ FzfPicker.grep = function(self, opts)
   opts = opts and opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir and Path:new(opts.dir) or self.client.dir
+  local dir = opts.dir and Path:new(opts.dir) or Obsidian.dir
   local cmd = table.concat(self:_build_grep_cmd(), " ")
   local actions = get_path_actions {
     callback = opts.callback,

--- a/lua/obsidian/pickers/_mini.lua
+++ b/lua/obsidian/pickers/_mini.lua
@@ -24,7 +24,7 @@ MiniPicker.find_files = function(self, opts)
   opts = opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir and Path:new(opts.dir) or self.client.dir
+  local dir = opts.dir and Path:new(opts.dir) or Obsidian.dir
 
   local path = mini_pick.builtin.cli({
     command = self:_build_find_cmd(),
@@ -50,7 +50,7 @@ MiniPicker.grep = function(self, opts)
   opts = opts and opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir and Path:new(opts.dir) or self.client.dir
+  local dir = opts.dir and Path:new(opts.dir) or Obsidian.dir
 
   local pick_opts = {
     source = {

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -44,7 +44,7 @@ SnacksPicker.find_files = function(self, opts)
   opts = opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir.filename and Path:new(opts.dir.filename) or self.client.dir
+  local dir = opts.dir.filename and Path:new(opts.dir.filename) or Obsidian.dir
 
   local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
 
@@ -75,7 +75,7 @@ SnacksPicker.grep = function(self, opts)
   debug_once("grep opts : ", opts)
 
   ---@type obsidian.Path
-  local dir = opts.dir.filename and Path:new(opts.dir.filename) or self.client.dir
+  local dir = opts.dir.filename and Path:new(opts.dir.filename) or Obsidian.dir
 
   local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
 

--- a/lua/obsidian/pickers/_telescope.lua
+++ b/lua/obsidian/pickers/_telescope.lua
@@ -136,7 +136,7 @@ TelescopePicker.find_files = function(self, opts)
 
   telescope.find_files {
     prompt_title = prompt_title,
-    cwd = opts.dir and tostring(opts.dir) or tostring(self.client.dir),
+    cwd = opts.dir and tostring(opts.dir) or tostring(Obsidian.dir),
     find_command = self:_build_find_cmd(),
     attach_mappings = function(_, map)
       attach_picker_mappings(map, {
@@ -154,7 +154,7 @@ end
 TelescopePicker.grep = function(self, opts)
   opts = opts or {}
 
-  local cwd = opts.dir and Path:new(opts.dir) or self.client.dir
+  local cwd = opts.dir and Path:new(opts.dir) or Obsidian.dir
 
   local prompt_title = self:_build_prompt {
     prompt_title = opts.prompt_title,

--- a/lua/obsidian/pickers/init.lua
+++ b/lua/obsidian/pickers/init.lua
@@ -9,7 +9,7 @@ local M = {}
 ---
 ---@return obsidian.Picker|?
 M.get = function(client, picker_name)
-  picker_name = picker_name and picker_name or client.opts.picker.name
+  picker_name = picker_name and picker_name or Obsidian.opts.picker.name
   if picker_name then
     picker_name = string.lower(picker_name)
   else

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -148,7 +148,7 @@ Picker.find_notes = function(self, opts)
 
   return self:find_files {
     prompt_title = opts.prompt_title or "Notes",
-    dir = self.client.dir,
+    dir = Obsidian.dir,
     callback = opts.callback,
     no_default_mappings = opts.no_default_mappings,
     query_mappings = query_mappings,
@@ -205,7 +205,7 @@ Picker.grep_notes = function(self, opts)
 
   self:grep {
     prompt_title = opts.prompt_title or "Grep notes",
-    dir = self.client.dir,
+    dir = Obsidian.dir,
     query = opts.query,
     callback = opts.callback,
     no_default_mappings = opts.no_default_mappings,
@@ -310,8 +310,8 @@ Picker._note_query_mappings = function(self)
   ---@type obsidian.PickerMappingTable
   local mappings = {}
 
-  if self.client.opts.picker.note_mappings and key_is_set(self.client.opts.picker.note_mappings.new) then
-    mappings[self.client.opts.picker.note_mappings.new] = {
+  if Obsidian.opts.picker.note_mappings and key_is_set(Obsidian.opts.picker.note_mappings.new) then
+    mappings[Obsidian.opts.picker.note_mappings.new] = {
       desc = "new",
       callback = function(query)
         ---@diagnostic disable-next-line: missing-fields
@@ -329,8 +329,8 @@ Picker._note_selection_mappings = function(self)
   ---@type obsidian.PickerMappingTable
   local mappings = {}
 
-  if self.client.opts.picker.note_mappings and key_is_set(self.client.opts.picker.note_mappings.insert_link) then
-    mappings[self.client.opts.picker.note_mappings.insert_link] = {
+  if Obsidian.opts.picker.note_mappings and key_is_set(Obsidian.opts.picker.note_mappings.insert_link) then
+    mappings[Obsidian.opts.picker.note_mappings.insert_link] = {
       desc = "insert link",
       callback = function(note_or_path)
         ---@type obsidian.Note
@@ -356,9 +356,9 @@ Picker._tag_selection_mappings = function(self)
   ---@type obsidian.PickerMappingTable
   local mappings = {}
 
-  if self.client.opts.picker.tag_mappings then
-    if key_is_set(self.client.opts.picker.tag_mappings.tag_note) then
-      mappings[self.client.opts.picker.tag_mappings.tag_note] = {
+  if Obsidian.opts.picker.tag_mappings then
+    if key_is_set(Obsidian.opts.picker.tag_mappings.tag_note) then
+      mappings[Obsidian.opts.picker.tag_mappings.tag_note] = {
         desc = "tag note",
         callback = function(...)
           local tags = { ... }
@@ -398,8 +398,8 @@ Picker._tag_selection_mappings = function(self)
       }
     end
 
-    if key_is_set(self.client.opts.picker.tag_mappings.insert_tag) then
-      mappings[self.client.opts.picker.tag_mappings.insert_tag] = {
+    if key_is_set(Obsidian.opts.picker.tag_mappings.insert_tag) then
+      mappings[Obsidian.opts.picker.tag_mappings.insert_tag] = {
         desc = "insert tag",
         callback = function(tag)
           vim.api.nvim_put({ "#" .. tag }, "", false, true)
@@ -504,15 +504,15 @@ end
 ---@return string[]
 Picker._build_find_cmd = function(self)
   local search = require "obsidian.search"
-  local search_opts = { sort_by = self.client.opts.sort_by, sort_reversed = self.client.opts.sort_reversed }
+  local search_opts = { sort_by = Obsidian.opts.sort_by, sort_reversed = Obsidian.opts.sort_reversed }
   return search.build_find_cmd(".", nil, search_opts)
 end
 
 Picker._build_grep_cmd = function(self)
   local search = require "obsidian.search"
   local search_opts = {
-    sort_by = self.client.opts.sort_by,
-    sort_reversed = self.client.opts.sort_reversed,
+    sort_by = Obsidian.opts.sort_by,
+    sort_reversed = Obsidian.opts.sort_reversed,
     smart_case = true,
     fixed_strings = true,
   }

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -3,6 +3,7 @@ local log = require "obsidian.log"
 local api = require "obsidian.api"
 local strings = require "plenary.strings"
 local Note = require "obsidian.note"
+local Path = require "obsidian.path"
 
 ---@class obsidian.Picker : obsidian.ABC
 ---
@@ -241,7 +242,7 @@ Picker.pick_note = function(self, notes, opts)
   local entries = {}
   for _, note in ipairs(notes) do
     assert(note.path)
-    local rel_path = tostring(assert(self.client:vault_relative_path(note.path, { strict = true })))
+    local rel_path = assert(note.path:vault_relative_path { strict = true })
     local display_name = note:display_name()
     entries[#entries + 1] = {
       value = note,
@@ -473,7 +474,7 @@ Picker._make_display = function(self, entry)
       end
     end
 
-    display = display .. tostring(self.client:vault_relative_path(entry.filename, { strict = true }))
+    display = display .. Path.new(entry.filename):vault_relative_path { strict = true }
 
     if entry.lnum ~= nil then
       display = display .. ":" .. entry.lnum

--- a/lua/obsidian/statusline/init.lua
+++ b/lua/obsidian/statusline/init.lua
@@ -18,7 +18,7 @@ M.start = function(client)
     client:find_backlinks_async(
       note,
       vim.schedule_wrap(function(backlinks)
-        local format = assert(client.opts.statusline.format)
+        local format = assert(Obsidian.opts.statusline.format)
         local wc = vim.fn.wordcount()
         local info = {
           words = wc.words,

--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -597,7 +597,7 @@ end
 ---@param bufnr integer|?
 M.update = function(bufnr)
   bufnr = bufnr or 0
-  local ui_opts = require("obsidian").get_client().opts.ui
+  local ui_opts = Obsidian.opts.ui
   if not should_update(ui_opts, bufnr) then
     return
   end

--- a/lua/obsidian/workspace.lua
+++ b/lua/obsidian/workspace.lua
@@ -117,27 +117,6 @@ Workspace.new_from_spec = function(spec)
   })
 end
 
---- Initialize a 'Workspace' object from the current working directory.
----
----@param opts obsidian.workspace.WorkspaceOpts|?
----
----@return obsidian.Workspace
-Workspace.new_from_cwd = function(opts)
-  local cwd = assert(vim.fn.getcwd())
-  return Workspace.new(cwd, opts)
-end
-
---- Initialize a 'Workspace' object from the parent directory of the current buffer.
----
----@param bufnr integer|?
----@param opts obsidian.workspace.WorkspaceOpts|?
----
----@return obsidian.Workspace
-Workspace.new_from_buf = function(bufnr, opts)
-  local bufdir = Path.buf_dir(bufnr)
-  return Workspace.new(bufdir, opts)
-end
-
 --- Lock the workspace.
 Workspace.lock = function(self)
   self.locked = true

--- a/lua/obsidian/workspace.lua
+++ b/lua/obsidian/workspace.lua
@@ -1,5 +1,8 @@
 local Path = require "obsidian.path"
 local abc = require "obsidian.abc"
+local api = require "obsidian.api"
+local util = require "obsidian.util"
+local config = require "obsidian.config"
 
 ---@class obsidian.workspace.WorkspaceSpec
 ---
@@ -189,6 +192,62 @@ Workspace.get_from_opts = function(opts)
   end
 
   return current_workspace
+end
+
+--- Get the normalize opts for a given workspace.
+---
+---@param workspace obsidian.Workspace|?
+---
+---@return obsidian.config.ClientOpts
+Workspace.normalize_opts = function(workspace)
+  if workspace then
+    return config.normalize(workspace.overrides and workspace.overrides or {}, Obsidian._opts)
+  else
+    return Obsidian.opts
+  end
+end
+
+---@param workspace obsidian.Workspace
+---@param opts { lock: boolean|? }|?
+Workspace.set = function(workspace, opts)
+  opts = opts and opts or {}
+
+  local dir = workspace.root
+  local options = Workspace.normalize_opts(workspace) -- TODO: test
+
+  Obsidian.workspace = workspace
+  Obsidian.dir = dir
+  Obsidian.opts = options
+
+  -- Ensure directories exist.
+  dir:mkdir { parents = true, exists_ok = true }
+
+  if options.notes_subdir ~= nil then
+    local notes_subdir = dir / Obsidian.opts.notes_subdir
+    notes_subdir:mkdir { parents = true, exists_ok = true }
+  end
+
+  if Obsidian.opts.daily_notes.folder ~= nil then
+    local daily_notes_subdir = Obsidian.dir / Obsidian.opts.daily_notes.folder
+    daily_notes_subdir:mkdir { parents = true, exists_ok = true }
+  end
+
+  -- Setup UI add-ons.
+  local has_no_renderer = not (api.get_plugin_info "render-markdown.nvim" or api.get_plugin_info "markview.nvim")
+  if has_no_renderer and Obsidian.opts.ui.enable then
+    require("obsidian.ui").setup(Obsidian.workspace, Obsidian.opts.ui)
+  end
+
+  if opts.lock then
+    Obsidian.workspace:lock()
+  end
+
+  util.fire_callback("post_set_workspace", Obsidian.opts.callbacks.post_set_workspace, workspace)
+
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "ObsidianWorkpspaceSet",
+    data = { workspace = workspace },
+  })
 end
 
 return Workspace

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -18,7 +18,7 @@ M.with_tmp_client = function(f, dir, opts)
   local client = obsidian.new_from_dir(tostring(dir))
 
   if opts then
-    client.opts = vim.deepcopy(opts)
+    Obsidian.opts = vim.deepcopy(opts)
   end
   local ok, err = pcall(f, client)
 

--- a/tests/test_client.lua
+++ b/tests/test_client.lua
@@ -18,7 +18,7 @@ local client_opts = {
 describe("Client:new_note_path()", function()
   it('should only append one ".md" at the end of the path', function()
     h.with_tmp_client(function(client)
-      client.opts.note_path_func = function(spec)
+      Obsidian.opts.note_path_func = function(spec)
         return (spec.dir / "foo-bar-123"):with_suffix ".md.md.md"
       end
 
@@ -109,7 +109,7 @@ describe("Client:parse_title_id_path()", function()
 
   it("should respect configured 'note_path_func'", function()
     h.with_tmp_client(function(client)
-      client.opts.note_path_func = function(spec)
+      Obsidian.opts.note_path_func = function(spec)
         return (spec.dir / "foo-bar-123"):with_suffix ".md"
       end
 
@@ -122,7 +122,7 @@ describe("Client:parse_title_id_path()", function()
 
   it("should ensure result of 'note_path_func' always has '.md' suffix", function()
     h.with_tmp_client(function(client)
-      client.opts.note_path_func = function(spec)
+      Obsidian.opts.note_path_func = function(spec)
         return spec.dir / "foo-bar-123"
       end
 
@@ -135,7 +135,7 @@ describe("Client:parse_title_id_path()", function()
 
   it("should ensure result of 'note_path_func' is always an absolute path and within provided directory", function()
     h.with_tmp_client(function(client)
-      client.opts.note_path_func = function(_)
+      Obsidian.opts.note_path_func = function(_)
         return "foo-bar-123.md"
       end
 

--- a/tests/test_client.lua
+++ b/tests/test_client.lua
@@ -1,6 +1,8 @@
 local Path = require "obsidian.path"
 local h = dofile "tests/helpers.lua"
 
+Obsidian = {}
+
 local client_opts = {
   note_id_func = function(title)
     local id = ""
@@ -35,12 +37,12 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path "notes/Foo"
       MiniTest.expect.equality("Foo", title)
       MiniTest.expect.equality("foo", id)
-      MiniTest.expect.equality(Path:new(client.dir) / "notes" / "foo.md", path)
+      MiniTest.expect.equality(Path:new(Obsidian.dir) / "notes" / "foo.md", path)
 
       title, id, path = client:parse_title_id_path "notes/New Title"
       MiniTest.expect.equality("New Title", title)
       MiniTest.expect.equality("new-title", id)
-      MiniTest.expect.equality(Path:new(client.dir) / "notes" / "new-title.md", path)
+      MiniTest.expect.equality(Path:new(Obsidian.dir) / "notes" / "new-title.md", path)
     end, nil, client_opts)
   end)
 
@@ -49,7 +51,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path("Foo", nil, "new-notes")
       MiniTest.expect.equality(title, "Foo")
       MiniTest.expect.equality(id, "foo")
-      MiniTest.expect.equality(path, Path:new(client.dir) / "new-notes" / "foo.md")
+      MiniTest.expect.equality(path, Path:new(Obsidian.dir) / "new-notes" / "foo.md")
     end, nil, client_opts)
   end)
 
@@ -58,7 +60,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path("Foo", "notes/1234-foo")
       MiniTest.expect.equality(title, "Foo")
       MiniTest.expect.equality(id, "1234-foo")
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(client.dir) / "notes" / "1234-foo.md"))
+      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "1234-foo.md"))
     end, nil, client_opts)
   end)
 
@@ -67,7 +69,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path "notes/foo.md"
       MiniTest.expect.equality(title, "foo")
       MiniTest.expect.equality(id, "foo")
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(client.dir) / "notes" / "foo.md"))
+      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "foo.md"))
     end)
   end)
 
@@ -76,7 +78,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path "notes/Foo  "
       MiniTest.expect.equality(title, "Foo")
       MiniTest.expect.equality(id, "foo")
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(client.dir) / "notes" / "foo.md"))
+      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "foo.md"))
     end, nil, client_opts)
   end)
 
@@ -85,7 +87,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path "notes/Foo Bar.md"
       MiniTest.expect.equality(title, "Foo Bar")
       MiniTest.expect.equality(id, "Foo Bar")
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(client.dir) / "notes" / "Foo Bar.md"))
+      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "Foo Bar.md"))
     end)
   end, nil, client_opts)
 
@@ -94,7 +96,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path("Title", "johnny.decimal", "notes")
       MiniTest.expect.equality(title, "Title")
       MiniTest.expect.equality(id, "johnny.decimal")
-      MiniTest.expect.equality(tostring(Path.new(client.dir) / "notes" / "johnny.decimal.md"), tostring(path))
+      MiniTest.expect.equality(tostring(Path.new(Obsidian.dir) / "notes" / "johnny.decimal.md"), tostring(path))
     end)
   end)
 
@@ -103,7 +105,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path "notes/"
       MiniTest.expect.equality(title, nil)
       MiniTest.expect.equality(#id, 4)
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(client.dir) / "notes" / (id .. ".md")))
+      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / (id .. ".md")))
     end, nil, client_opts)
   end)
 
@@ -116,7 +118,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path "New Note"
       MiniTest.expect.equality("New Note", title)
       MiniTest.expect.equality("new-note", id)
-      MiniTest.expect.equality(Path:new(client.dir) / "foo-bar-123.md", path)
+      MiniTest.expect.equality(Path:new(Obsidian.dir) / "foo-bar-123.md", path)
     end, nil, client_opts)
   end)
 
@@ -129,7 +131,7 @@ describe("Client:parse_title_id_path()", function()
       local title, id, path = client:parse_title_id_path "New Note"
       MiniTest.expect.equality("New Note", title)
       MiniTest.expect.equality("new-note", id)
-      MiniTest.expect.equality(Path:new(client.dir) / "foo-bar-123.md", path)
+      MiniTest.expect.equality(Path:new(Obsidian.dir) / "foo-bar-123.md", path)
     end, nil, client_opts)
   end)
 
@@ -139,12 +141,12 @@ describe("Client:parse_title_id_path()", function()
         return "foo-bar-123.md"
       end
 
-      (client.dir / "notes"):mkdir { exist_ok = true }
+      (Obsidian.dir / "notes"):mkdir { exist_ok = true }
 
-      local title, id, path = client:parse_title_id_path("New Note", nil, client.dir / "notes")
+      local title, id, path = client:parse_title_id_path("New Note", nil, Obsidian.dir / "notes")
       MiniTest.expect.equality("New Note", title)
       MiniTest.expect.equality("new-note", id)
-      MiniTest.expect.equality(Path:new(client.dir) / "notes" / "foo-bar-123.md", path)
+      MiniTest.expect.equality(Path:new(Obsidian.dir) / "notes" / "foo-bar-123.md", path)
     end, nil, client_opts)
   end)
 end)
@@ -166,7 +168,7 @@ describe("Client:vault_relative_path()", function()
   it("should resolve relative paths", function()
     h.with_tmp_client(function(client)
       MiniTest.expect.equality(client:vault_relative_path "foo.md", Path.new "foo.md")
-      MiniTest.expect.equality(client:vault_relative_path(client.dir / "foo.md"), Path.new "foo.md")
+      MiniTest.expect.equality(client:vault_relative_path(Obsidian.dir / "foo.md"), Path.new "foo.md")
     end)
   end)
 
@@ -192,7 +194,7 @@ describe("Client:create_note()", function()
       MiniTest.expect.equality(note.title, "Foo")
       MiniTest.expect.equality(note.aliases, { "Bar", "Foo" })
       MiniTest.expect.equality(note.tags, { "note" })
-      MiniTest.expect.equality(note.path, client.dir / "foo.md")
+      MiniTest.expect.equality(note.path, Obsidian.dir / "foo.md")
     end, nil, client_opts)
   end)
 end)

--- a/tests/test_client.lua
+++ b/tests/test_client.lua
@@ -1,7 +1,8 @@
 local Path = require "obsidian.path"
 local h = dofile "tests/helpers.lua"
 
-Obsidian = {}
+---@diagnostic disable-next-line: missing-fields
+_G.Obsidian = {}
 
 local client_opts = {
   note_id_func = function(title)

--- a/tests/test_client.lua
+++ b/tests/test_client.lua
@@ -1,5 +1,6 @@
 local Path = require "obsidian.path"
 local h = dofile "tests/helpers.lua"
+local eq = MiniTest.expect.equality
 
 ---@diagnostic disable-next-line: missing-fields
 _G.Obsidian = {}
@@ -18,95 +19,81 @@ local client_opts = {
   end,
 }
 
-describe("Client:new_note_path()", function()
-  it('should only append one ".md" at the end of the path', function()
-    h.with_tmp_client(function(client)
-      Obsidian.opts.note_path_func = function(spec)
-        return (spec.dir / "foo-bar-123"):with_suffix ".md.md.md"
-      end
-
-      -- Okay to set `id` and `dir` to default values because `note_path_func` is set
-      local path = client:new_note_path { id = "", dir = Path:new() }
-      MiniTest.expect.equality(Path:new() / "foo-bar-123.md", path)
-    end)
-  end)
-end)
-
 describe("Client:parse_title_id_path()", function()
   it("should parse a title that's a partial path and generate new ID", function()
     h.with_tmp_client(function(client)
       local title, id, path = client:parse_title_id_path "notes/Foo"
-      MiniTest.expect.equality("Foo", title)
-      MiniTest.expect.equality("foo", id)
-      MiniTest.expect.equality(Path:new(Obsidian.dir) / "notes" / "foo.md", path)
+      eq("Foo", title)
+      eq("foo", id)
+      eq(Path:new(Obsidian.dir) / "notes" / "foo.md", path)
 
       title, id, path = client:parse_title_id_path "notes/New Title"
-      MiniTest.expect.equality("New Title", title)
-      MiniTest.expect.equality("new-title", id)
-      MiniTest.expect.equality(Path:new(Obsidian.dir) / "notes" / "new-title.md", path)
+      eq("New Title", title)
+      eq("new-title", id)
+      eq(Path:new(Obsidian.dir) / "notes" / "new-title.md", path)
     end, nil, client_opts)
   end)
 
   it("should interpret relative directories relative to vault root.", function()
     h.with_tmp_client(function(client)
       local title, id, path = client:parse_title_id_path("Foo", nil, "new-notes")
-      MiniTest.expect.equality(title, "Foo")
-      MiniTest.expect.equality(id, "foo")
-      MiniTest.expect.equality(path, Path:new(Obsidian.dir) / "new-notes" / "foo.md")
+      eq(title, "Foo")
+      eq(id, "foo")
+      eq(path, Path:new(Obsidian.dir) / "new-notes" / "foo.md")
     end, nil, client_opts)
   end)
 
   it("should parse an ID that's a path", function()
     h.with_tmp_client(function(client)
       local title, id, path = client:parse_title_id_path("Foo", "notes/1234-foo")
-      MiniTest.expect.equality(title, "Foo")
-      MiniTest.expect.equality(id, "1234-foo")
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "1234-foo.md"))
+      eq(title, "Foo")
+      eq(id, "1234-foo")
+      eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "1234-foo.md"))
     end, nil, client_opts)
   end)
 
   it("should parse a title that's an exact path", function()
     h.with_tmp_client(function(client)
       local title, id, path = client:parse_title_id_path "notes/foo.md"
-      MiniTest.expect.equality(title, "foo")
-      MiniTest.expect.equality(id, "foo")
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "foo.md"))
+      eq(title, "foo")
+      eq(id, "foo")
+      eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "foo.md"))
     end)
   end)
 
   it("should ignore boundary whitespace when parsing a title", function()
     h.with_tmp_client(function(client)
       local title, id, path = client:parse_title_id_path "notes/Foo  "
-      MiniTest.expect.equality(title, "Foo")
-      MiniTest.expect.equality(id, "foo")
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "foo.md"))
+      eq(title, "Foo")
+      eq(id, "foo")
+      eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "foo.md"))
     end, nil, client_opts)
   end)
 
   it("should keep whitespace within a path when parsing a title", function()
     h.with_tmp_client(function(client)
       local title, id, path = client:parse_title_id_path "notes/Foo Bar.md"
-      MiniTest.expect.equality(title, "Foo Bar")
-      MiniTest.expect.equality(id, "Foo Bar")
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "Foo Bar.md"))
+      eq(title, "Foo Bar")
+      eq(id, "Foo Bar")
+      eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "Foo Bar.md"))
     end)
   end, nil, client_opts)
 
   it("should keep allow decimals in ID", function()
     h.with_tmp_client(function(client)
       local title, id, path = client:parse_title_id_path("Title", "johnny.decimal", "notes")
-      MiniTest.expect.equality(title, "Title")
-      MiniTest.expect.equality(id, "johnny.decimal")
-      MiniTest.expect.equality(tostring(Path.new(Obsidian.dir) / "notes" / "johnny.decimal.md"), tostring(path))
+      eq(title, "Title")
+      eq(id, "johnny.decimal")
+      eq(tostring(Path.new(Obsidian.dir) / "notes" / "johnny.decimal.md"), tostring(path))
     end)
   end)
 
   it("should generate a new id when the title is just a folder", function()
     h.with_tmp_client(function(client)
       local title, id, path = client:parse_title_id_path "notes/"
-      MiniTest.expect.equality(title, nil)
-      MiniTest.expect.equality(#id, 4)
-      MiniTest.expect.equality(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / (id .. ".md")))
+      eq(title, nil)
+      eq(#id, 4)
+      eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / (id .. ".md")))
     end, nil, client_opts)
   end)
 
@@ -117,9 +104,9 @@ describe("Client:parse_title_id_path()", function()
       end
 
       local title, id, path = client:parse_title_id_path "New Note"
-      MiniTest.expect.equality("New Note", title)
-      MiniTest.expect.equality("new-note", id)
-      MiniTest.expect.equality(Path:new(Obsidian.dir) / "foo-bar-123.md", path)
+      eq("New Note", title)
+      eq("new-note", id)
+      eq(Path:new(Obsidian.dir) / "foo-bar-123.md", path)
     end, nil, client_opts)
   end)
 
@@ -130,9 +117,9 @@ describe("Client:parse_title_id_path()", function()
       end
 
       local title, id, path = client:parse_title_id_path "New Note"
-      MiniTest.expect.equality("New Note", title)
-      MiniTest.expect.equality("new-note", id)
-      MiniTest.expect.equality(Path:new(Obsidian.dir) / "foo-bar-123.md", path)
+      eq("New Note", title)
+      eq("new-note", id)
+      eq(Path:new(Obsidian.dir) / "foo-bar-123.md", path)
     end, nil, client_opts)
   end)
 
@@ -145,9 +132,9 @@ describe("Client:parse_title_id_path()", function()
       (Obsidian.dir / "notes"):mkdir { exist_ok = true }
 
       local title, id, path = client:parse_title_id_path("New Note", nil, Obsidian.dir / "notes")
-      MiniTest.expect.equality("New Note", title)
-      MiniTest.expect.equality("new-note", id)
-      MiniTest.expect.equality(Path:new(Obsidian.dir) / "notes" / "foo-bar-123.md", path)
+      eq("New Note", title)
+      eq("new-note", id)
+      eq(Path:new(Obsidian.dir) / "notes" / "foo-bar-123.md", path)
     end, nil, client_opts)
   end)
 end)
@@ -157,33 +144,7 @@ describe("Client:_prepare_search_opts()", function()
     h.with_tmp_client(function(client)
       ---@diagnostic disable-next-line: invisible
       local opts = client:_prepare_search_opts(true, { max_count_per_file = 1 })
-      MiniTest.expect.equality(
-        require("obsidian.search").SearchOpts.to_ripgrep_opts(opts),
-        { "--sortr=modified", "-m=1" }
-      )
-    end)
-  end)
-end)
-
-describe("Client:vault_relative_path()", function()
-  it("should resolve relative paths", function()
-    h.with_tmp_client(function(client)
-      MiniTest.expect.equality(client:vault_relative_path "foo.md", Path.new "foo.md")
-      MiniTest.expect.equality(client:vault_relative_path(Obsidian.dir / "foo.md"), Path.new "foo.md")
-    end)
-  end)
-
-  it("should error when strict=true and the relative path can't be resolved", function()
-    h.with_tmp_client(function(client)
-      MiniTest.expect.error(function()
-        client:vault_relative_path("/Users/petew/foo.md", { strict = true })
-      end)
-    end)
-  end)
-
-  it("should not error when strict=false and the relative path can't be resolved", function()
-    h.with_tmp_client(function(client)
-      MiniTest.expect.equality(nil, client:vault_relative_path "/Users/petew/foo.md")
+      eq(require("obsidian.search").SearchOpts.to_ripgrep_opts(opts), { "--sortr=modified", "-m=1" })
     end)
   end)
 end)
@@ -192,10 +153,10 @@ describe("Client:create_note()", function()
   it("should create a new note with or without aliases and tags", function()
     h.with_tmp_client(function(client)
       local note = client:create_note { title = "Foo", aliases = { "Bar" }, tags = { "note" } }
-      MiniTest.expect.equality(note.title, "Foo")
-      MiniTest.expect.equality(note.aliases, { "Bar", "Foo" })
-      MiniTest.expect.equality(note.tags, { "note" })
-      MiniTest.expect.equality(note.path, Obsidian.dir / "foo.md")
+      eq(note.title, "Foo")
+      eq(note.aliases, { "Bar", "Foo" })
+      eq(note.tags, { "note" })
+      eq(note.path, Obsidian.dir / "foo.md")
     end, nil, client_opts)
   end)
 end)

--- a/tests/test_client_mini.lua
+++ b/tests/test_client_mini.lua
@@ -1,6 +1,8 @@
 local h = dofile "tests/helpers.lua"
+local Path = require "obsidian.path"
 
-local new_set, eq = MiniTest.new_set, MiniTest.expect.equality
+local new_set, expect = MiniTest.new_set, MiniTest.expect
+local eq, has_error = expect.equality, expect.error
 
 local fixtures = vim.fs.joinpath(vim.uv.cwd(), "tests", "fixtures", "notes")
 
@@ -18,6 +20,20 @@ T["Client:apply_async_raw"] = function()
       end,
     })
   end, fixtures)
+end
+
+T["new_note_path"] = new_set()
+
+T["new_note_path"]['should only append one ".md" at the end of the path'] = function()
+  h.with_tmp_client(function(client)
+    Obsidian.opts.note_path_func = function(spec)
+      return (spec.dir / "foo-bar-123"):with_suffix ".md.md.md"
+    end
+
+    -- Okay to set `id` and `dir` to default values because `note_path_func` is set
+    local path = client:new_note_path { id = "", dir = Path:new() }
+    eq(Path:new() / "foo-bar-123.md", path)
+  end)
 end
 
 return T

--- a/tests/test_client_mini.lua
+++ b/tests/test_client_mini.lua
@@ -2,7 +2,7 @@ local h = dofile "tests/helpers.lua"
 local Path = require "obsidian.path"
 
 local new_set, expect = MiniTest.new_set, MiniTest.expect
-local eq, has_error = expect.equality, expect.error
+local eq = expect.equality
 
 local fixtures = vim.fs.joinpath(vim.uv.cwd(), "tests", "fixtures", "notes")
 

--- a/tests/test_daily.lua
+++ b/tests/test_daily.lua
@@ -24,7 +24,7 @@ local T = new_set {
 T["daily_note_path"] = new_set()
 
 T["daily_note_path"]["should use the path stem as the ID"] = function()
-  _G.client.opts.daily_notes.date_format = "%Y/%b/%Y-%m-%d"
+  _G.Obsidian.opts.daily_notes.date_format = "%Y/%b/%Y-%m-%d"
   local path, id = M.daily_note_path(nil, _G.client.opts)
   assert(vim.endswith(tostring(path), tostring(os.date("%Y/%b/%Y-%m-%d.md", os.time()))))
   eq(id, os.date("%Y-%m-%d", os.time()))
@@ -38,7 +38,7 @@ end
 
 T["daily_note_path"]["should not add frontmatter for today when disabled"] = function()
   h.with_tmp_client(function(client)
-    _G.client.opts.disable_frontmatter = true
+    _G.Obsidian.opts.disable_frontmatter = true
     local new_note = M.today(_G.client.opts)
 
     local saved_note = Note.from_file(new_note.path)
@@ -47,7 +47,7 @@ T["daily_note_path"]["should not add frontmatter for today when disabled"] = fun
 end
 
 T["daily_note_path"]["should not add frontmatter for yesterday when disabled"] = function()
-  _G.client.opts.disable_frontmatter = true
+  _G.Obsidian.opts.disable_frontmatter = true
   local new_note = M.yesterday(_G.client.opts)
   local saved_note = Note.from_file(new_note.path)
   eq(false, saved_note.has_frontmatter)

--- a/tests/test_daily.lua
+++ b/tests/test_daily.lua
@@ -9,14 +9,14 @@ local T = new_set {
     pre_case = function()
       local dir = Path.temp { suffix = "-obsidian" }
       dir:mkdir { parents = true }
-      _G.client = require("obsidian").setup {
+      require("obsidian").setup {
         workspaces = { {
           path = tostring(dir),
         } },
       }
     end,
     post_case = function()
-      vim.fn.delete(tostring(_G.client.dir), "rf")
+      vim.fn.delete(tostring(Obsidian.dir), "rf")
     end,
   },
 }
@@ -24,22 +24,22 @@ local T = new_set {
 T["daily_note_path"] = new_set()
 
 T["daily_note_path"]["should use the path stem as the ID"] = function()
-  _G.Obsidian.opts.daily_notes.date_format = "%Y/%b/%Y-%m-%d"
-  local path, id = M.daily_note_path(nil, _G.client.opts)
+  Obsidian.opts.daily_notes.date_format = "%Y/%b/%Y-%m-%d"
+  local path, id = M.daily_note_path(nil)
   assert(vim.endswith(tostring(path), tostring(os.date("%Y/%b/%Y-%m-%d.md", os.time()))))
   eq(id, os.date("%Y-%m-%d", os.time()))
 end
 
 T["daily_note_path"]["should be able to initialize a daily note"] = function()
-  local note = M.today(_G.client.opts)
+  local note = M.today()
   eq(true, note.path ~= nil)
   eq(true, note:exists())
 end
 
 T["daily_note_path"]["should not add frontmatter for today when disabled"] = function()
   h.with_tmp_client(function(client)
-    _G.Obsidian.opts.disable_frontmatter = true
-    local new_note = M.today(_G.client.opts)
+    Obsidian.opts.disable_frontmatter = true
+    local new_note = M.today()
 
     local saved_note = Note.from_file(new_note.path)
     eq(false, saved_note.has_frontmatter)
@@ -47,8 +47,8 @@ T["daily_note_path"]["should not add frontmatter for today when disabled"] = fun
 end
 
 T["daily_note_path"]["should not add frontmatter for yesterday when disabled"] = function()
-  _G.Obsidian.opts.disable_frontmatter = true
-  local new_note = M.yesterday(_G.client.opts)
+  Obsidian.opts.disable_frontmatter = true
+  local new_note = M.yesterday()
   local saved_note = Note.from_file(new_note.path)
   eq(false, saved_note.has_frontmatter)
 end

--- a/tests/test_path.lua
+++ b/tests/test_path.lua
@@ -1,5 +1,6 @@
 local Path = require "obsidian.path"
 local api = require "obsidian.api"
+local h = dofile "tests/helpers.lua"
 
 local new_set, eq, has_error = MiniTest.new_set, MiniTest.expect.equality, MiniTest.expect.error
 
@@ -310,6 +311,29 @@ T["mkdir"]["should rename a directory"] = function()
 
   target:rmdir()
   eq(false, target:exists())
+end
+
+T["vault_relative_path"] = new_set()
+
+T["vault_relative_path"]["should resolve relative paths"] = function()
+  h.with_tmp_client(function(client)
+    eq(Path.new("foo.md"):vault_relative_path(), "foo.md")
+    eq(Path.new(Obsidian.dir / "foo.md"):vault_relative_path(), "foo.md")
+  end)
+end
+
+T["vault_relative_path"]["should error when strict=true and the relative path can't be resolved"] = function()
+  h.with_tmp_client(function(client)
+    has_error(function()
+      Path.new("/Users/petew/foo.md"):vault_relative_path { strict = true }
+    end)
+  end)
+end
+
+T["vault_relative_path"]["should not error when strict=false and the relative path can't be resolved"] = function()
+  h.with_tmp_client(function(client)
+    eq(nil, Path.new("/Users/petew/foo.md"):vault_relative_path())
+  end)
 end
 
 return T

--- a/tests/test_templates.lua
+++ b/tests/test_templates.lua
@@ -15,7 +15,7 @@ local tmp_template_context = function(client, ctx)
   return vim.tbl_extend("keep", ctx or {}, {
     type = "insert_template",
     templates_dir = client:templates_dir(),
-    template_opts = client.opts.templates,
+    template_opts = Obsidian.opts.templates,
     partial_note = Note.new("FOO", { "FOO" }, {}),
   })
 end
@@ -34,7 +34,7 @@ end
 
 T["substitute_template_variables()"]["should substitute custom variables"] = function()
   h.with_tmp_client(function(client)
-    client.opts.templates.substitutions = {
+    Obsidian.opts.templates.substitutions = {
       weekday = function()
         return "Monday"
       end,
@@ -42,14 +42,14 @@ T["substitute_template_variables()"]["should substitute custom variables"] = fun
     local text = "today is {{weekday}}"
     eq("today is Monday", M.substitute_template_variables(text, tmp_template_context(client)))
 
-    eq(1, vim.tbl_count(client.opts.templates.substitutions))
-    eq("function", type(client.opts.templates.substitutions.weekday))
+    eq(1, vim.tbl_count(Obsidian.opts.templates.substitutions))
+    eq("function", type(Obsidian.opts.templates.substitutions.weekday))
   end)
 end
 
 T["substitute_template_variables()"]["should substitute consecutive custom variables"] = function()
   h.with_tmp_client(function(client)
-    client.opts.templates.substitutions = {
+    Obsidian.opts.templates.substitutions = {
       value = function()
         return "VALUE"
       end,
@@ -61,7 +61,7 @@ end
 
 T["substitute_template_variables()"]["should provide substitution functions with template context"] = function()
   h.with_tmp_client(function(client)
-    client.opts.templates.substitutions = {
+    Obsidian.opts.templates.substitutions = {
       test_var = function(ctx)
         return tostring(ctx.template_name)
       end,

--- a/tests/test_workspace.lua
+++ b/tests/test_workspace.lua
@@ -13,10 +13,4 @@ T["should be able to initialize a workspace"] = function()
   tmpdir:rmdir()
 end
 
-T["should be able to initialize from cwd"] = function()
-  local ws = workspace.new_from_cwd()
-  local cwd = Path.cwd()
-  eq(true, cwd == ws.path)
-end
-
 return T


### PR DESCRIPTION
use _G.Obsidian to hold state, instead of client

This is in the style of mini.nvim and snacks.nvim, it is much cleaner now.
Also moved some workspace related client methods to workspace module.

Also removed some random unused functions.

- [x] client deprecate strategy: add a placeholder client table, with index meta method, warning user to use `_G.Obsidian` instead.
- [x] add a wiki page, `Scripting` to teach users about the `Obsidian` state, and how they can use it in their config.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
