### PR TITLE
fix: re-apply hl groups on colorscheme changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed highlight groups not applying after changing colorschemes
 - Only error once if template folder is not found.
 - Fixed corrupted text when custom variables appear more than once in a template file (#198)
 - Add further checks to void false positives when finding tags

--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -640,7 +640,7 @@ M.setup = function(workspace, ui_opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ 'ColorScheme' }, {
+  vim.api.nvim_create_autocmd({ "ColorScheme" }, {
     group = group,
     -- Remove the pattern completely for ColorScheme events
     callback = function()
@@ -650,8 +650,7 @@ M.setup = function(workspace, ui_opts)
       -- to ensure they use the new highlight groups
       local ns_id = vim.api.nvim_create_namespace(NAMESPACE)
       for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-        if vim.api.nvim_buf_is_loaded(bufnr) and should_update(ui_opts, bufnr)
-        then
+        if vim.api.nvim_buf_is_loaded(bufnr) and should_update(ui_opts, bufnr) then
           update_extmarks(bufnr, ns_id, ui_opts)
         end
       end

--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -640,6 +640,24 @@ M.setup = function(workspace, ui_opts)
     end,
   })
 
+  vim.api.nvim_create_autocmd({ 'ColorScheme' }, {
+    group = group,
+    -- Remove the pattern completely for ColorScheme events
+    callback = function()
+      install_hl_groups(ui_opts)
+
+      -- Also need to update extmarks for all open markdown buffers
+      -- to ensure they use the new highlight groups
+      local ns_id = vim.api.nvim_create_namespace(NAMESPACE)
+      for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_is_loaded(bufnr) and should_update(ui_opts, bufnr)
+        then
+          update_extmarks(bufnr, ns_id, ui_opts)
+        end
+      end
+    end,
+  })
+
   vim.api.nvim_create_autocmd({ "BufEnter" }, {
     group = group,
     pattern = pattern,


### PR DESCRIPTION
# Fixes issue #755 on epwalsh repo

What does the PR do?

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)


## Caveat

I'll be honest. This portion of the code is AI generated. I tried just calling `install_hl_groups` but that didn't do it.

```lua
  vim.api.nvim_create_autocmd({ 'ColorScheme' }, {
    group = group,
    -- Remove the pattern completely for ColorScheme events
    callback = function()
      install_hl_groups(ui_opts)

      ------------------------AI Generated Begin--------------------------------------------------
      -- Also need to update extmarks for all open markdown buffers
      -- to ensure they use the new highlight groups
      local ns_id = vim.api.nvim_create_namespace(NAMESPACE)
      for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
        if vim.api.nvim_buf_is_loaded(bufnr) and should_update(ui_opts, bufnr)
        then
          update_extmarks(bufnr, ns_id, ui_opts)
        end
      end
      ------------------------AI Generated End--------------------------------------------------
    end,
  })
```


