### PR TITLE
Improve clipboard image detection and Wayland paste handling.

### DIFF
--- a/lua/obsidian/img_paste.lua
+++ b/lua/obsidian/img_paste.lua
@@ -33,10 +33,9 @@ end
 ---
 ---@return boolean
 local function clipboard_is_img()
-  local content = {}
-  for output in assert(io.popen(get_clip_check_command())):lines() do
-    content[#content + 1] = output
-  end
+  local check_cmd = get_clip_check_command()
+  local result_string = vim.fn.system(check_cmd)
+  local content = vim.split(result_string, "\n")
 
   local is_img = false
   -- See: [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme)
@@ -74,7 +73,8 @@ local function save_clipboard_image(path)
     if display_server == "x11" or display_server == "tty" then
       cmd = string.format("xclip -selection clipboard -t image/png -o > '%s'", path)
     elseif display_server == "wayland" then
-      cmd = string.format("wl-paste --no-newline --type image/png > '%s'", path)
+      cmd = string.format("wl-paste --no-newline --type image/png > %s", vim.fn.shellescape(path))
+      return run_job { "bash", "-c", cmd }
     end
 
     local result = os.execute(cmd)


### PR DESCRIPTION
- Refactor `clipboard_is_img` to use `vim.fn.system` and `vim.split` for reading clipboard content, improving reliability.
- Update Wayland branch in `save_clipboard_image` to use `vim.fn.shellescape` for safe path handling and run the command asynchronously with `run_job`.

Closes #254 

## what does this PR do?
Solves the issue of pasting images in a wayland session using `ObsidianPasteImg` or `Obsidian paste_img`.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
