### PR TITLE
Handle error exit code from git in get_plugin_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Off-by-one bug when avoiding tag in code blocks
 - Make tag picker case insensitive
 - `ObsidianPasteImg` will now work on Wayland sessions
+- Handle error exit code from git in get_plugin_info
 
 ### Changed
 

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -474,10 +474,11 @@ M.get_plugin_info = function(name)
   end
   local out = { path = src_root }
   local obj = vim.system({ "git", "rev-parse", "HEAD" }, { cwd = src_root }):wait(1000)
-  if obj.code ~= 0 then
-    return
+  if obj.code == 0 then
+    out.commit = vim.trim(obj.stdout)
+  else
+    out.commit = "unknown"
   end
-  out.commit = vim.trim(obj.stdout)
   return out
 end
 


### PR DESCRIPTION
# Handle error exit code from git in get_plugin_info

Returns "unknown" commit hash instead of failing when git info is unavailable, fixing checkhealth functionality in environments like [nixvim](https://github.com/nix-community/nixvim).

This issue is mention in https://github.com/nix-community/nixvim/issues/3355.

## Screenshots

### before

```bash
==============================================================================
obsidian:                                                                 1 ❌

- ✅ OK neovim >= 0.11

obsidian.nvim [Version] ~
- ❌ ERROR Failed to run healthcheck for "obsidian" plugin. Exception:
  ...ovimPackages/start/obsidian.nvim/lua/obsidian/health.lua:0: attempt to index a nil value
```

### after

```bash
==============================================================================
obsidian:                                                                   ✅

- ✅ OK neovim >= 0.11

obsidian.nvim [Version] ~
- ✅ OK obsidian.nvim v3.12.0 (unknown)

obsidian.nvim [Environment] ~
- ✅ OK operating system: Darwin

obsidian.nvim [Config] ~
- ✅ OK • dir: /Users/trash-panda-v91-beta/notes

obsidian.nvim [Pickers] ~
- ✅ OK mini.nvim: unknown

obsidian.nvim [Completion] ~
- ✅ OK blink.cmp: unknown

obsidian.nvim [Dependencies] ~
- ✅ OK rg: 14.1.1
- ✅ OK plenary.nvim: unknown
- ✅ OK pngpaste: found
```

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
