### PR TITLE
feat: obsidian + snacks.image compatible img_text_func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `makefile types` target to check types via lua-ls.
 - New `obsidian.config` type for user config type check.
 - More informative healthcheck.
+- A guide to embed images for both viewing in neovim and obsidian app: https://github.com/obsidian-nvim/obsidian.nvim/wiki/Images
 
 ### Changed
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - change `clipboard_is_img` to use `vim.fn.system` instead of `io.popen` to get the output of the command with awareness of the shell variables.
 - use `run_job` wrap with `bash` to run `save_clipboard_image` async for Wayland sessions to avoid data corruption.
 - Use a `Obsidian` global variable to hold the state instead of client.
+- `opts.img_text_func` has an obsidian app compatibility, and only accept one path argument.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ There's one entry point user command for this plugin: `Obsidian`
 
 - Neovim >= 0.10.0
 - For completion and search features:
+
   - Backend: [ripgrep](https://github.com/BurntSushi/ripgrep), see [ripgrep#installation](https://github.com/BurntSushi/ripgrep)
   - Frontend: a picker, see [Plugin dependencies](#plugin-dependencies)
 
@@ -149,15 +150,20 @@ The only **required** plugin dependency is [plenary.nvim](https://github.com/nvi
 
 **Completion:**
 
-- **[recommended]** [hrsh7th/nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
+- **[recommended]** [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 - [blink.cmp](https://github.com/Saghen/blink.cmp) (new)
 
 **Pickers:**
 
-- **[recommended]** [nvim-telescope/telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
-- [ibhagwan/fzf-lua](https://github.com/ibhagwan/fzf-lua)
-- [Mini.Pick](https://github.com/echasnovski/mini.pick) from the mini.nvim library
-- [Snacks.Picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) from the snacks.nvim library
+- **[recommended]** [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
+- [fzf-lua](https://github.com/ibhagwan/fzf-lua)
+- [mini.pick](https://github.com/echasnovski/mini.pick)
+- [snacks.picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md)
+
+**Image viewing:**
+
+- [snacks.image](https://github.com/folke/snacks.nvim/blob/main/docs/image.md)
+- See [Images](https://github.com/obsidian-nvim/obsidian.nvim/wiki/Images) for configuration.
 
 **Syntax highlighting:**
 
@@ -165,7 +171,7 @@ See [syntax highlighting](#syntax-highlighting) for more details.
 
 - For base syntax highlighting:
   - **[recommended]** [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
-  - [preservim/vim-markdown](https://github.com/preservim/vim-markdown)
+  - [vim-markdown](https://github.com/preservim/vim-markdown)
 - For additional syntax features:
   - [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim)
   - [markview.nvim](https://github.com/OXY2DEV/markview.nvim)
@@ -583,17 +589,13 @@ require("obsidian").setup {
   ---Default name for pasted images
   ---@field img_name_func? fun(): string
   ---
-  ---Default text to insert for pasted images
-  ---@field img_text_func? fun(client: obsidian.Client, path: obsidian.Path): string
+  ---Default text to insert for pasted images, for customizing, see: https://github.com/obsidian-nvim/obsidian.nvim/wiki/Images
+  ---@field img_text_func? fun(path: obsidian.Path): string
   ---
   ---Whether to confirm the paste or not. Defaults to true.
   ---@field confirm_img_paste? boolean
   attachments = {
     img_folder = "assets/imgs",
-    img_text_func = function(client, path)
-      local encoded_path = require("obsidian.util").urlencode(path:vault_relative_path() or tostring(path))
-      return string.format("![%s](%s)", path.name, encoded_path)
-    end,
     img_name_func = function()
       return string.format("Pasted image %s", os.date "%Y%m%d%H%M%S")
     end,

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -39,6 +39,12 @@ end
 ---@return boolean
 M.path_is_note = function(path, workspace)
   path = Path.new(path):resolve()
+  workspace = workspace or Obsidian.workspace
+
+  local in_vault = path.filename:find(vim.pesc(tostring(workspace.root))) ~= nil
+  if not in_vault then
+    return false
+  end
 
   -- Notes have to be markdown file.
   if path.suffix ~= ".md" then
@@ -611,6 +617,14 @@ M.get_icon = function(path)
     end
   end
   return nil
+end
+
+--- Resolve a basename to full path inside the vault.
+---
+---@param src string
+---@return string
+M.resolve_image_path = function(src)
+  return vim.fs.joinpath(tostring(Obsidian.dir), Obsidian.opts.attachments.img_folder, src)
 end
 
 return M

--- a/lua/obsidian/builtin.lua
+++ b/lua/obsidian/builtin.lua
@@ -121,4 +121,20 @@ M.markdown_link = function(opts)
   return string.format("[%s%s](%s%s)", opts.label, header, path, anchor)
 end
 
+---@param path string
+M.img_text_func = function(path)
+  local format_string = {
+    markdown = "![](%s)",
+    wiki = "![[%s]]",
+  }
+  local style = Obsidian.opts.preferred_link_style
+  local name = vim.fs.basename(tostring(path))
+
+  if style == "markdown" then
+    name = require("obsidian.util").urlencode(name)
+  end
+
+  return string.format(format_string[style], name)
+end
+
 return M

--- a/lua/obsidian/commands/paste_img.lua
+++ b/lua/obsidian/commands/paste_img.lua
@@ -23,6 +23,7 @@ return function(client, data)
   }
 
   if path ~= nil then
-    vim.api.nvim_put({ Obsidian.opts.attachments.img_text_func(client, path) }, "c", true, false)
+    local img_text = Obsidian.opts.attachments.img_text_func(path)
+    vim.api.nvim_put({ img_text }, "c", true, false)
   end
 end

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -274,16 +274,13 @@ config.default = {
   ---@field img_name_func? fun(): string
   ---
   ---Default text to insert for pasted images
-  ---@field img_text_func? fun(client: obsidian.Client, path: obsidian.Path): string
+  ---@field img_text_func? fun(path: obsidian.Path): string
   ---
   ---Whether to confirm the paste or not. Defaults to true.
   ---@field confirm_img_paste? boolean
   attachments = {
     img_folder = "assets/imgs",
-    img_text_func = function(client, path)
-      local encoded_path = require("obsidian.util").urlencode(path:vault_relative_path() or tostring(path))
-      return string.format("![%s](%s)", path.name, encoded_path)
-    end,
+    img_text_func = require("obsidian.builtin").img_text_func,
     img_name_func = function()
       return string.format("Pasted image %s", os.date "%Y%m%d%H%M%S")
     end,

--- a/tests/attachment/test_image.lua
+++ b/tests/attachment/test_image.lua
@@ -1,0 +1,33 @@
+local builtin = require "obsidian.builtin"
+local new_set, eq = MiniTest.new_set, MiniTest.expect.equality
+local Path = require "obsidian.path"
+
+local T = new_set {
+  hooks = {
+    pre_case = function()
+      local path = Path.temp()
+      path:mkdir()
+      require("obsidian").setup {
+        workspaces = {
+          {
+            path = tostring(path),
+          },
+        },
+      }
+    end,
+    post_case = function()
+      vim.fn.delete(tostring(Obsidian.dir), "rf")
+    end,
+  },
+}
+
+T["img_text_func"] = new_set()
+
+T["img_text_func"] = function()
+  local mock_file = vim.fs.joinpath(tostring(Obsidian.dir), Obsidian.opts.attachments.img_folder, "test file.png")
+  eq("![[test file.png]]", builtin.img_text_func(mock_file))
+  Obsidian.opts.preferred_link_style = "markdown"
+  eq("![](test%20file.png)", builtin.img_text_func(mock_file))
+end
+
+return T


### PR DESCRIPTION
resolves #119 and inspired by https://github.com/orgs/obsidian-nvim/discussions/265

There's now a 100% obsidian compatible default `img_text_func`, that formats differently depend on link style

```md
For markdown

![](encoded_basename)

For wiki

![[basename]]
```

Then there's a new wiki page for configuring snacks to resolve image paths

https://github.com/obsidian-nvim/obsidian.nvim/wiki/Images


## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
