### PR TITLE
feat: add `check_buffers` option to `Note.write` and `Note.save` for automatically reloading buffers with `checktime` after writing them to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `obsidian.config` type for user config type check.
 - More informative healthcheck.
 - A guide to embed images for both viewing in neovim and obsidian app: https://github.com/obsidian-nvim/obsidian.nvim/wiki/Images
+- Added `check_buffers` option to `Note.write` and `Note.save` for automatically reloading buffers with `checktime` after writing them to disk
 
 ### Changed
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -32,6 +32,17 @@ local CODE_BLOCK_PATTERN = "^%s*```[%w_-]*$"
 --- @field should_write boolean|? Don't write the note to disk
 --- @field template string|? The name of the template
 
+---@class obsidian.note.NoteSaveOpts
+--- Specify a path to save to. Defaults to `self.path`.
+---@field path? string|obsidian.Path
+--- Whether to insert/update frontmatter. Defaults to `true`.
+---@field insert_frontmatter? boolean
+--- Override the frontmatter. Defaults to the result of `self:frontmatter()`.
+---@field frontmatter? table
+--- A function to update the contents of the note. This takes a list of lines representing the text to be written
+--- excluding frontmatter, and returns the lines that will actually be written (again excluding frontmatter).
+---@field update_content? fun(lines: string[]): string[]
+
 ---@class obsidian.note.NoteWriteOpts
 --- Specify a path to save to. Defaults to `self.path`.
 ---@field path? string|obsidian.Path
@@ -1018,15 +1029,7 @@ end
 --- In general this only updates the frontmatter and header, leaving the rest of the contents unchanged
 --- unless you use the `update_content()` callback.
 ---
----@param opts { path: string|obsidian.Path|?, insert_frontmatter: boolean|?, frontmatter: table|?, update_content: (fun(lines: string[]): string[])|? }|? Options.
----
---- Options:
----  - `path`: Specify a path to save to. Defaults to `self.path`.
----  - `insert_frontmatter`: Whether to insert/update frontmatter. Defaults to `true`.
----  - `frontmatter`: Override the frontmatter. Defaults to the result of `self:frontmatter()`.
----  - `update_content`: A function to update the contents of the note. This takes a list of lines
----    representing the text to be written excluding frontmatter, and returns the lines that will
----    actually be written (again excluding frontmatter).
+---@param opts? obsidian.note.NoteSaveOpts
 Note.save = function(self, opts)
   opts = opts or {}
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -32,6 +32,15 @@ local CODE_BLOCK_PATTERN = "^%s*```[%w_-]*$"
 --- @field should_write boolean|? Don't write the note to disk
 --- @field template string|? The name of the template
 
+---@class obsidian.note.NoteWriteOpts
+--- Specify a path to save to. Defaults to `self.path`.
+---@field path? string|obsidian.Path
+--- The name of a template to use if the note file doesn't already exist.
+---@field template? string
+--- A function to update the contents of the note. This takes a list of lines representing the text to be written
+--- excluding frontmatter, and returns the lines that will actually be written (again excluding frontmatter).
+---@field update_content? fun(lines: string[]): string[]
+
 ---@class obsidian.note.HeaderAnchor
 ---
 ---@field anchor string
@@ -961,14 +970,7 @@ end
 
 --- Write the note to disk.
 ---
----@param opts { path: string|obsidian.Path, template: string|?, update_content: (fun(lines: string[]): string[])|? }|? Options.
----
---- Options:
----  - `template`: The name of a template to use if the note file doesn't already exist.
----  - `update_content`: A function to update the contents of the note. This takes a list of lines
----    representing the text to be written excluding frontmatter, and returns the lines that will
----    actually be written (again excluding frontmatter).
----
+---@param opts? obsidian.note.NoteWriteOpts
 ---@return obsidian.Note
 Note.write = function(self, opts)
   local Template = require "obsidian.templates"

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -42,7 +42,7 @@ local CODE_BLOCK_PATTERN = "^%s*```[%w_-]*$"
 --- A function to update the contents of the note. This takes a list of lines representing the text to be written
 --- excluding frontmatter, and returns the lines that will actually be written (again excluding frontmatter).
 ---@field update_content? fun(lines: string[]): string[]
---- Whether to call |checktime| on open buffers pointing to the written note.
+--- Whether to call |checktime| on open buffers pointing to the written note. Defaults to true.
 --- When enabled, Neovim will warn the user if changes would be lost and/or reload the updated file.
 --- See `:help checktime` to learn more.
 ---@field check_buffers? boolean
@@ -55,7 +55,7 @@ local CODE_BLOCK_PATTERN = "^%s*```[%w_-]*$"
 --- A function to update the contents of the note. This takes a list of lines representing the text to be written
 --- excluding frontmatter, and returns the lines that will actually be written (again excluding frontmatter).
 ---@field update_content? fun(lines: string[]): string[]
---- Whether to call |checktime| on open buffers pointing to the written note.
+--- Whether to call |checktime| on open buffers pointing to the written note. Defaults to true.
 --- When enabled, Neovim will warn the user if changes would be lost and/or reload each buffer's content.
 --- See `:help checktime` to learn more.
 ---@field check_buffers? boolean
@@ -993,7 +993,7 @@ end
 ---@return obsidian.Note
 Note.write = function(self, opts)
   local Template = require "obsidian.templates"
-  opts = opts or {}
+  opts = vim.tbl_extend("keep", opts or {}, { check_buffers = true })
 
   local path = assert(self.path, "A path must be provided")
   path = Path.new(path)
@@ -1040,7 +1040,7 @@ end
 ---
 ---@param opts? obsidian.note.NoteSaveOpts
 Note.save = function(self, opts)
-  opts = opts or {}
+  opts = vim.tbl_extend("keep", opts or {}, { check_buffers = true })
 
   if self.path == nil then
     error "a path is required"


### PR DESCRIPTION
Fixes #279: add `check_buffers` option to `Note.write` and `Note.save` for automatically reloading buffers with `checktime` after writing them to disk

When enabled, `Note.save` checks if at least one buffer would be affected and, if so, then calls `checktime`. `Note.write` is just a wrapper around `Note.save`, so I've only changed it to forward the new option's value.

## Screenshots

N/A

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file -> N/A obsidian.Note's API is only documented via comments
- [x] The code complies with `make chores` (for style, lint, types, and tests)
