### PR TITLE
Fix false positive invalid id detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle error exit code from git in get_plugin_info
 - Fixed incorrect usage of `Note.create` in `daily_notes`.
 - Fixed tag completion for blink.cmp and improved frontmatter tag handling
+- Fixed to allow numbers in note IDs.
 
 ## [v3.12.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.12.0) - 2025-06-05
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -783,7 +783,7 @@ Note.from_lines = function(lines, path, opts)
       ---@diagnostic disable-next-line: param-type-mismatch
       for k, v in pairs(data) do
         if k == "id" then
-          if type(v) == "string" then
+          if type(v) == "string" or type(v) == "number" then
             id = v
           else
             log.warn("Invalid 'id' in frontmatter for " .. tostring(path))


### PR DESCRIPTION
# Fix to allow numbers in note ID

Stop false-pasitive invalid 'id' detection in frontmatter.

## Screenshots

TODO Add screenshots to help explain your changes, if applicable.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
