### PR TITLE
fix: respect subdirectories in date_format for daily files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle error exit code from git in get_plugin_info
 - Fixed incorrect usage of `Note.create` in `daily_notes`.
 - Fixed tag completion for blink.cmp and improved frontmatter tag handling
+- Fixed ignore subdirectories specified in `daily_notes.date_format`
 
 ## [v3.12.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.12.0) - 2025-06-05
 

--- a/lua/obsidian/daily/init.lua
+++ b/lua/obsidian/daily/init.lua
@@ -69,7 +69,7 @@ local _daily = function(datetime, opts)
       id = id,
       aliases = {},
       tags = options.daily_notes.default_tags or {},
-      dir = options.daily_notes.folder,
+      dir = path:parent(),
     }
 
     if alias then


### PR DESCRIPTION
# fix: respect subdirectories specified in daily_note.date_format

Solves #290

Uses the `path:parent()` instead `opts.daily_note.folder` for the directory for daily notes. `opts.daily_note.folder` is already integrated into path from

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
