### PR TITLE
feat: add support for `title` frontmatter property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added footer options.
 - Added default mappings: `]o` and `[o`, for navigating links in note.
 - Support pasting image to sub directory in current directory.
+- Support parsing `title` frontmatter property
 
 ### Changed
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -766,11 +766,6 @@ Note.from_lines = function(lines, path, opts)
     end
   end
 
-  if title ~= nil then
-    -- Remove references and links from title
-    title = search.replace_refs(title)
-  end
-
   -- Parse the frontmatter YAML.
   local metadata = nil
   if #frontmatter_lines > 0 then
@@ -787,6 +782,12 @@ Note.from_lines = function(lines, path, opts)
             id = v
           else
             log.warn("Invalid 'id' in frontmatter for " .. tostring(path))
+          end
+        elseif k == "title" then
+          if type(v) == "string" then
+            title = v
+          else
+            log.warn("Invalid 'title' in frontmatter for " .. tostring(path))
           end
         elseif k == "aliases" then
           if type(v) == "table" then
@@ -836,6 +837,11 @@ Note.from_lines = function(lines, path, opts)
         end
       end
     end
+  end
+
+  if title ~= nil then
+    -- Remove references and links from title
+    title = search.replace_refs(title)
   end
 
   -- ID should default to the filename without the extension.

--- a/tests/fixtures/notes/note_with_additional_metadata.md
+++ b/tests/fixtures/notes/note_with_additional_metadata.md
@@ -1,5 +1,6 @@
 ---
 id: note_with_additional_metadata
+title: Note (has additional metadata)
 aliases: []
 tags: []
 foo: bar

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -197,6 +197,7 @@ end
 T["from_file"]["should collect additional frontmatter metadata"] = function()
   local note = M.from_file "tests/fixtures/notes/note_with_additional_metadata.md"
   eq(note.id, "note_with_additional_metadata")
+  eq(note.title, "Note (has additional metadata)")
   not_eq(note.metadata, nil)
   eq(note.metadata.foo, "bar")
   eq(


### PR DESCRIPTION
# Add support for `title` frontmatter property

This PR makes `obsidian.nvim` respect `title` property in frontmatter. This is especially useful for zettelkasten users,
who have unique id for a note name, and need `title` to be respected for search / completion to work as expected.

## Screenshots

N/A, see test.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
  - Haven't updated `README.md` due to lack of new feature functionality
- [x] The code complies with `make chores` (for style, lint, types, and tests)
  - `types` is failing for me locally on `main` as well, the rest works

P.S. Thanks a ton for stepping up and maintaining community fork, love to see it!
