### PR TITLE
fix(#326): remove client param from post_set_workspace callback signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed incorrect call signature for `options.callbacks.post_set_workspace`
+
 ## [v3.13.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.13.0) - 2025-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -491,9 +491,8 @@ require("obsidian").setup {
     pre_write_note = function(client, note) end,
 
     -- Runs anytime the workspace is set/changed.
-    ---@param client obsidian.Client
     ---@param workspace obsidian.Workspace
-    post_set_workspace = function(client, workspace) end,
+    post_set_workspace = function(workspace) end,
   },
 
   -- Optional, configure additional syntax highlighting / extmarks.

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -313,7 +313,7 @@ config.default = {
   ---@field pre_write_note? fun(client: obsidian.Client, note: obsidian.Note)
   ---
   ---Runs anytime the workspace is set/changed.
-  ---@field post_set_workspace? fun(client: obsidian.Client, workspace: obsidian.Workspace)
+  ---@field post_set_workspace? fun(workspace: obsidian.Workspace)
   callbacks = {},
 
   ---@class obsidian.config.StatuslineOpts


### PR DESCRIPTION
# Fixes #326: `post_set_workspace` callback signature

Config and README state this callback should receive 2 params (`client, workspace`), when in reality it only receives one.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
