### PR TITLE
fix: `Snacks.picker` now follow `sort_by` and `sort_reversed` settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed incorrect fallback for `resolve_note`.
 - Fixed async with minimal functions copied from `vim._async`.
 - No longer notify user `Updated Frontmatter`.
+- `Snacks.picker` now follow `sort_by` and `sort_reversed` settings.
 
 ## [v3.13.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.13.0) - 2025-07-28
 

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -43,10 +43,15 @@ SnacksPicker.find_files = function(self, opts)
 
   local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
 
+  local args = self:_build_find_cmd()
+  local cmd = table.remove(args, 1)
+
   local pick_opts = vim.tbl_extend("force", map or {}, {
     source = "files",
     title = opts.prompt_title,
     cwd = tostring(dir),
+    cmd = cmd,
+    args = args,
     confirm = function(picker, item, action)
       picker:close()
       if item then

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -75,10 +75,15 @@ SnacksPicker.grep = function(self, opts)
 
   local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
 
+  local args = self:_build_grep_cmd()
+  local cmd = table.remove(args, 1)
+
   local pick_opts = vim.tbl_extend("force", map or {}, {
     source = "grep",
     title = opts.prompt_title,
     cwd = tostring(dir),
+    cmd = cmd,
+    args = args,
     confirm = function(picker, item, action)
       picker:close()
       if item then


### PR DESCRIPTION
#97 fix for snacks.picker

