### PR TITLE
Add an Option to Insert Checkboxes on Empty Lines

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -3,6 +3,6 @@
   "diagnostics.libraryFiles": "Disable",
   "workspace.checkThirdParty": "Disable",
   "workspace.ignoreDir": ["completion/", "compat.lua"],
-  "workspace.library": ["$VIMRUNTIME/lua/", "./lua/"],
+  "workspace.library": ["$VIMRUNTIME/lua/", "./lua/", "${3rd}/luv/library"],
   "diagnostics.globals": ["vim", "MiniTest"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added an option to have the 'ObsidianToggleCheckbox' command to work on blank lines
+
 ### Fixed
 
 - Fixed incorrect call signature for `options.callbacks.post_set_workspace`

--- a/README.md
+++ b/README.md
@@ -582,10 +582,21 @@ require("obsidian").setup {
   },
   ---@class obsidian.config.CheckboxOpts
   ---
+  ---@field enabled? boolean
+  ---
   ---Order of checkbox state chars, e.g. { " ", "x" }
   ---@field order? string[]
+  ---
+  ---Whether to create new checkbox on paragraphs
+  ---@field create_new? boolean
+  ---
+  ---Whether to create new checkbox on empty lines
+  ---@field create_on_empty? boolean
   checkbox = {
+    enabled = true,
     order = { " ", "~", "!", ">", "x" },
+    create_new = true,
+    create_on_empty = false,
   },
 }
 ```

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -112,7 +112,10 @@ end
 ---@param states table|nil Optional table containing checkbox states (e.g., {" ", "x"}).
 ---@param line_num number|nil Optional line number to toggle the checkbox on. Defaults to the current line.
 M.toggle_checkbox = function(states, line_num)
-  if not util.in_node { "list", "paragraph" } or util.in_node "block_quote" then
+  if
+    (not util.in_node { "list", "paragraph" } or util.in_node "block_quote")
+    and not Obsidian.opts.checkbox.create_on_empty
+  then
     return
   end
   line_num = line_num or unpack(vim.api.nvim_win_get_cursor(0))
@@ -120,7 +123,9 @@ M.toggle_checkbox = function(states, line_num)
 
   local checkboxes = states or { " ", "x" }
 
-  if util.is_checkbox(line) then
+  if (line == "" or nil) and Obsidian.opts.checkbox.create_on_empty then
+    line = "- [ ] "
+  elseif util.is_checkbox(line) then
     for i, check_char in ipairs(checkboxes) do
       if string.match(line, "^.* %[" .. vim.pesc(check_char) .. "%].*") then
         i = i % #checkboxes

--- a/lua/obsidian/commands/toggle_checkbox.lua
+++ b/lua/obsidian/commands/toggle_checkbox.lua
@@ -4,6 +4,7 @@ local toggle_checkbox = require("obsidian.api").toggle_checkbox
 return function(_, data)
   local start_line, end_line
   local checkboxes = Obsidian.opts.checkbox.order
+  local create_on_empty = Obsidian.opts.checkbox.create_on_empty
   start_line = data.line1
   end_line = data.line2
 
@@ -11,7 +12,7 @@ return function(_, data)
 
   for line_nb = start_line, end_line do
     local current_line = vim.api.nvim_buf_get_lines(buf, line_nb - 1, line_nb, false)[1]
-    if current_line and current_line:match "%S" then
+    if (current_line and current_line:match "%S") or create_on_empty then
       toggle_checkbox(checkboxes, line_nb)
     end
   end

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -359,9 +359,13 @@ config.default = {
   ---
   ---Whether to create new checkbox on paragraphs
   ---@field create_new? boolean
+  ---
+  ---Whether to create new checkbox on empty lines
+  ---@field create_on_empty? boolean
   checkbox = {
     enabled = true,
     create_new = true,
+    create_on_empty = false,
     order = { " ", "~", "!", ">", "x" },
   },
 


### PR DESCRIPTION
## Changes
Added an option that causes the toggle_checkbox command to work on empty lines, as it functions in Obsidian.  #351 
## Testing
I saw that all the other tests for checkboxes are broken currently and I didn't want to wade into that so I didn't write any.
## Documentation
updated `CHANGELOG.md`, but it was out of date, see #354
updated `README.md` with my changes and the existing options that were not documented there
## Note on `make chores`
For some reason I had to change the `luarc.json` file to explicitly reference the luv library, I'm guessing this is just an issue on my machine and doesn't need to be pulled into the main repo but I don't really understand what's going on there.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests) **See the above note**
