### PR TITLE
fix: cache note as local var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No longer notify user `Updated Frontmatter`.
 - `Snacks.picker` now follow `sort_by` and `sort_reversed` settings.
 - `Note.open` refactor, so that API works as expected.
+- Cache note as buffer-local variable, to avoid loss of info.
 
 ## [v3.13.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.13.0) - 2025-07-28
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -584,6 +584,14 @@ end
 ---@return obsidian.Note
 Note.from_buffer = function(bufnr, opts)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
+  ---@type obsidian.Note
+  local cache_note = vim.b[bufnr].note
+  if cache_note ~= nil then
+    local new_note = vim.deepcopy(cache_note)
+    setmetatable(new_note.path, { __index = require "obsidian.path" })
+    setmetatable(new_note, { __index = Note })
+    return new_note
+  end
   local path = vim.api.nvim_buf_get_name(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local note = Note.from_lines(iter(lines), path, opts)
@@ -1238,10 +1246,10 @@ Note.open = function(note, opts)
   local function open_it()
     local open_cmd = api.get_open_strategy(opts.open_strategy and opts.open_strategy or Obsidian.opts.open_notes_in)
     local bufnr = api.open_buffer(note.path, { line = opts.line, col = opts.col, cmd = open_cmd })
+    vim.b[bufnr].note = note
     if opts.callback then
       opts.callback(bufnr)
     end
-    note:update_frontmatter(bufnr)
   end
 
   if opts.sync then


### PR DESCRIPTION
resolves #352 

avoids loss of creation info, tags and etc, and don't eagerly update frontmatter until saving.