### PR TITLE
fix(tags): drop second tag query; make frontmatter tag query case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Snacks.picker` now follow `sort_by` and `sort_reversed` settings.
 - `Note.open` refactor, so that API works as expected.
 - Cache note as buffer-local variable, to avoid loss of info.
+- Fixed case sensitive front matter tags query.
+- Refactor tags command duplicate queries. 
 
 ## [v3.13.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.13.0) - 2025-07-28
 

--- a/lua/obsidian/commands/tags.lua
+++ b/lua/obsidian/commands/tags.lua
@@ -2,49 +2,60 @@ local log = require "obsidian.log"
 local util = require "obsidian.util"
 local api = require "obsidian.api"
 
+
+---@param tag_locations obsidian.TagLocation[]
+---@return string[]
+local list_tags = function(tag_locations)
+  local tags = {}
+  for _, tag_loc in ipairs(tag_locations) do
+    local tag = tag_loc.tag
+    if not tags[tag] then
+      tags[tag] = true
+    end
+  end
+  return vim.tbl_keys(tags)
+end
+
 ---@param client obsidian.Client
 ---@param picker obsidian.Picker
+---@param tag_locations obsidian.TagLocation[]
 ---@param tags string[]
-local function gather_tag_picker_list(client, picker, tags)
-  client:find_tags_async(tags, function(tag_locations)
-    -- Format results into picker entries, filtering out results that aren't exact matches or sub-tags.
-    ---@type obsidian.PickerEntry[]
-    local entries = {}
-    for _, tag_loc in ipairs(tag_locations) do
-      for _, tag in ipairs(tags) do
-        if tag_loc.tag:lower() == tag:lower() or vim.startswith(tag_loc.tag:lower(), tag:lower() .. "/") then
-          local display = string.format("%s [%s] %s", tag_loc.note:display_name(), tag_loc.line, tag_loc.text)
-          entries[#entries + 1] = {
-            value = { path = tag_loc.path, line = tag_loc.line, col = tag_loc.tag_start },
-            display = display,
-            ordinal = display,
-            filename = tostring(tag_loc.path),
-            lnum = tag_loc.line,
-            col = tag_loc.tag_start,
-          }
-          break
-        end
+local function gather_tag_picker_list(client, picker, tag_locations, tags)
+  ---@type obsidian.PickerEntry[]
+  local entries = {}
+  for _, tag_loc in ipairs(tag_locations) do
+    for _, tag in ipairs(tags) do
+      if tag_loc.tag:lower() == tag:lower() or vim.startswith(tag_loc.tag:lower(), tag:lower() .. "/") then
+        local display = string.format("%s [%s] %s", tag_loc.note:display_name(), tag_loc.line, tag_loc.text)
+        entries[#entries + 1] = {
+          value = { path = tag_loc.path, line = tag_loc.line, col = tag_loc.tag_start },
+          display = display,
+          ordinal = display,
+          filename = tostring(tag_loc.path),
+          lnum = tag_loc.line,
+          col = tag_loc.tag_start,
+        }
+        break
       end
     end
-
-    if vim.tbl_isempty(entries) then
-      if #tags == 1 then
-        log.warn "Tag not found"
-      else
-        log.warn "Tags not found"
-      end
-      return
+  end
+  if vim.tbl_isempty(entries) then
+    if #tags == 1 then
+      log.warn "Tag not found"
+    else
+      log.warn "Tags not found"
     end
+    return
+  end
 
-    vim.schedule(function()
-      picker:pick(entries, {
-        prompt_title = "#" .. table.concat(tags, ", #"),
-        callback = function(value)
-          api.open_buffer(value.path, { line = value.line, col = value.col })
-        end,
-      })
-    end)
-  end, { search = { sort = true } })
+  vim.schedule(function()
+    picker:pick(entries, {
+      prompt_title = "#" .. table.concat(tags, ", #"),
+      callback = function(value)
+        api.open_buffer(value.path, { line = value.line, col = value.col })
+      end,
+    })
+  end)
 end
 
 ---@param client obsidian.Client
@@ -66,18 +77,20 @@ return function(client, data)
   end
 
   if not vim.tbl_isempty(tags) then
-    return gather_tag_picker_list(client, picker, util.tbl_unique(tags))
-  else
-    client:list_tags_async(nil, function(all_tags)
-      vim.schedule(function()
-        -- Open picker with tags.
-        picker:pick_tag(all_tags, {
-          callback = function(...)
-            gather_tag_picker_list(client, picker, { ... })
-          end,
-          allow_multiple = true,
-        })
+      client:find_tags_async(tags, function(tag_locations)
+        return gather_tag_picker_list(client, picker, tag_locations, util.tbl_unique(tags))
       end)
-    end)
-  end
+    else
+      client:find_tags_async("", function(tag_locations)
+        tags = list_tags(tag_locations)
+        vim.schedule(function()
+          picker:pick(tags, {
+            callback = function(...)
+              gather_tag_picker_list(client, picker, tag_locations, {...})
+            end,
+            allow_multiple = true,
+          })
+        end)
+      end)
+    end
 end


### PR DESCRIPTION
# Changes Summary
* fix: Frontmatter tag query is now case-insensitive.
* refactor: Reuse initial tag query result to remove redundant follow-up call.

# Detail
- ObsidianTags command was querying twice, once to create a list of tags for the picker, and then again when a value was selected to query for the location. Eliminated the second query, by using the cached results from the first query.
- Frontmatter search was case sensitive, even though inline tags were not. Frontmatter search uses 'util.string_contains'. Normalized the search, so Frontmatter search is now case insensitive.