### PR TITLE
picker cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed case sensitive front matter tags query.
 - Refactor tags command duplicate queries.
 - Make sure fold options are remove on `BufLeave`
+- Unified picker interface.
 
 ## [v3.13.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.13.0) - 2025-07-28
 

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -26,7 +26,6 @@ local function collect_backlinks(picker, note, opts)
 
     for _, backlink in ipairs(backlinks) do
       entries[#entries + 1] = {
-        value = { path = backlink.path, line = backlink.line },
         filename = tostring(backlink.path),
         lnum = backlink.line,
       }
@@ -46,7 +45,7 @@ local function collect_backlinks(picker, note, opts)
       picker:pick(entries, {
         prompt_title = prompt_title,
         callback = function(value)
-          api.open_buffer(value.path, { line = value.line })
+          api.open_buffer(value.filename, { line = value.lnum })
         end,
       })
     end)

--- a/lua/obsidian/commands/dailies.lua
+++ b/lua/obsidian/commands/dailies.lua
@@ -68,8 +68,8 @@ return function(_, data)
 
   picker:pick(dailies, {
     prompt_title = "Dailies",
-    callback = function(offset)
-      local note = daily.daily(offset, {})
+    callback = function(entry)
+      local note = daily.daily(entry.value, {})
       note:open()
     end,
   })

--- a/lua/obsidian/commands/links.lua
+++ b/lua/obsidian/commands/links.lua
@@ -19,8 +19,8 @@ return function()
     -- Launch picker.
     picker:pick(entries, {
       prompt_title = "Links",
-      callback = function(link)
-        api.follow_link(link)
+      callback = function(entry)
+        api.follow_link(entry.value)
       end,
     })
   end)

--- a/lua/obsidian/commands/new_from_template.lua
+++ b/lua/obsidian/commands/new_from_template.lua
@@ -1,5 +1,6 @@
 local log = require "obsidian.log"
 local util = require "obsidian.util"
+local api = require "obsidian.api"
 local Note = require "obsidian.note"
 
 ---@param data CommandArgs
@@ -8,6 +9,11 @@ return function(_, data)
   if not picker then
     log.err "No picker configured"
     return
+  end
+
+  local templates_dir = api.templates_dir()
+  if not templates_dir then
+    return log.err "Templates folder is not defined or does not exist"
   end
 
   ---@type string?
@@ -20,7 +26,10 @@ return function(_, data)
     return
   end
 
-  picker:find_templates {
+  picker:find_files {
+    prompt_title = "Templates",
+    dir = templates_dir,
+    no_default_mappings = true,
     callback = function(template_name)
       if title == nil or title == "" then
         -- Must use pcall in case of KeyboardInterrupt

--- a/lua/obsidian/commands/tags.lua
+++ b/lua/obsidian/commands/tags.lua
@@ -84,7 +84,10 @@ return function(client, data)
       vim.schedule(function()
         picker:pick(tags, {
           callback = function(...)
-            gather_tag_picker_list(picker, tag_locations, { ... })
+            tags = vim.tbl_map(function(v)
+              return v.value
+            end, { ... })
+            gather_tag_picker_list(picker, tag_locations, tags)
           end,
           allow_multiple = true,
         })

--- a/lua/obsidian/commands/tags.lua
+++ b/lua/obsidian/commands/tags.lua
@@ -50,7 +50,7 @@ local function gather_tag_picker_list(picker, tag_locations, tags)
     picker:pick(entries, {
       prompt_title = "#" .. table.concat(tags, ", #"),
       callback = function(value)
-        api.open_buffer(value.path, { line = value.line, col = value.col })
+        api.open_buffer(value.filename, { line = value.lnum, col = value.col })
       end,
     })
   end)

--- a/lua/obsidian/commands/template.lua
+++ b/lua/obsidian/commands/template.lua
@@ -6,8 +6,7 @@ local api = require "obsidian.api"
 return function(_, data)
   local templates_dir = api.templates_dir()
   if not templates_dir then
-    log.err "Templates folder is not defined or does not exist"
-    return
+    return log.err "Templates folder is not defined or does not exist"
   end
 
   -- We need to get this upfront before the picker hijacks the current window.
@@ -35,9 +34,12 @@ return function(_, data)
     return
   end
 
-  picker:find_templates {
+  picker:find_files {
+    prompt_title = "Templates",
     callback = function(path)
       insert_template(path)
     end,
+    dir = templates_dir,
+    no_default_mappings = true,
   }
 end

--- a/lua/obsidian/commands/workspace.lua
+++ b/lua/obsidian/commands/workspace.lua
@@ -15,8 +15,8 @@ return function(_, data)
       end, Obsidian.workspaces)
       picker:pick(options, {
         prompt_title = "Obsidian Workspace",
-        callback = function(ws)
-          Workspace.switch(ws.name, { lock = true })
+        callback = function(entry)
+          Workspace.switch(entry.value.name, { lock = true })
         end,
       })
     else

--- a/lua/obsidian/pickers/_fzf.lua
+++ b/lua/obsidian/pickers/_fzf.lua
@@ -149,7 +149,7 @@ FzfPicker.grep = function(self, opts)
   local dir = opts.dir and Path:new(opts.dir) or Obsidian.dir
   local cmd = table.concat(self:_build_grep_cmd(), " ")
   local actions = get_path_actions {
-    callback = opts.callback,
+    -- TODO: callback for the full object
     no_default_mappings = opts.no_default_mappings,
     selection_mappings = opts.selection_mappings,
   }
@@ -191,7 +191,7 @@ FzfPicker.pick = function(self, values, opts)
       entries[#entries + 1] = value
     elseif value.valid ~= false then
       local display = self:_make_display(value)
-      display_to_value_map[display] = value.value
+      display_to_value_map[display] = value
       entries[#entries + 1] = display
     end
   end

--- a/lua/obsidian/pickers/_fzf.lua
+++ b/lua/obsidian/pickers/_fzf.lua
@@ -186,11 +186,14 @@ FzfPicker.pick = function(self, values, opts)
   ---@type string[]
   local entries = {}
   for _, value in ipairs(values) do
+    local display
     if type(value) == "string" then
-      display_to_value_map[value] = value
-      entries[#entries + 1] = value
-    elseif value.valid ~= false then
-      local display = self:_make_display(value)
+      display = value
+      value = { value = value }
+    else
+      display = self:_make_display(value)
+    end
+    if value.valid ~= false then
       display_to_value_map[display] = value
       entries[#entries + 1] = display
     end

--- a/lua/obsidian/pickers/_mini.lua
+++ b/lua/obsidian/pickers/_mini.lua
@@ -7,8 +7,8 @@ local Picker = require "obsidian.pickers.picker"
 ---@param entry string
 ---@return string
 local function clean_path(entry)
-  local path_end = assert(string.find(entry, ":", 1, true))
-  return string.sub(entry, 1, path_end - 1)
+  local path_end = assert(string.find(entry, ".md", 1, true))
+  return string.sub(entry, 1, path_end + 2)
 end
 
 ---@class obsidian.pickers.MiniPicker : obsidian.Picker
@@ -113,7 +113,12 @@ MiniPicker.pick = function(self, values, opts)
     if type(entry) == "string" then
       opts.callback(entry)
     else
-      opts.callback(entry.value)
+      opts.callback {
+        filename = entry.path,
+        col = entry.col,
+        lnum = entry.lnum,
+        value = entry.value,
+      }
     end
   end
 end

--- a/lua/obsidian/pickers/_mini.lua
+++ b/lua/obsidian/pickers/_mini.lua
@@ -110,16 +110,12 @@ MiniPicker.pick = function(self, values, opts)
   }
 
   if entry and opts.callback then
-    if type(entry) == "string" then
-      opts.callback(entry)
-    else
-      opts.callback {
-        filename = entry.path,
-        col = entry.col,
-        lnum = entry.lnum,
-        value = entry.value,
-      }
-    end
+    opts.callback {
+      filename = entry.path,
+      col = entry.col,
+      lnum = entry.lnum,
+      value = entry.value,
+    }
   end
 end
 

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -141,7 +141,16 @@ SnacksPicker.pick = function(self, values, opts)
       picker:close()
       if item then
         if opts.callback then
-          opts.callback(item.value)
+          if item.file then
+            opts.callback {
+              filename = item.file,
+              col = item.pos and item.pos[2],
+              lnum = item.pos and item.pos[1],
+              value = item.value,
+            }
+          else
+            opts.callback(item.value)
+          end
         else
           snacks_picker.actions.jump(picker, item, action)
         end

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -149,7 +149,9 @@ SnacksPicker.pick = function(self, values, opts)
               value = item.value,
             }
           else
-            opts.callback(item.value)
+            opts.callback {
+              value = item.value,
+            }
           end
         else
           snacks_picker.actions.jump(picker, item, action)

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -88,7 +88,12 @@ SnacksPicker.grep = function(self, opts)
       picker:close()
       if item then
         if opts.callback then
-          opts.callback(item._path or item.filename)
+          opts.callback {
+            filename = item._path or item.filename,
+            col = item.pos and item.pos[2],
+            lnum = item.pos and item.pos[1],
+            value = item.value,
+          }
         else
           snacks_picker.actions.jump(picker, item, action)
         end

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -116,21 +116,20 @@ SnacksPicker.pick = function(self, values, opts)
 
   local entries = {}
   for _, value in ipairs(values) do
+    local display
     if type(value) == "string" then
-      table.insert(entries, {
-        text = value,
-        value = value,
-      })
-    elseif type(value) == "table" then
-      local name = self:_make_display(value)
-      table.insert(entries, {
-        text = name,
-        file = value.filename,
-        value = value.value,
-        pos = value.lnum and { value.lnum, value.col or 0 },
-        dir = Path.new(value.filename):is_dir(),
-      })
+      display = value
+      value = { value = value }
+    else
+      display = self:_make_display(value)
     end
+    table.insert(entries, {
+      text = display,
+      file = value.filename,
+      value = value.value,
+      pos = value.lnum and { value.lnum, value.col or 0 },
+      dir = value.filename and Path.new(value.filename):is_dir() or false,
+    })
   end
 
   local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
@@ -141,7 +140,7 @@ SnacksPicker.pick = function(self, values, opts)
     layout = {
       preview = preview,
     },
-    format = preview and "file" or "text",
+    format = "text",
     confirm = function(picker, item, action)
       picker:close()
       if item then

--- a/lua/obsidian/pickers/_telescope.lua
+++ b/lua/obsidian/pickers/_telescope.lua
@@ -34,7 +34,7 @@ local function get_selected(prompt_bufnr, keep_open, allow_multiple)
   ---@return obsidian.PickerEntry
   local function selection_to_entry(selection)
     return {
-      filename = selection.path,
+      filename = selection.path or selection.filename or selection.value.path,
       lnum = selection.lnum,
       col = selection.col,
       value = selection.value,

--- a/lua/obsidian/pickers/_telescope.lua
+++ b/lua/obsidian/pickers/_telescope.lua
@@ -31,6 +31,16 @@ end
 ---@param allow_multiple boolean|?
 ---@return table[]|?
 local function get_selected(prompt_bufnr, keep_open, allow_multiple)
+  ---@return obsidian.PickerEntry
+  local function selection_to_entry(selection)
+    return {
+      filename = selection.path,
+      lnum = selection.lnum,
+      col = selection.col,
+      value = selection.value,
+    }
+  end
+
   local picker = actions_state.get_current_picker(prompt_bufnr)
   local entries = picker:get_multi_selection()
   if entries and #entries > 0 then
@@ -43,12 +53,12 @@ local function get_selected(prompt_bufnr, keep_open, allow_multiple)
       telescope_actions.close(prompt_bufnr)
     end
 
-    return entries
+    return vim.tbl_map(selection_to_entry, entries)
   else
     local entry = get_entry(prompt_bufnr, keep_open)
 
     if entry then
-      return { entry }
+      return vim.tbl_map(selection_to_entry, { entry })
     end
   end
 end
@@ -72,18 +82,10 @@ local function get_query(prompt_bufnr, keep_open, initial_query)
   end
 end
 
----@param opts { entry_key: string|?, callback: fun(path: string)|?, allow_multiple: boolean|?, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|?, initial_query: string|? }
+---@param opts { callback: fun(entry: obsidian.PickerEntry)|?, allow_multiple: boolean|?, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|?, initial_query: string|? }
 local function attach_picker_mappings(map, opts)
   -- Docs for telescope actions:
   -- https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/actions/init.lua
-
-  local function entry_to_value(entry)
-    if opts.entry_key then
-      return entry[opts.entry_key]
-    else
-      return entry
-    end
-  end
 
   if opts.query_mappings then
     for key, mapping in pairs(opts.query_mappings) do
@@ -101,8 +103,7 @@ local function attach_picker_mappings(map, opts)
       map({ "i", "n" }, key, function(prompt_bufnr)
         local entries = get_selected(prompt_bufnr, mapping.keep_open, mapping.allow_multiple)
         if entries then
-          local values = vim.tbl_map(entry_to_value, entries)
-          mapping.callback(unpack(values))
+          mapping.callback(unpack(entries))
         elseif mapping.fallback_to_query then
           local query = get_query(prompt_bufnr, mapping.keep_open)
           if query then
@@ -117,8 +118,8 @@ local function attach_picker_mappings(map, opts)
     map({ "i", "n" }, "<CR>", function(prompt_bufnr)
       local entries = get_selected(prompt_bufnr, false, opts.allow_multiple)
       if entries then
-        local values = vim.tbl_map(entry_to_value, entries)
-        opts.callback(unpack(values))
+        ---@diagnostic disable-next-line: param-type-mismatch
+        opts.callback(unpack(entries))
       end
     end)
   end
@@ -140,8 +141,11 @@ TelescopePicker.find_files = function(self, opts)
     find_command = self:_build_find_cmd(),
     attach_mappings = function(_, map)
       attach_picker_mappings(map, {
-        entry_key = "path",
-        callback = opts.callback,
+        callback = function(entry)
+          if opts.callback then
+            opts.callback(entry.filename)
+          end
+        end,
         query_mappings = opts.query_mappings,
         selection_mappings = opts.selection_mappings,
       })
@@ -164,7 +168,6 @@ TelescopePicker.grep = function(self, opts)
 
   local attach_mappings = function(_, map)
     attach_picker_mappings(map, {
-      entry_key = "path",
       callback = opts.callback,
       query_mappings = opts.query_mappings,
       selection_mappings = opts.selection_mappings,

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -99,7 +99,7 @@ end
 ---@class obsidian.PickerPickOpts
 ---
 ---@field prompt_title string|?
----@field callback fun(value: obsidian.PickerEntry, ...: obsidian.PickerEntry)|?
+---@field callback fun(value: obsidian.PickerEntry|string, ...: obsidian.PickerEntry|string)|?
 ---@field allow_multiple boolean|?
 ---@field query_mappings obsidian.PickerMappingTable|?
 ---@field selection_mappings obsidian.PickerMappingTable|?
@@ -258,35 +258,6 @@ Picker.pick_note = function(self, notes, opts)
     allow_multiple = opts.allow_multiple,
     no_default_mappings = opts.no_default_mappings,
     query_mappings = query_mappings,
-    selection_mappings = selection_mappings,
-  })
-end
-
---- Open picker with a list of tags.
----
----@param tags string[]
----@param opts { prompt_title: string|?, callback: fun(tag: string, ...: string), allow_multiple: boolean|?, no_default_mappings: boolean|? }|? Options.
----
---- Options:
----  `prompt_title`: Title for the prompt window.
----  `callback`: Callback to run with the selected tag(s).
----  `allow_multiple`: Allow multiple selections to pass to the callback.
----  `no_default_mappings`: Don't apply picker's default mappings.
-Picker.pick_tag = function(self, tags, opts)
-  self.calling_bufnr = vim.api.nvim_get_current_buf()
-
-  opts = opts or {}
-
-  local selection_mappings
-  if not opts.no_default_mappings then
-    selection_mappings = self:_tag_selection_mappings()
-  end
-
-  self:pick(tags, {
-    prompt_title = opts.prompt_title or "Tags",
-    callback = opts.callback,
-    allow_multiple = opts.allow_multiple,
-    no_default_mappings = opts.no_default_mappings,
     selection_mappings = selection_mappings,
   })
 end

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -434,8 +434,10 @@ Picker._make_display = function(self, entry)
   end
 
   if entry.display then
+    buf[#buf + 1] = " "
     buf[#buf + 1] = entry.display
   elseif entry.value then
+    buf[#buf + 1] = " "
     buf[#buf + 1] = tostring(entry.value)
   end
 

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -155,32 +155,6 @@ Picker.find_notes = function(self, opts)
   }
 end
 
---- Find templates by filename.
----
----@param opts { prompt_title: string|?, callback: fun(path: string) }|? Options.
----
---- Options:
----  `callback`: Callback to run with the selected template path.
-Picker.find_templates = function(self, opts)
-  self.calling_bufnr = vim.api.nvim_get_current_buf()
-
-  opts = opts or {}
-
-  local templates_dir = api.templates_dir()
-
-  if templates_dir == nil then
-    log.err "Templates folder is not defined or does not exist"
-    return
-  end
-
-  return self:find_files {
-    prompt_title = opts.prompt_title or "Templates",
-    callback = opts.callback,
-    dir = templates_dir,
-    no_default_mappings = true,
-  }
-end
-
 --- Grep search in notes.
 ---
 ---@param opts { prompt_title: string|?, query: string|?, callback: fun(entry: obsidian.PickerEntry)|?, no_default_mappings: boolean|? }|? Options.

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -99,7 +99,7 @@ end
 ---@class obsidian.PickerPickOpts
 ---
 ---@field prompt_title string|?
----@field callback fun(value: any, ...: any)|?
+---@field callback fun(value: obsidian.PickerEntry, ...: obsidian.PickerEntry)|?
 ---@field allow_multiple boolean|?
 ---@field query_mappings obsidian.PickerMappingTable|?
 ---@field selection_mappings obsidian.PickerMappingTable|?
@@ -148,7 +148,7 @@ Picker.find_notes = function(self, opts)
   return self:find_files {
     prompt_title = opts.prompt_title or "Notes",
     dir = Obsidian.dir,
-    callback = opts.callback,
+    callback = opts.callback or api.open_buffer,
     no_default_mappings = opts.no_default_mappings,
     query_mappings = query_mappings,
     selection_mappings = selection_mappings,
@@ -206,7 +206,9 @@ Picker.grep_notes = function(self, opts)
     prompt_title = opts.prompt_title or "Grep notes",
     dir = Obsidian.dir,
     query = opts.query,
-    callback = opts.callback,
+    callback = opts.callback or function(v)
+      return api.open_buffer(v.filename, { line = v.lnum, col = v.col })
+    end,
     no_default_mappings = opts.no_default_mappings,
     query_mappings = query_mappings,
     selection_mappings = selection_mappings,

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -61,7 +61,7 @@ end
 ---@field prompt_title string|?
 ---@field dir string|obsidian.Path|?
 ---@field query string|?
----@field callback fun(path: string)|?
+---@field callback fun(entry: obsidian.PickerEntry)|?
 ---@field no_default_mappings boolean|?
 ---@field query_mappings obsidian.PickerMappingTable
 ---@field selection_mappings obsidian.PickerMappingTable
@@ -183,7 +183,7 @@ end
 
 --- Grep search in notes.
 ---
----@param opts { prompt_title: string|?, query: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|? }|? Options.
+---@param opts { prompt_title: string|?, query: string|?, callback: fun(entry: obsidian.PickerEntry)|?, no_default_mappings: boolean|? }|? Options.
 ---
 --- Options:
 ---  `prompt_title`: Title for the prompt window.

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -99,7 +99,7 @@ end
 ---@class obsidian.PickerPickOpts
 ---
 ---@field prompt_title string|?
----@field callback fun(value: obsidian.PickerEntry|string, ...: obsidian.PickerEntry|string)|?
+---@field callback fun(value: obsidian.PickerEntry, ...: obsidian.PickerEntry)|?
 ---@field allow_multiple boolean|?
 ---@field query_mappings obsidian.PickerMappingTable|?
 ---@field selection_mappings obsidian.PickerMappingTable|?


### PR DESCRIPTION
pickers are historically contributed by different people, the logic is messy. This will enable the simplification of LSP code.

- [x] grep should jump to line and col
- [x] pick.callback gets the `obsidian.PickerEntry`
- [ ] `format_item` callback like `vim.ui.select`
