### PR TITLE
feat: enabled api.toggle_checkbox to function on blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- added an optional `opts` table parameter for api.toggle_checkbox to enable it to insert checkboxes on empty lines with `opts.create_on_empty = true`
+
 ### Changed
 
 - `require"obsidian".module` now can be LSP completed for better api usage.

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -113,8 +113,11 @@ end
 ---
 ---@param states table|nil Optional table containing checkbox states (e.g., {" ", "x"}).
 ---@param line_num number|nil Optional line number to toggle the checkbox on. Defaults to the current line.
-M.toggle_checkbox = function(states, line_num)
-  if not util.in_node { "list", "paragraph" } or util.in_node "block_quote" then
+---@param opts table|nil Optional table of options that alter function behaviour
+M.toggle_checkbox = function(states, line_num, opts)
+  opts = opts or {}
+
+  if not opts.create_on_empty and (not util.in_node { "list", "paragraph" } or util.in_node "block_quote") then
     return
   end
   line_num = line_num or unpack(vim.api.nvim_win_get_cursor(0))
@@ -130,7 +133,7 @@ M.toggle_checkbox = function(states, line_num)
         break
       end
     end
-  elseif Obsidian.opts.checkbox.create_new then
+  elseif opts.create_on_empty or Obsidian.opts.checkbox.create_new then
     local unordered_list_pattern = "^(%s*)[-*+] (.*)"
     if string.match(line, unordered_list_pattern) then
       line = string.gsub(line, unordered_list_pattern, "%1- [ ] %2")


### PR DESCRIPTION
I changed the `api.toggle_checkbox` function to take an additonal `opts` argument, a table that can alter the behaviour of the function. I used this behaviour with the option `opts.create_on_empty` to make the function work on empty lines, as requested in #351. 

I did followed the course of action described in #355. 

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
