### PR TITLE
Remove custom fold options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make sure fold options are remove on `BufLeave`
 - Unified picker interface.
 - `follow_link` will prompt to create on markdown paths that don't exist.
+- `fold` related options are properly set on `BufEnter` and restored on `BufHidden`.
 
 ## [v3.13.1](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.13.1) - 2025-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make sure fold options are remove on `BufLeave`
 - Unified picker interface.
 - `follow_link` will prompt to create on markdown paths that don't exist.
-- `fold` related options are properly set on `BufEnter` and restored on `BufHidden`.
+- remove any fold option overriding, only do fold when fold is setup by the user.
 
 ## [v3.13.1](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.13.1) - 2025-08-01
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ The fork aims to stay close to the original, but fix bugs, include and merge use
 ### Keymaps
 
 - `smart_action`, bind to `<CR>` will:
-  - If cursor is on a link, follow the link
-  - If cursor is on a tag, show all notes with that tag in a picker
-  - If cursor is on a checkbox, toggle the checkbox
-  - If cursor is on a heading, cycle the fold of that heading
+  - If cursor is on a link, follow the link.
+  - If cursor is on a tag, show all notes with that tag in a picker.
+  - If cursor is on a checkbox, toggle the checkbox.
+  - If cursor is on a heading, cycle the fold of that heading, see [Folding](https://github.com/obsidian-nvim/obsidian.nvim/wiki/Folding) to set this up.
 - `nav_link`, bind to `[o` and `]o` will navigate cursor to next valid link in the buffer.
 
 For remapping and creating your own mappings, see [Keymaps](https://github.com/obsidian-nvim/obsidian.nvim/wiki/Keymaps)

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -699,6 +699,17 @@ M.nav_link = function(direction)
   end)
 end
 
+local function has_markdown_folding()
+  if vim.wo.foldmethod == "expr" and vim.wo.foldexpr == "v:lua.vim.treesitter.foldexpr()" then
+    return true
+  elseif vim.g.markdown_folding == 1 then
+    return true
+  elseif vim.wo.foldmethod == "expr" and vim.wo.foldexpr == "MarkdownFold()" then
+    return true
+  end
+  return false
+end
+
 M.smart_action = function()
   local legacy = Obsidian.opts.legacy_commands
   -- follow link if possible
@@ -712,7 +723,11 @@ M.smart_action = function()
   end
 
   if M.cursor_heading() then
-    return "za"
+    if has_markdown_folding() then
+      return "za"
+    else
+      return "<CR>"
+    end
   end
 
   -- toggle task if possible

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -108,8 +108,6 @@ obsidian.setup = function(opts)
     })
   end
 
-  local og_options = {}
-
   -- Complete setup and update workspace (if needed) when entering a markdown buffer.
   vim.api.nvim_create_autocmd({ "BufEnter" }, {
     group = group,

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -127,14 +127,6 @@ obsidian.setup = function(opts)
         return
       end
 
-      for _, name in ipairs { "foldmethod", "foldexpr", "foldlevel" } do
-        og_options[name] = og_options[name] or vim.wo[name]
-      end
-
-      vim.wo.foldmethod = "expr"
-      vim.wo.foldexpr = "v:lua.vim.treesitter.foldexpr()"
-      vim.wo.foldlevel = 99
-
       if opts.comment.enabled then
         vim.o.commentstring = "%%%s%%"
       end
@@ -199,22 +191,6 @@ obsidian.setup = function(opts)
       obsidian.util.fire_callback("leave_note", Obsidian.opts.callbacks.leave_note, client, note)
 
       exec_autocmds("ObsidianNoteLeave", ev.buf)
-    end,
-  })
-
-  vim.api.nvim_create_autocmd("BufHidden", {
-    group = group,
-    pattern = "*.md",
-    callback = function(ev)
-      -- Check if we're in *any* workspace.
-      local workspace = obsidian.Workspace.get_workspace_for_dir(vim.fs.dirname(ev.match), Obsidian.opts.workspaces)
-      if not workspace then
-        return
-      end
-      for _, name in ipairs { "foldmethod", "foldexpr", "foldlevel" } do
-        vim.wo[name] = og_options[name]
-      end
-      og_options = {}
     end,
   })
 


### PR DESCRIPTION
fold is not very in scope for now, but it causes a lot of bugs, we just guide users to setup fold in https://github.com/obsidian-nvim/obsidian.nvim/wiki/Folding

and if they have sensible fold options, trigger `za` in `smart_action`.
