### PR TITLE
feat: `documentSymbol` based toc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Note:link` and `Note:backlinks` as convenience method.
 - LSP `references` and `definition`.
+- LSP `documentSymbol` -> `Obsidian toc`.
 
 ### Changed
 

--- a/lua/obsidian/commands/toc.lua
+++ b/lua/obsidian/commands/toc.lua
@@ -1,25 +1,17 @@
-local util = require "obsidian.util"
-local api = require "obsidian.api"
-
 return function()
-  local note = assert(api.current_note(0, { collect_anchor_links = true }))
-
-  ---@type obsidian.PickerEntry[]
-  local picker_entries = {}
-  for _, anchor in pairs(note.anchor_links) do
-    local display = string.rep("#", anchor.level) .. " " .. anchor.header
-    table.insert(
-      picker_entries,
-      { value = display, display = display, filename = tostring(note.path), lnum = anchor.line }
-    )
-  end
-
-  -- De-duplicate and sort.
-  picker_entries = util.tbl_unique(picker_entries)
-  table.sort(picker_entries, function(a, b)
-    return a.lnum < b.lnum
-  end)
-
   local picker = assert(Obsidian.picker)
-  picker:pick(picker_entries, { prompt_title = "Table of Contents" })
+  vim.lsp.buf.document_symbol {
+    on_list = picker and function(t)
+      local items = vim.tbl_map(function(value)
+        value.display = value.text:sub(7)
+        return value
+      end, t.items)
+      picker:pick(items, {
+        prompt_title = "Table of Contents",
+        callback = function(v)
+          vim.api.nvim_win_set_cursor(0, { v.line, 0 })
+        end,
+      })
+    end,
+  }
 end

--- a/lua/obsidian/commands/toc.lua
+++ b/lua/obsidian/commands/toc.lua
@@ -8,8 +8,11 @@ return function()
       end, t.items)
       picker:pick(items, {
         prompt_title = "Table of Contents",
+        format_item = function(v)
+          return v.display
+        end,
         callback = function(v)
-          vim.api.nvim_win_set_cursor(0, { v.line, 0 })
+          vim.api.nvim_win_set_cursor(0, { v.lnum, 0 })
         end,
       })
     end,

--- a/lua/obsidian/lsp/handlers.lua
+++ b/lua/obsidian/lsp/handlers.lua
@@ -7,6 +7,7 @@ return setmetatable({
   [ms.initialized] = require "obsidian.lsp.handlers.initialized",
   [ms.textDocument_references] = require "obsidian.lsp.handlers.references",
   [ms.textDocument_definition] = require "obsidian.lsp.handlers.definition",
+  [ms.textDocument_documentSymbol] = require "obsidian.lsp.handlers.document_symbol",
 }, {
   __index = function(_, k)
     return function() end

--- a/lua/obsidian/lsp/handlers/document_symbol.lua
+++ b/lua/obsidian/lsp/handlers/document_symbol.lua
@@ -1,0 +1,29 @@
+local api = require "obsidian.api"
+
+---@param params lsp.DocumentSymbolParams
+return function(params, handler)
+  local note = assert(api.current_note(0, { collect_anchor_links = true }))
+
+  ---@type lsp.DocumentSymbol[]
+  local symbols = {}
+  for _, anchor in pairs(note.anchor_links) do
+    local display = string.rep("#", anchor.level) .. " " .. anchor.header
+    local rge = {
+      start = { line = anchor.line - 1, character = 0 },
+      ["end"] = { line = anchor.line - 1, character = 0 },
+    }
+    symbols[#symbols + 1] = {
+      name = display,
+      kind = 1,
+      filename = note.path.filename,
+      range = rge,
+      selectionRange = rge,
+    }
+  end
+
+  table.sort(symbols, function(a, b)
+    return a.range.start.line < b.range.start.line
+  end)
+
+  handler(nil, symbols)
+end

--- a/lua/obsidian/lsp/handlers/initialize.lua
+++ b/lua/obsidian/lsp/handlers/initialize.lua
@@ -5,6 +5,7 @@ local initializeResult = {
     },
     referencesProvider = true,
     definitionProvider = true,
+    documentSymbolProvider = true,
   },
   serverInfo = {
     name = "obsidian-ls",

--- a/lua/obsidian/pickers/_fzf.lua
+++ b/lua/obsidian/pickers/_fzf.lua
@@ -191,7 +191,7 @@ FzfPicker.pick = function(self, values, opts)
       display = value
       value = { value = value }
     else
-      display = self:_make_display(value)
+      display = opts.format_item and opts.format_item(value) or self:_make_display(value)
     end
     if value.valid ~= false then
       display_to_value_map[display] = value

--- a/lua/obsidian/pickers/_mini.lua
+++ b/lua/obsidian/pickers/_mini.lua
@@ -97,7 +97,7 @@ MiniPicker.pick = function(self, values, opts)
       display = value
       value = { value = value }
     else
-      display = self:_make_display(value)
+      display = opts.format_item and opts.format_item(value) or self:_make_display(value)
     end
     if value.valid ~= false then
       entries[#entries + 1] = {

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -121,7 +121,7 @@ SnacksPicker.pick = function(self, values, opts)
       display = value
       value = { value = value }
     else
-      display = self:_make_display(value)
+      display = opts.format_item and opts.format_item(value) or self:_make_display(value)
     end
     table.insert(entries, {
       text = display,

--- a/lua/obsidian/pickers/_telescope.lua
+++ b/lua/obsidian/pickers/_telescope.lua
@@ -219,7 +219,7 @@ TelescopePicker.pick = function(self, values, opts)
   }
 
   local displayer = function(entry)
-    return self:_make_display(entry.raw)
+    return opts.format_item and opts.format_item(entry.raw) or self:_make_display(entry.raw)
   end
 
   local prompt_title = self:_build_prompt {

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -103,7 +103,7 @@ end
 ---@field allow_multiple boolean|?
 ---@field query_mappings obsidian.PickerMappingTable|?
 ---@field selection_mappings obsidian.PickerMappingTable|?
----@field format_item fun(value: obsidian.PickerEntry): string
+---@field format_item (fun(value: obsidian.PickerEntry): string)|?
 
 --- Pick from a list of items.
 ---

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -103,6 +103,7 @@ end
 ---@field allow_multiple boolean|?
 ---@field query_mappings obsidian.PickerMappingTable|?
 ---@field selection_mappings obsidian.PickerMappingTable|?
+---@field format_item fun(value: obsidian.PickerEntry): string
 
 --- Pick from a list of items.
 ---
@@ -396,8 +397,7 @@ end
 ---@param entry obsidian.PickerEntry
 ---
 ---@return string, { [1]: { [1]: integer, [2]: integer }, [2]: string }[]
----@diagnostic disable-next-line: unused-local
-Picker._make_display = function(self, entry)
+Picker._make_display = function(_, entry)
   local buf = {}
   ---@type { [1]: { [1]: integer, [2]: integer }, [2]: string }[]
   local highlights = {}


### PR DESCRIPTION
- as titled
- also adds `format_item` callback to picker:pick, so cleaner display.