### PR TITLE
fix(blink): replace non existing function `get_workspace_for_dir` with `find_workspace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replace non existing function `get_workspace_for_dir` with `find_workspace`
 - Fixed async with minimal functions copied from `vim._async`.
 - No longer notify user `Updated Frontmatter`.
 - `Snacks.picker` now follow `sort_by` and `sort_reversed` settings.

--- a/lua/obsidian/completion/plugin_initializers/blink.lua
+++ b/lua/obsidian/completion/plugin_initializers/blink.lua
@@ -46,16 +46,21 @@ local function add_element_to_list_if_not_exists(list, element)
   end
 end
 
+-- find workspaces of a path
+---@param path string
+---@return obsidian.Workspace
+local function find_workspace(path)
+  return vim.iter(Obsidian.workspaces):find(function(ws)
+    return obsidian.api.path_is_note(path, ws)
+  end)
+end
+
 local function should_return_if_not_in_workspace()
   local current_file_path = vim.api.nvim_buf_get_name(0)
   local buf_dir = vim.fs.dirname(current_file_path)
 
-  local workspace = obsidian.Workspace.get_workspace_for_dir(buf_dir, Obsidian.opts.workspaces)
-  if not workspace then
-    return true
-  else
-    return false
-  end
+  local workspace = find_workspace(buf_dir)
+  return workspace ~= nil
 end
 
 local function log_unexpected_type(config_path, unexpected_type, expected_type)


### PR DESCRIPTION
# Replace function `get_workspace_for_dir` with `find_workspace`

```
Error executing lua callback: ...im/lua/obsidian/completion/plugin_initializers/blink.lua:53: attempt to call field 'get_workspace_for_dir' (a nil value)
stack traceback:
	...im/lua/obsidian/completion/plugin_initializers/blink.lua:53: in function 'should_return_if_not_in_workspace'
	...im/lua/obsidian/completion/plugin_initializers/blink.lua:136: in function 'default_providers'
	...e/nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/init.lua:71: in function 'get_enabled_provider_ids'
	...e/nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/init.lua:104: in function 'get_enabled_providers'
	...e/nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/init.lua:259: in function 'get_signature_help_trigger_characters'
	.../nvim/lazy/blink.cmp/lua/blink/cmp/signature/trigger.lua:102: in function 'is_trigger_character'
	.../nvim/lazy/blink.cmp/lua/blink/cmp/signature/trigger.lua:61: in function 'on_char_added'
	.../nvim/lazy/blink.cmp/lua/blink/cmp/lib/buffer_events.lua:54: in function <.../nvim/lazy/blink.cmp/lua/blink/cmp/lib/buffer_events.lua:44>
```

## Config

```
{
    'obsidian-nvim/obsidian.nvim',
    dependencies = {
        'nvim-lua/plenary.nvim',
    },
    opts = {
        legacy_commands = false,
        completion = {
            nvim_cmp = false,
            blink = true,
        },
        ui = { enable = false },
    },
},
```

## Environment

```
==============================================================================
obsidian:                                                                   ✅

- ✅ OK neovim >= 0.11

obsidian.nvim [Version] ~
- ✅ OK obsidian.nvim v3.13.0 (9a0e71ddae5d0e531d86429699cdbf6059754d43)

obsidian.nvim [Environment] ~
- ✅ OK operating system: Darwin

obsidian.nvim [Config] ~
- ✅ OK • dir: /Users/va.gusev/notes

obsidian.nvim [Pickers] ~
- ✅ OK snacks.nvim: d67a47739dfc652cfcf66c59e929c704a854b37a

obsidian.nvim [Completion] ~
- ✅ OK blink.cmp: 2fcf66aa31e37d4b443c669ec1bf189530dcbf20

obsidian.nvim [Dependencies] ~
- ✅ OK rg: 14.1.1
```

```
==============================================================================
blink.cmp:                                                                1 ❌

System ~
- ✅ OK curl is installed
- ✅ OK git is installed
- ✅ OK Your system is supported by pre-built binaries (aarch64-apple-darwin)
- ✅ OK blink_cmp_fuzzy lib is downloaded/built

Sources ~
- ❌ ERROR Failed to run healthcheck for "blink.cmp" plugin. Exception:
  ...im/lua/obsidian/completion/plugin_initializers/blink.lua:53: attempt to call field 'get_workspace_for_dir' (a nil value)

```

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
