### PR TITLE
fix: remove unused path methods

### DIFF
--- a/lua/obsidian/daily/init.lua
+++ b/lua/obsidian/daily/init.lua
@@ -11,7 +11,7 @@ local daily_note_path = function(datetime)
   datetime = datetime and datetime or os.time()
 
   ---@type obsidian.Path
-  local path = Path:new(Obsidian.dir)
+  local path = Path.new(Obsidian.dir)
 
   local options = Obsidian.opts
 

--- a/lua/obsidian/path.lua
+++ b/lua/obsidian/path.lua
@@ -110,7 +110,7 @@ Path.mt = {
     return a.filename == b.filename
   end,
   __div = function(self, other)
-    return self:joinpath(other)
+    return Path.new(vim.fs.joinpath(self.filename, tostring(other)))
   end,
   __index = function(self, k)
     local raw = rawget(Path, k)
@@ -154,28 +154,18 @@ end
 
 --- Create a new path from a string.
 ---
----@param ... string|obsidian.Path
+---@param p string|obsidian.Path
 ---
 ---@return obsidian.Path
-Path.new = function(...)
+Path.new = function(p)
   local self = Path.init()
 
-  local args = { ... }
-  local arg
-  if #args == 1 then
-    arg = tostring(args[1])
-  elseif #args == 2 and args[1] == Path then
-    arg = tostring(args[2])
-  else
-    error "expected one argument"
+  if Path.is_path_obj(p) then
+    ---@cast p -string
+    return p
   end
 
-  if Path.is_path_obj(arg) then
-    ---@cast arg obsidian.Path
-    return arg
-  end
-
-  self.filename = vim.fs.normalize(tostring(arg))
+  self.filename = vim.fs.normalize(tostring(p))
 
   return self
 end
@@ -194,13 +184,6 @@ Path.temp = function(opts)
   return Path.new(tmpname)
 end
 
---- Get a path corresponding to the current working directory as given by `vim.uv.cwd()`.
----
----@return obsidian.Path
-Path.cwd = function()
-  return assert(Path.new(vim.uv.cwd()))
-end
-
 --- Get a path corresponding to a buffer.
 ---
 ---@param bufnr integer|? The buffer number or `0` / `nil` for the current buffer.
@@ -208,15 +191,6 @@ end
 ---@return obsidian.Path
 Path.buffer = function(bufnr)
   return Path.new(vim.api.nvim_buf_get_name(bufnr or 0))
-end
-
---- Get a path corresponding to the parent of a buffer.
----
----@param bufnr integer|? The buffer number or `0` / `nil` for the current buffer.
----
----@return obsidian.Path
-Path.buf_dir = function(bufnr)
-  return assert(Path.buffer(bufnr):parent())
 end
 
 -------------------------------------------------------------------------------
@@ -267,13 +241,6 @@ Path.is_absolute = function(self)
   else
     return false
   end
-end
-
----@param ... obsidian.Path|string
----@return obsidian.Path
-Path.joinpath = function(self, ...)
-  local args = vim.iter({ ... }):map(tostring):totable()
-  return Path.new(vim.fs.joinpath(self.filename, unpack(args)))
 end
 
 --- Try to resolve a version of the path relative to the other.
@@ -458,87 +425,9 @@ Path.mkdir = function(self, opts)
   self:mkdir { mode = mode }
 end
 
---- Remove the corresponding directory. This directory must be empty.
-Path.rmdir = function(self)
-  local resolved = self:resolve { strict = false }
-
-  if not resolved:is_dir() then
-    return
-  end
-
-  local ok, err_name, err_msg = vim.uv.fs_rmdir(resolved.filename)
-  if not ok then
-    error(err_name .. ": " .. err_msg)
-  end
-end
-
 -- TODO: not implemented and not used, after we get to 0.11 we can simply use vim.fs.rm
 --- Recursively remove an entire directory and its contents.
 Path.rmtree = function(self) end
-
---- Create a file at this given path.
----
----@param opts { mode: integer|?, exist_ok: boolean|? }|?
-Path.touch = function(self, opts)
-  opts = opts or {}
-  local mode = opts.mode or 420
-
-  local resolved = self:resolve { strict = false }
-  if resolved:exists() then
-    local new_time = os.time()
-    vim.uv.fs_utime(resolved.filename, new_time, new_time)
-    return
-  end
-
-  local parent = resolved:parent()
-  if parent and not parent:exists() then
-    error("FileNotFoundError: " .. parent.filename)
-  end
-
-  local fd, err_name, err_msg = vim.uv.fs_open(resolved.filename, "w", mode)
-  if not fd then
-    error(err_name .. ": " .. err_msg)
-  end
-  vim.uv.fs_close(fd)
-end
-
---- Rename this file or directory to the given target.
----
----@param target obsidian.Path|string
----
----@return obsidian.Path
-Path.rename = function(self, target)
-  local resolved = self:resolve { strict = false }
-  target = Path.new(target)
-
-  local ok, err_name, err_msg = vim.uv.fs_rename(resolved.filename, target.filename)
-  if not ok then
-    error(err_name .. ": " .. err_msg)
-  end
-
-  return target
-end
-
---- Remove the file.
----
----@param opts { missing_ok: boolean|? }|?
-Path.unlink = function(self, opts)
-  opts = opts or {}
-
-  local resolved = self:resolve { strict = false }
-
-  if not resolved:exists() then
-    if not opts.missing_ok then
-      error("FileNotFoundError: " .. resolved.filename)
-    end
-    return
-  end
-
-  local ok, err_name, err_msg = vim.uv.fs_unlink(resolved.filename)
-  if not ok then
-    error(err_name .. ": " .. err_msg)
-  end
-end
 
 --- Make a path relative to the vault root, if possible, return a string
 ---

--- a/lua/obsidian/pickers/_fzf.lua
+++ b/lua/obsidian/pickers/_fzf.lua
@@ -146,7 +146,7 @@ FzfPicker.grep = function(self, opts)
   opts = opts and opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir and Path:new(opts.dir) or Obsidian.dir
+  local dir = opts.dir and Path.new(opts.dir) or Obsidian.dir
   local cmd = table.concat(self:_build_grep_cmd(), " ")
   local actions = get_path_actions {
     -- TODO: callback for the full object

--- a/lua/obsidian/pickers/_mini.lua
+++ b/lua/obsidian/pickers/_mini.lua
@@ -24,7 +24,7 @@ MiniPicker.find_files = function(self, opts)
   opts = opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir and Path:new(opts.dir) or Obsidian.dir
+  local dir = opts.dir and Path.new(opts.dir) or Obsidian.dir
 
   local path = mini_pick.builtin.cli({
     command = self:_build_find_cmd(),
@@ -50,7 +50,7 @@ MiniPicker.grep = function(self, opts)
   opts = opts and opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir and Path:new(opts.dir) or Obsidian.dir
+  local dir = opts.dir and Path.new(opts.dir) or Obsidian.dir
 
   local pick_opts = {
     source = {

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -39,7 +39,7 @@ SnacksPicker.find_files = function(self, opts)
   opts = opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir.filename and Path:new(opts.dir.filename) or Obsidian.dir
+  local dir = opts.dir.filename and Path.new(opts.dir.filename) or Obsidian.dir
 
   local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
 
@@ -71,7 +71,7 @@ SnacksPicker.grep = function(self, opts)
   opts = opts or {}
 
   ---@type obsidian.Path
-  local dir = opts.dir.filename and Path:new(opts.dir.filename) or Obsidian.dir
+  local dir = opts.dir.filename and Path.new(opts.dir.filename) or Obsidian.dir
 
   local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
 

--- a/lua/obsidian/pickers/_telescope.lua
+++ b/lua/obsidian/pickers/_telescope.lua
@@ -158,7 +158,7 @@ end
 TelescopePicker.grep = function(self, opts)
   opts = opts or {}
 
-  local cwd = opts.dir and Path:new(opts.dir) or Obsidian.dir
+  local cwd = opts.dir and Path.new(opts.dir) or Obsidian.dir
 
   local prompt_title = self:_build_prompt {
     prompt_title = opts.prompt_title,

--- a/lua/obsidian/templates.lua
+++ b/lua/obsidian/templates.lua
@@ -14,13 +14,13 @@ local M = {}
 M.resolve_template = function(template_name, templates_dir)
   ---@type obsidian.Path|?
   local template_path
-  local paths_to_check = { templates_dir / tostring(template_name), Path:new(template_name) }
+  local paths_to_check = { templates_dir / tostring(template_name), Path.new(template_name) }
   for _, path in ipairs(paths_to_check) do
     if path:is_file() then
       template_path = path
       break
     elseif not vim.endswith(tostring(path), ".md") then
-      local path_with_suffix = Path:new(tostring(path) .. ".md")
+      local path_with_suffix = Path.new(tostring(path) .. ".md")
       if path_with_suffix:is_file() then
         template_path = path_with_suffix
         break

--- a/tests/attachment/test_image.lua
+++ b/tests/attachment/test_image.lua
@@ -8,6 +8,7 @@ local T = new_set {
       local path = Path.temp()
       path:mkdir()
       require("obsidian").setup {
+        legacy_commands = false,
         workspaces = {
           {
             path = tostring(path),

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,53 +1,7 @@
 local Path = require "obsidian.path"
-local obsidian = require "obsidian"
 local child = MiniTest.new_child_neovim()
 
 local M = {}
-
----Create a new Obsidian client in a given vault directory.
----
----@param dir string
----@param opts obsidian.config.Internal|?
----@return obsidian.Client
-local new_from_dir = function(dir, opts)
-  opts = vim.tbl_deep_extend("keep", opts or {}, obsidian.config.default)
-  opts.workspaces = { { path = dir, strict = true } }
-  return obsidian.Client.new(opts)
-end
-
----Get a client in a temporary directory.
----
----@param f fun(client: obsidian.Client)
----@param opts obsidian.config.Internal
-M.with_tmp_client = function(f, dir, opts)
-  local tmp
-  local templates_dir
-  if not dir then
-    tmp = true
-    dir = dir or Path.temp { suffix = "-obsidian" }
-    dir:mkdir { parents = true }
-
-    if opts and opts.templates and opts.templates.folder then
-      templates_dir = dir / opts.templates.folder
-      templates_dir:mkdir()
-    end
-  end
-
-  local client = new_from_dir(tostring(dir), opts)
-  local ok, err = pcall(f, client)
-
-  if tmp then
-    vim.fn.delete(tostring(dir), "rf")
-  end
-
-  if templates_dir then
-    vim.fn.delete(tostring(templates_dir), "rf")
-  end
-
-  if not ok then
-    error(err)
-  end
-end
 
 M.temp_vault = MiniTest.new_set {
   hooks = {
@@ -55,6 +9,7 @@ M.temp_vault = MiniTest.new_set {
       local dir = Path.temp { suffix = "-obsidian" }
       dir:mkdir { parents = true }
       require("obsidian").setup {
+        legacy_commands = false,
         workspaces = { {
           path = tostring(dir),
         } },

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -277,8 +277,8 @@ T["new_note_path"]['should only append one ".md" at the end of the path'] = func
   end
 
   -- Okay to set `id` and `dir` to default values because `note_path_func` is set
-  local path = M._generate_path(nil, "", Path:new())
-  eq(Path:new() / "foo-bar-123.md", path)
+  local path = M._generate_path(nil, "", Path.new())
+  eq(Path.new() / "foo-bar-123.md", path)
 end
 
 T["resolve_title_id_path"] = new_set()
@@ -286,47 +286,47 @@ T["resolve_title_id_path"]["should parse a title that's a partial path and gener
   local title, id, path = M._resolve_title_id_path("notes/Foo", nil, nil, default_note_creation_opts)
   eq("Foo", title)
   eq("foo", id)
-  eq(Path:new(Obsidian.dir) / "notes" / "foo.md", path)
+  eq(Path.new(Obsidian.dir) / "notes" / "foo.md", path)
 
   title, id, path = M._resolve_title_id_path("notes/New Title", nil, nil, default_note_creation_opts)
   eq("New Title", title)
   eq("new-title", id)
-  eq(Path:new(Obsidian.dir) / "notes" / "new-title.md", path)
+  eq(Path.new(Obsidian.dir) / "notes" / "new-title.md", path)
 end
 
 T["resolve_title_id_path"]["should interpret relative directories relative to vault root."] = function()
   local title, id, path = M._resolve_title_id_path("Foo", nil, "new-notes", default_note_creation_opts)
   eq(title, "Foo")
   eq(id, "foo")
-  eq(path, Path:new(Obsidian.dir) / "new-notes" / "foo.md")
+  eq(path, Path.new(Obsidian.dir) / "new-notes" / "foo.md")
 end
 
 T["resolve_title_id_path"]["should parse an ID that's a path"] = function()
   local title, id, path = M._resolve_title_id_path("Foo", "notes/1234-foo", nil, default_note_creation_opts)
   eq(title, "Foo")
   eq(id, "1234-foo")
-  eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "1234-foo.md"))
+  eq(tostring(path), tostring(Path.new(Obsidian.dir) / "notes" / "1234-foo.md"))
 end
 
 T["resolve_title_id_path"]["should parse a title that's an exact path"] = function()
   local title, id, path = M._resolve_title_id_path("notes/foo.md", nil, nil, default_note_creation_opts)
   eq(title, "foo")
   eq(id, "foo")
-  eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "foo.md"))
+  eq(tostring(path), tostring(Path.new(Obsidian.dir) / "notes" / "foo.md"))
 end
 
 T["resolve_title_id_path"]["should ignore boundary whitespace when parsing a title"] = function()
   local title, id, path = M._resolve_title_id_path("notes/Foo  ", nil, nil, default_note_creation_opts)
   eq(title, "Foo")
   eq(id, "foo")
-  eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "foo.md"))
+  eq(tostring(path), tostring(Path.new(Obsidian.dir) / "notes" / "foo.md"))
 end
 
 T["resolve_title_id_path"]["should keep whitespace within a path when parsing a title"] = function()
   local title, id, path = M._resolve_title_id_path("notes/Foo Bar.md", nil, nil, default_note_creation_opts)
   eq(title, "Foo Bar")
   eq(id, "Foo Bar")
-  eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / "Foo Bar.md"))
+  eq(tostring(path), tostring(Path.new(Obsidian.dir) / "notes" / "Foo Bar.md"))
 end
 
 T["resolve_title_id_path"]["should keep allow decimals in ID"] = function()
@@ -340,7 +340,7 @@ T["resolve_title_id_path"]["should generate a new id when the title is just a fo
   local title, id, path = M._resolve_title_id_path("notes/", nil, nil, default_note_creation_opts)
   eq(title, nil)
   eq(#id, 4)
-  eq(tostring(path), tostring(Path:new(Obsidian.dir) / "notes" / (id .. ".md")))
+  eq(tostring(path), tostring(Path.new(Obsidian.dir) / "notes" / (id .. ".md")))
 end
 
 T["resolve_title_id_path"]["should respect configured 'note_path_func'"] = function()
@@ -351,7 +351,7 @@ T["resolve_title_id_path"]["should respect configured 'note_path_func'"] = funct
   local title, id, path = M._resolve_title_id_path("New Note", nil, nil, default_note_creation_opts)
   eq("New Note", title)
   eq("new-note", id)
-  eq(Path:new(Obsidian.dir) / "foo-bar-123.md", path)
+  eq(Path.new(Obsidian.dir) / "foo-bar-123.md", path)
 end
 
 T["resolve_title_id_path"]["should ensure result of 'note_path_func' always has '.md' suffix"] = function()
@@ -362,7 +362,7 @@ T["resolve_title_id_path"]["should ensure result of 'note_path_func' always has 
   local title, id, path = M._resolve_title_id_path("New Note", nil, nil, default_note_creation_opts)
   eq("New Note", title)
   eq("new-note", id)
-  eq(Path:new(Obsidian.dir) / "foo-bar-123.md", path)
+  eq(Path.new(Obsidian.dir) / "foo-bar-123.md", path)
 end
 
 T["resolve_title_id_path"]["should ensure result of 'note_path_func' is always an absolute path and within provided directory"] = function()
@@ -375,7 +375,7 @@ T["resolve_title_id_path"]["should ensure result of 'note_path_func' is always a
   local title, id, path = M._resolve_title_id_path("New Note", nil, Obsidian.dir / "notes", default_note_creation_opts)
   eq("New Note", title)
   eq("new-note", id)
-  eq(Path:new(Obsidian.dir) / "notes" / "foo-bar-123.md", path)
+  eq(Path.new(Obsidian.dir) / "notes" / "foo-bar-123.md", path)
 end
 
 return T

--- a/tests/test_path.lua
+++ b/tests/test_path.lua
@@ -1,6 +1,5 @@
 local Path = require "obsidian.path"
 local api = require "obsidian.api"
-local h = dofile "tests/helpers.lua"
 
 local new_set, eq, has_error = MiniTest.new_set, MiniTest.expect.equality, MiniTest.expect.error
 
@@ -15,7 +14,7 @@ T["new"]["should initialize with both method syntax and regular dot access"] = f
   path = Path.new "README.md"
   eq("README.md", path.filename)
 
-  path = Path:new "README.md"
+  path = Path.new "README.md"
   eq("README.md", path.filename)
 end
 
@@ -24,16 +23,9 @@ T["new"]["should return same object when arg is already a path"] = function()
   eq(path, Path.new(path))
 end
 
-T["new"]["should raise an error if 2 args are passed and the first isn't Path"] = function()
-  has_error(function()
-    ---@diagnostic disable-next-line
-    Path.new(1, "bar")
-  end)
-end
-
 if api.get_os() == api.OSType.Windows then
   T["new"]["should normalize lowercase c drives on windows correctly"] = function()
-    local path = Path:new "c:/foo/bar"
+    local path = Path.new "c:/foo/bar"
     eq(path.filename, "C:/foo/bar")
   end
 end
@@ -54,61 +46,61 @@ end
 T["__eq"] = new_set()
 
 T["__eq"]["should compare with other paths correctly"] = function()
-  eq(true, Path:new "README.md" == Path:new "README.md")
-  eq(true, Path:new "/foo" == Path:new "/foo/")
+  eq(true, Path.new "README.md" == Path.new "README.md")
+  eq(true, Path.new "/foo" == Path.new "/foo/")
 
-  local path = Path:new "README.md"
+  local path = Path.new "README.md"
   local _ = path.name
-  eq(true, path == Path:new "README.md")
+  eq(true, path == Path.new "README.md")
   eq(true, path == Path.new(path))
 end
 
 T["__div"] = new_set()
 
 T["__div"]["should join paths"] = function()
-  assert(Path:new "/foo/" / "bar" == Path:new "/foo/bar")
+  assert(Path.new "/foo/" / "bar" == Path.new "/foo/bar")
 end
 
 T["name"] = new_set()
 
 T["name"]["should return final component"] = function()
-  eq("bar.md", Path:new("/foo/bar.md").name)
+  eq("bar.md", Path.new("/foo/bar.md").name)
 end
 
 T["suffix"] = new_set()
 
 T["suffix"]["should return final suffix"] = function()
-  eq(".md", Path:new("/foo/bar.md").suffix)
-  eq(".gz", Path:new("/foo/bar.tar.gz").suffix)
+  eq(".md", Path.new("/foo/bar.md").suffix)
+  eq(".gz", Path.new("/foo/bar.tar.gz").suffix)
 end
 
 T["suffix"]["should return nil when there is no suffix"] = function()
-  eq(nil, Path:new("/foo/bar").suffix)
+  eq(nil, Path.new("/foo/bar").suffix)
 end
 
 T["suffixes"] = new_set()
 T["suffixes"]["should return all extensions"] = function()
-  eq({ ".md" }, Path:new("/foo/bar.md").suffixes)
-  eq({ ".tar", ".gz" }, Path:new("/foo/bar.tar.gz").suffixes)
+  eq({ ".md" }, Path.new("/foo/bar.md").suffixes)
+  eq({ ".tar", ".gz" }, Path.new("/foo/bar.tar.gz").suffixes)
 end
 
 T["suffixes"]["should return empty list when there is no suffix"] = function()
-  eq({}, Path:new("/foo/bar").suffixes)
+  eq({}, Path.new("/foo/bar").suffixes)
 end
 
 T["stem"] = new_set()
 
 T["stem"]["should return the final name without suffix"] = function()
-  eq("bar", Path:new("/foo/bar.md").stem)
-  eq(nil, Path:new("/").stem)
+  eq("bar", Path.new("/foo/bar.md").stem)
+  eq(nil, Path.new("/").stem)
 end
 
 T["with_suffix"] = new_set()
 
 T["with_suffix"]["should create a new path with the new suffix"] = function()
-  eq(true, Path:new("/foo/bar.md"):with_suffix ".tar.gz" == Path.new "/foo/bar.tar.gz")
-  eq(true, Path:new("/foo/bar.tar.gz"):with_suffix ".bz2" == Path.new "/foo/bar.tar.bz2")
-  eq(true, Path:new("/foo/bar"):with_suffix ".md" == Path.new "/foo/bar.md")
+  eq(true, Path.new("/foo/bar.md"):with_suffix ".tar.gz" == Path.new "/foo/bar.tar.gz")
+  eq(true, Path.new("/foo/bar.tar.gz"):with_suffix ".bz2" == Path.new "/foo/bar.tar.bz2")
+  eq(true, Path.new("/foo/bar"):with_suffix ".md" == Path.new "/foo/bar.md")
 end
 
 T["with_suffix"]["should not add anything else to the filename"] = function()
@@ -129,44 +121,37 @@ end
 T["is_absolute"] = new_set()
 
 T["is_absolute"]["should work for windows or unix paths"] = function()
-  assert(Path:new("/foo/"):is_absolute())
+  assert(Path.new("/foo/"):is_absolute())
   if api.get_os() == api.OSType.Windows then
-    assert(Path:new("C:/foo/"):is_absolute())
-    assert(Path:new("C:\\foo\\"):is_absolute())
+    assert(Path.new("C:/foo/"):is_absolute())
+    assert(Path.new("C:\\foo\\"):is_absolute())
   end
-end
-
-T["joinpath"] = new_set()
-T["joinpath"]["can join multiple"] = function()
-  eq(true, Path.new "foo/bar/baz.md" == Path.new("foo"):joinpath("bar", "baz.md"))
-  eq(true, Path.new "foo/bar/baz.md" == Path.new("foo/"):joinpath("bar/", "baz.md"))
-  eq(true, Path.new "foo/bar/baz.md" == Path.new("foo/"):joinpath("bar/", "/baz.md"))
 end
 
 T["relative_to"] = new_set()
 
 T["relative_to"]["should work on absolute paths"] = function()
-  eq("baz.md", Path:new("/foo/bar/baz.md"):relative_to("/foo/bar/").filename)
-  eq("baz.md", Path:new("/foo/bar/baz.md"):relative_to("/foo/bar").filename)
-  eq("baz.md", Path:new("/baz.md"):relative_to("/").filename)
+  eq("baz.md", Path.new("/foo/bar/baz.md"):relative_to("/foo/bar/").filename)
+  eq("baz.md", Path.new("/foo/bar/baz.md"):relative_to("/foo/bar").filename)
+  eq("baz.md", Path.new("/baz.md"):relative_to("/").filename)
 end
 
 T["relative_to"]["should raise an error when the relative path can't be resolved"] = function()
   has_error(function()
-    Path:new("/bar/bar/baz.md"):relative_to "/foo/"
+    Path.new("/bar/bar/baz.md"):relative_to "/foo/"
   end)
 
   has_error(function()
-    Path:new("bar/bar/baz.md"):relative_to "/bar"
+    Path.new("bar/bar/baz.md"):relative_to "/bar"
   end)
 end
 
 T["relative_to"]["should work on relative paths"] = function()
-  eq("img.png", Path:new("assets/img.png"):relative_to("assets").filename)
-  eq("img.png", Path:new("assets/img.png"):relative_to("./assets").filename)
+  eq("img.png", Path.new("assets/img.png"):relative_to("assets").filename)
+  eq("img.png", Path.new("assets/img.png"):relative_to("./assets").filename)
 
-  eq("assets/img.png", Path:new("assets/img.png"):relative_to("./").filename)
-  eq("assets/img.png", Path:new("./assets/img.png"):relative_to("./").filename)
+  eq("assets/img.png", Path.new("assets/img.png"):relative_to("./").filename)
+  eq("assets/img.png", Path.new("./assets/img.png"):relative_to("./").filename)
 end
 
 T["parent"] = new_set()
@@ -250,9 +235,6 @@ T["mkdir"]["should make a directory"] = function()
 
   dir:mkdir {}
   eq(true, dir:exists())
-
-  dir:rmdir()
-  eq(false, dir:exists())
 end
 
 T["mkdir"]["should make a directory and its parents"] = function()
@@ -264,67 +246,23 @@ T["mkdir"]["should make a directory and its parents"] = function()
   dir:mkdir { parents = true }
   eq(true, base_dir:exists())
   eq(true, dir:exists())
-
-  dir:rmdir()
-  eq(false, dir:exists())
-
-  base_dir:rmdir()
-  eq(false, base_dir:exists())
-end
-
-T["mkdir"]["should rename a file"] = function()
-  local temp_file = Path.temp()
-  temp_file:touch()
-  eq(true, temp_file:is_file())
-
-  local target = Path.temp()
-  eq(false, target:exists())
-
-  temp_file:rename(target)
-  eq(true, target:is_file())
-  eq(false, temp_file:is_file())
-
-  target:unlink()
-  eq(false, target:is_file())
-end
-
-T["mkdir"]["should rename a directory"] = function()
-  local temp_dir = Path.temp()
-  temp_dir:mkdir()
-  eq(true, temp_dir:is_dir())
-
-  local target = Path.temp()
-  eq(false, target:exists())
-
-  temp_dir:rename(target)
-  eq(true, target:is_dir())
-  eq(false, temp_dir:is_dir())
-
-  target:rmdir()
-  eq(false, target:exists())
 end
 
 T["vault_relative_path"] = new_set()
 
 T["vault_relative_path"]["should resolve relative paths"] = function()
-  h.with_tmp_client(function(client)
-    eq(Path.new("foo.md"):vault_relative_path(), "foo.md")
-    eq(Path.new(Obsidian.dir / "foo.md"):vault_relative_path(), "foo.md")
-  end)
+  eq(Path.new("foo.md"):vault_relative_path(), "foo.md")
+  eq(Path.new(Obsidian.dir / "foo.md"):vault_relative_path(), "foo.md")
 end
 
 T["vault_relative_path"]["should error when strict=true and the relative path can't be resolved"] = function()
-  h.with_tmp_client(function(client)
-    has_error(function()
-      Path.new("/Users/petew/foo.md"):vault_relative_path { strict = true }
-    end)
+  has_error(function()
+    Path.new("/Users/petew/foo.md"):vault_relative_path { strict = true }
   end)
 end
 
 T["vault_relative_path"]["should not error when strict=false and the relative path can't be resolved"] = function()
-  h.with_tmp_client(function(client)
-    eq(nil, Path.new("/Users/petew/foo.md"):vault_relative_path())
-  end)
+  eq(nil, Path.new("/Users/petew/foo.md"):vault_relative_path())
 end
 
 return T

--- a/tests/test_workspace.lua
+++ b/tests/test_workspace.lua
@@ -11,9 +11,9 @@ T["should be able to initialize a workspace"] = function()
     path = tmpdir,
     name = "test_workspace",
   }
+  assert(ws)
   eq("test_workspace", ws.name)
   eq(true, tmpdir:resolve() == ws.path)
-  tmpdir:rmdir()
 end
 
 return T


### PR DESCRIPTION
We should move to an as minimal `Path` class as possible, should just use `vim.fs` when possible. 