### PR TITLE
fix(yaml): Allow for mapping key to contain paren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix typo in `open` command.
 - Check if a user specified workspace exists before listing it as valid.
 - Tags in html comments will be properly ignored.
+- Allow for parent (`()`) and `/` char in frontmatter keys.
 
 ## [v3.13.1](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.13.1) - 2025-08-01
 

--- a/lua/obsidian/yaml/parser.lua
+++ b/lua/obsidian/yaml/parser.lua
@@ -207,6 +207,10 @@ Parser._error_msg = function(_, msg, line_num, line_text)
   return full_msg
 end
 
+local YAML_KEY_REGEX = "([a-zA-Z0-9_-()/]+[a-zA-Z0-9_()/ -]*)"
+local YAML_MAPPING_START_REGEX = string.format("%s:$", YAML_KEY_REGEX)
+local YAML_MAPPING_INLINE_REGEX = string.format("%s: (.*)", YAML_KEY_REGEX)
+
 ---@param self obsidian.yaml.Parser
 ---@param i integer
 ---@param lines obsidian.yaml.Line[]
@@ -219,10 +223,10 @@ Parser._try_parse_field = function(self, lines, i, text)
   local _, key, value
 
   -- First look for start of mapping, array, block, etc, e.g. 'foo:'
-  _, _, key = string.find(text, "([a-zA-Z0-9_-]+[a-zA-Z0-9_ -]*):$")
+  _, _, key = string.find(text, YAML_MAPPING_START_REGEX)
   if not key then
     -- Then try inline field, e.g. 'foo: bar'
-    _, _, key, value = string.find(text, "([a-zA-Z0-9_-]+[a-zA-Z0-9_ -]*): (.*)")
+    _, _, key, value = string.find(text, YAML_MAPPING_INLINE_REGEX)
   end
 
   value = value and vim.trim(value) or nil

--- a/tests/yaml/test_parser.lua
+++ b/tests/yaml/test_parser.lua
@@ -120,6 +120,22 @@ T["should parse mappings with spaces for keys"] = function()
   }, result)
 end
 
+T["should parse mappings with parens for keys"] = function()
+  local result = parser:parse(table.concat({
+    "bar: 5",
+    "weight (Kg): 24",
+    "Top speeds (m/s):",
+    "- 5",
+    "- 4.5",
+    "- 2",
+  }, "\n"))
+  eq({
+    bar = 5,
+    ["weight (Kg)"] = 24,
+    ["Top speeds (m/s)"] = { 5, 4.5, 2 },
+  }, result)
+end
+
 T["should ignore comments"] = function()
   local result = parser:parse(table.concat({
     "foo: 1  # this is a comment",


### PR DESCRIPTION
# Allow for frontmatter keys to have paren

Fix the yaml parser used for the frontmatter to allow for parent (`()`) to be used a mapping keys.

- I've update the used regex to allow for the chars `(` and `)` during the yaml mapping parsing.
- I've refactor how the regex is defined for that part to share a common base for the key parsing to prevent missing a spot.
- I've included a test to check if the modification work as expected.

## Screenshots

N/A

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
