### PR TITLE
fix(snacks): always set a layout preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Use the default layout for `Snack.picker` to handle all configurations
 - Replace non existing function `get_workspace_for_dir` with `find_workspace`
 - Fixed async with minimal functions copied from `vim._async`.
 - No longer notify user `Updated Frontmatter`.

--- a/lua/obsidian/pickers/_snacks.lua
+++ b/lua/obsidian/pickers/_snacks.lua
@@ -138,6 +138,7 @@ SnacksPicker.pick = function(self, values, opts)
     items = entries,
     layout = {
       preview = preview,
+      preset = "default",
     },
     format = "text",
     confirm = function(picker, item, action)


### PR DESCRIPTION
Fixes #442 by adding `preset = 'default'` to the layout table.

## Screenshots

TODO Add screenshots to help explain your changes, if applicable.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
