### PR TITLE
feat: `smart_action_key` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `opts.smart_action_key` to change the keymap for smart actions.
+
 ### Changed
 
 - Rename and Backlinks no longer use id and aliases to identify notes, to stay consistent with obsidian app.

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -677,18 +677,21 @@ end
 -- If cursor is on a tag, show all notes with that tag in a picker
 -- If cursor is on a checkbox, toggle the checkbox
 -- If cursor is on a heading, cycle the fold of that heading
-M.smart_action = function()
-  local legacy = Obsidian.opts.legacy_commands
-  if M.cursor_link() then
-    return legacy and "<cmd>ObsidianFollowLink<cr>" or "<cmd>Obsidian follow_link<cr>"
-  elseif M.cursor_tag() then
-    return legacy and "<cmd>ObsidianTags<cr>" or "<cmd>Obsidian tags<cr>"
-  elseif M.cursor_heading() and has_markdown_folding() then
-    return "za"
-  elseif M.cursor_checkbox() or Obsidian.opts.checkbox.create_new then
-    return legacy and "<cmd>ObsidianToggleCheckbox<cr>" or "<cmd>Obsidian toggle_checkbox<cr>"
-  else
-    return "<CR>"
+---@param key string
+M.smart_action = function(key)
+  return function()
+    local legacy = Obsidian.opts.legacy_commands
+    if M.cursor_link() then
+      return legacy and "<cmd>ObsidianFollowLink<cr>" or "<cmd>Obsidian follow_link<cr>"
+    elseif M.cursor_tag() then
+      return legacy and "<cmd>ObsidianTags<cr>" or "<cmd>Obsidian tags<cr>"
+    elseif M.cursor_heading() and has_markdown_folding() then
+      return "za"
+    elseif M.cursor_checkbox() or Obsidian.opts.checkbox.create_new then
+      return legacy and "<cmd>ObsidianToggleCheckbox<cr>" or "<cmd>Obsidian toggle_checkbox<cr>"
+    else
+      return key
+    end
   end
 end
 

--- a/lua/obsidian/autocmds.lua
+++ b/lua/obsidian/autocmds.lua
@@ -45,7 +45,12 @@ vim.api.nvim_create_autocmd({ "BufEnter" }, {
     end
 
     -- Register keymap.
-    vim.keymap.set("n", "<CR>", api.smart_action, { expr = true, buffer = true, desc = "Obsidian Smart Action" })
+    vim.keymap.set(
+      "n",
+      opts.smart_action_key,
+      api.smart_action(opts.smart_action_key),
+      { expr = true, buffer = true, desc = "Obsidian Smart Action" }
+    )
 
     vim.keymap.set("n", "]o", function()
       api.nav_link "next"

--- a/lua/obsidian/config/default.lua
+++ b/lua/obsidian/config/default.lua
@@ -31,6 +31,7 @@ return {
   markdown_link_func = require("obsidian.builtin").markdown_link,
   preferred_link_style = "wiki",
   open_notes_in = "current",
+  smart_action_key = "<CR>",
 
   ---@class obsidian.config.FrontmatterOpts
   ---

--- a/lua/obsidian/types.lua
+++ b/lua/obsidian/types.lua
@@ -56,6 +56,7 @@
 ---@field sort_reversed? boolean
 ---@field search_max_lines? integer
 ---@field open_notes_in? obsidian.config.OpenStrategy
+---@field smart_action_key? string
 ---@field ui? obsidian.config.UIOpts | table<string, any>
 ---@field attachments? obsidian.config.AttachmentsOpts
 ---@field callbacks? obsidian.config.CallbackConfig
@@ -89,6 +90,7 @@
 ---@field sort_reversed boolean|?
 ---@field search_max_lines integer
 ---@field open_notes_in obsidian.config.OpenStrategy
+---@field smart_action_key string
 ---@field ui obsidian.config.UIOpts | table<string, any>
 ---@field attachments obsidian.config.AttachmentsOpts
 ---@field callbacks obsidian.config.CallbackConfig


### PR DESCRIPTION
Adds a `opts.smart_action_key` option to change the default mapping from `<CR>`. I personally use `<CR>` for opening my file picker so I remapped this to `<leader><CR>`.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
