### PR TITLE
fix: `rename` bug due do neovim API version difference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `definition` will properly follow encoded paths.
+- `rename` bug due do neovim API version difference.
 
 ## [v3.14.5](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.14.5) - 2025-11-13
 

--- a/lua/obsidian/lsp/handlers/_rename.lua
+++ b/lua/obsidian/lsp/handlers/_rename.lua
@@ -24,6 +24,8 @@ M.validate = function(name)
   return true
 end
 
+local has_nvim_0_12 = (vim.fn.has "nvim-0.12.0" == 1)
+
 -- TODO: note:rename(self, new_name, callback)
 
 ---@param note obsidian.Note
@@ -58,7 +60,7 @@ M.rename = function(note, new_name, callback)
         documentChanges[#documentChanges + 1] = {
           textDocument = {
             uri = vim.uri_from_fname(match_path),
-            version = vim.NIL,
+            version = has_nvim_0_12 and vim.NIL or nil,
           },
           edits = {
             {


### PR DESCRIPTION
Cause:
- Prior to nightly versions, `apply_text_document_edit` checks if `version` is nil
- on nightly it checks for `vim.NIL`

