### PR TITLE
fix: tag note respects buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `definition` will properly follow encoded paths.
 - `rename` bug due do neovim API version difference.
+- `tag note` bug which ignored picker buffer entry when there is no selection
 
 ## [v3.14.5](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.14.5) - 2025-11-13
 

--- a/lua/obsidian/picker/init.lua
+++ b/lua/obsidian/picker/init.lua
@@ -238,7 +238,7 @@ M._tag_selection_mappings = function()
       desc = "tag note",
       callback = function(...)
         local tags = vim.tbl_map(function(value)
-          return value.user_data
+          return value.user_data ~= nil and value.user_data or value
         end, { ... })
 
         local note = api.current_note(state.calling_bufnr)


### PR DESCRIPTION
# Fix: tag note mapping ignores buffer when no selection

Fixes the bug that when you search for tags and want to tag the note with new tag (no selection, tag from input buffer) the input was ignored and no tag was inserted in the frontmatter. I actually used this feature quite a lot before, but I don't remember which release have broken it.

## Screenshots

<img width="1502" height="1215" alt="obraz" src="https://github.com/user-attachments/assets/0c4ed103-c1cd-4343-a28b-95ce174ab070" />

In this screenshot we have the situation mentioned above. Currently tag note <C-x> does not work with that `newtag` tag
## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
