### PR TITLE
chore: add legacy_commands in install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ return {
   ---@module 'obsidian'
   ---@type obsidian.config
   opts = {
+    legacy_commands = false, -- this will be removed in the next major release
     workspaces = {
       {
         name = "personal",


### PR DESCRIPTION
What does the PR do?

The installation snippet with lazy.nvim doesn't set this option to `false` by default, which when installing the plugin yells a warning to the new user

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
