### PR TITLE
fix: auto-save parent file after link_new and extract_note #552

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fzf` template picker fix.
 - relaxed the condition to trigger folds in `smart_action`.
 - Fixed visual selection corrupting multibyte UTF-8 characters (Cyrillic, CJK, emoji, etc.) in commands like `:Obsidian link_new` and `:Obsidian extract_note`. The fix uses LSP TextEdit with proper UTF-8 byte offsets, enabling future code actions preview support.
+- `link_new` and `extract_note` now auto-save the parent file so backlinks are immediately discoverable.
 
 ## [v3.14.6](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.14.6) - 2025-11-23
 

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -880,6 +880,9 @@ M.link_new = function(label)
 
   local note = require("obsidian.note").create { title = label }
   replace_selection(viz, note:format_link { label = label })
+
+  -- Save file so backlinks search (ripgrep) can find the new link
+  vim.cmd "silent! write"
 end
 
 ---Extract the selected text into a new note
@@ -913,6 +916,9 @@ M.extract_note = function(label)
   -- replace selection with link to new note
   local link = note:format_link()
   replace_selection(viz, link)
+
+  -- Save file so backlinks search (ripgrep) can find the new link
+  vim.cmd "silent! write"
 
   -- add the selected text to the end of the new note
   note:open { sync = true }


### PR DESCRIPTION
### Summary
- link_new and extract_note now auto-save the parent file so backlinks are immediately discoverable
### Problem

After using :Obsidian link_new or :Obsidian extract_note, the newly created note shows 0 backlinks in the statusline, even though a link to it was just created.
Running :Obsidian backlinks correctly navigates to the parent note, but the count stays at 0 until manual :w.

### Cause
The parent file (containing the new link) is not saved to disk after inserting the link. Since backlinks search uses ripgrep on the filesystem, it can't find the link that exists only in the buffer.

###Solution
Auto-save the parent file with vim.cmd "silent! write" after replace_selection() in both link_new and extract_note functions.

fixes #552 

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
