### PR TITLE
fix: `:Obsidian new` allows multiple word argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove incorrect `Note.crete`'s `tilte` field usage.
 - Remove duplicates in note with multiple tags in `:Obsidian tags`.
 - Picker will highlight search results as best as the backend supports.
+- `:Obsidian new` allows multiple word argument.
 
 ## [v3.15.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.15.0) - 2025-12-25
 

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -225,7 +225,7 @@ M.register("tomorrow", { nargs = 0 })
 
 M.register("dailies", { nargs = "*" })
 
-M.register("new", { nargs = "?" })
+M.register("new", { nargs = "*" })
 
 M.register("open", { nargs = "?", complete = M.note_complete })
 


### PR DESCRIPTION
resolves #572 
