### PR TITLE
fix: escape ripgrep globs in file search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Picker will highlight search results as best as the backend supports.
 - `:Obsidian new` allows multiple word argument.
 - `daily_notes` note creation will not be effected by global `note_id_func`.
+- completion input with `rg` globs like `{` are escaped properly.
 
 ## [v3.15.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.15.0) - 2025-12-25
 

--- a/tests/search/test_ripgrep.lua
+++ b/tests/search/test_ripgrep.lua
@@ -24,4 +24,50 @@ T["grep_cmd works"] = function()
   eq(out.code, 0)
 end
 
+-- https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#manual-filtering-globs
+T["escape_rg_glob: leaves normal text unchanged"] = function()
+  eq(M._escape_rg_glob "hello-world_123", "hello-world_123")
+end
+
+T["escape_rg_glob: escapes braces (alternation)"] = function()
+  eq(M._escape_rg_glob "{foo}", "[{]foo[}]")
+end
+
+T["escape_rg_glob: escapes wildcards"] = function()
+  eq(M._escape_rg_glob "*a?b*", "[*]a[?]b[*]")
+end
+
+T["escape_rg_glob: escapes character classes"] = function()
+  eq(M._escape_rg_glob "[ab]", "[[]ab[]]")
+end
+
+T["escape_rg_glob: escapes closing bracket correctly"] = function()
+  eq(M._escape_rg_glob "]", "[]]")
+end
+
+T["escape_rg_glob: escapes backslash"] = function()
+  eq(M._escape_rg_glob [[a\b\c]], [[a[\]b[\]c]])
+end
+
+T["escape_rg_glob: handles leading ! (negation)"] = function()
+  eq(M._escape_rg_glob "!foo", "[!]foo")
+end
+
+T["escape_rg_glob: does not special-case ! when not leading"] = function()
+  eq(M._escape_rg_glob "foo!bar", "foo!bar")
+end
+
+T["escape_rg_glob: realistic URL-like input stays literal"] = function()
+  local input = "https://example.com/{foo}[bar]?a=1*b"
+  local expected = "https://example.com/[{]foo[}][[]bar[]][?]a=1[*]b"
+  eq(M._escape_rg_glob(input), expected)
+end
+
+T["escape_rg_glob: roundtrip-ish: embed in *...* glob safely"] = function()
+  local input = "*{sdsds*.md"
+  local glob = "*" .. M._escape_rg_glob(input) .. "*"
+  local expected = "*[*][{]sdsds[*].md*"
+  eq(glob, expected)
+end
+
 return T


### PR DESCRIPTION
#37 

root cause is `{` is a ripgrep glob pattern
