### PR TITLE
fix(search): improve tag parsing to avoid false positives in code and frontmatter

### DIFF
--- a/lua/obsidian/parse/tags.lua
+++ b/lua/obsidian/parse/tags.lua
@@ -1,6 +1,7 @@
 local lpeg = vim.lpeg
 local P, R, S = lpeg.P, lpeg.R, lpeg.S
 local C, Cp, Ct = lpeg.C, lpeg.Cp, lpeg.Ct
+local backticked = P "`" * (P(1) - P "`")^0 * P "`"
 
 local M = {}
 
@@ -34,11 +35,12 @@ local boundary = (utf8_char - keyword_prev - P "\\") * core
 local tag_at_bol = P(function(_, i)
   return i == 1 and i or nil
 end) * core
-local one_tag = tag_at_bol + boundary
+local header = P("#") ^ 1 * P(" ") -- markdown headers
+local one_tag = (tag_at_bol + boundary) * -S(" ")
 
 -- Find all occurrences anywhere in the line:
 -- (skip 1 UTF-8 char at a time until a match is found; repeat)
-local all_tags = Ct(((utf8_char - one_tag) ^ 0 * one_tag) ^ 0)
+local all_tags = Ct(((backticked + header + utf8_char - one_tag) ^ 0 * one_tag) ^ 0)
 
 --- Find Obsidian-style tags in a markdown line (Unicode-safe).
 --- UTF-8 indices are 0-based and end-exclusive.

--- a/lua/obsidian/search/init.lua
+++ b/lua/obsidian/search/init.lua
@@ -882,11 +882,27 @@ M.find_tags_async = function(term, callback, opts)
       and note.has_frontmatter
       and match_data.line_number < note.frontmatter_end_line
       and note.tags ~= nil
-      and (vim.startswith(line, "tags:") or string.match(line, "%s*- "))
     then
-      local tag = vim.trim(string.sub(line, 3)) -- HACK: works because we force '  - tag'
-      if string.match(tag, "^" .. M.Patterns.TagCharsRequired .. "$") then
-        add_match(tag, path, note, match_data.line_number, line)
+      local tag
+      if vim.startswith(line, "tags:") then
+        tag = vim.trim(string.sub(line, 6))
+      elseif string.match(line, "^%s*- ") then
+        tag = vim.trim(string.sub(line, 3))
+      end
+
+      if tag then
+        -- Verify this tag actually exists in the note's parsed tags
+        local is_real_tag = false
+        for _, t in ipairs(note.tags) do
+          if t == tag then
+            is_real_tag = true
+            break
+          end
+        end
+
+        if is_real_tag and string.match(tag, "^" .. M.Patterns.TagCharsRequired .. "$") then
+          add_match(tag, path, note, match_data.line_number, line)
+        end
       end
     end
   end

--- a/tests/search/test_search_tags.lua
+++ b/tests/search/test_search_tags.lua
@@ -71,4 +71,30 @@ end, {})
   eq(res[2].line, 7) -- 1-indexed
 end
 
+
+T["should ignore other frontmatter fields that look like tags"] = function()
+  local root = child.lua_get [[tostring(Obsidian.dir)]]
+  local filepath = vim.fs.joinpath(root, "frontmatter_test.md")
+  local file = [==[
+---
+tags:
+  - real-tag
+Other Field:
+  - not-a-tag
+---
+]==]
+  vim.fn.writefile(vim.split(file, "\n"), filepath)
+  
+  child.lua [[
+local search = require"obsidian.search"
+search.find_tags_async("", function(res)
+   _G.res = res
+end, {})
+  ]]
+  vim.uv.sleep(100)
+  local res = child.lua_get [[res]]
+
+  eq(#res, 1)
+  eq(res[1].tag, "real-tag")
+end
 return T

--- a/tests/util/test_parse_tag.lua
+++ b/tests/util/test_parse_tag.lua
@@ -74,4 +74,19 @@ T["should find non-English tags"] = function()
   eq(1, #M.parse_tags "#项目_计划")
 end
 
+
+T["should ignore tags in backticks"] = function()
+  local s = "`#not-a-tag` and #real-tag"
+  eq({ { 16, 25, "Tag" } }, M.parse_tags(s))
+end
+
+T["should ignore markdown headers"] = function()
+  local s = "### Header Not A Tag"
+  eq({}, M.parse_tags(s))
+end
+
+T["should ignore header links"] = function()
+  local s = "[[Note#Header Link]]"
+  eq({}, M.parse_tags(s))
+end
 return T


### PR DESCRIPTION
## Summary
This PR improves tag parsing to avoid common false positives from code comments (MIPS, assembly), Markdown headers, and unrelated frontmatter fields.

### Changes
1. **Inline Parsing (`parse/tags.lua`)**:
   - Updated the lpeg grammar to skip content inside backticks. This fixes issues where code comments starting with `#` were detected as tags.
   - Added logic to explicitly skip Markdown headers (lines starting with `#` followed by a space).
   - Ensured that `#` followed by a space is never parsed as a tag.
2. **Frontmatter Parsing (`search/init.lua`)**:
   - Updated `find_tags_async` to verify that `  - tag` lines in the frontmatter are actually present in the `note.tags` table.
   - This prevents values from unrelated frontmatter keys (like `Course: - CS335` or `AI Topics: - upscaling`) from being incorrectly detected as tags.

### Verification
- Verified manually with various edge cases in note content.
- Added regression tests in `tests/util/test_parse_tag.lua` and `tests/search/test_search_tags.lua`.