### PR TITLE
fix: template customization fallback to global config if omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Template customizations falls back to global configuration if not provided
+
 ### Changed
 
 - `completion`'s create note action also use `opts.note.template`.

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -175,8 +175,8 @@ Note._get_creation_opts = function(opts)
   for key, cfg in pairs(Obsidian.opts.templates.customizations) do
     if key:lower() == stem then
       ret = {
-        notes_subdir = cfg.notes_subdir,
-        note_id_func = cfg.note_id_func,
+        notes_subdir = cfg.notes_subdir or ret.notes_subdir,
+        note_id_func = cfg.note_id_func or ret.note_id_func,
         new_notes_location = "notes_subdir",
       }
     end

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -294,6 +294,20 @@ T["_get_note_creation_opts"]["should load customizations for existing template"]
   eq(spec.note_id_func, zettelConfig.note_id_func)
 end
 
+T["_get_note_creation_opts"]["should fallback to global note_id_func if customization omits it"] = function()
+  local partialConfig = {
+    notes_subdir = "partials",
+  }
+  Obsidian.opts.templates.customizations = {
+    Partial = partialConfig,
+  }
+  local temp_template = api.templates_dir() / "Partial"
+  vim.fn.writefile({}, tostring(temp_template))
+  local spec = assert(M._get_creation_opts { template = "Partial" })
+  eq(spec.notes_subdir, "partials")
+  eq(spec.note_id_func, Obsidian.opts.note_id_func)
+end
+
 T["new_note_path"] = new_set()
 
 T["new_note_path"]['should only append one ".md" at the end of the path'] = function()


### PR DESCRIPTION
Fixes note_id_func being nil when trying to create a new note from template that didn't provide a note_id_func

This closes #661 

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
