### PR TITLE
fix: create_new_note also use opts.note.template by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `completion`'s create note action also use `opts.note.template`.
+- `create_new_note` action also use `opts.note.template`.
 
 ### Fixed
 


### PR DESCRIPTION
What does the PR do?
Fix #668 
The[`create_new_note`](https://github.com/obsidian-nvim/obsidian.nvim/blob/main/lua/obsidian/lsp/handlers/_definition.lua#L24) function used in `open_note` does not add alias or title by default, this pr fix this by adding `opts.note.template `to it's default behavior

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
