### PR TITLE
fix: Merge user edits and frontmatter updates into single undo operation

### DIFF
--- a/lua/obsidian/autocmds.lua
+++ b/lua/obsidian/autocmds.lua
@@ -91,7 +91,9 @@ vim.api.nvim_create_autocmd("FileType", {
       exec_autocmds "ObsidianNoteWritePre"
       local note = Note.from_buffer(ev.buf)
       if not vim.b[ev.buf].obsidian_help then
+        pcall(vim.cmd, "undojoin")
         note:update_frontmatter(ev.buf) -- Update buffer with new frontmatter.
+        pcall(vim.cmd, "undojoin")
       end
     end)
     create_autocmd("BufWritePost", args.buf, function(ev)


### PR DESCRIPTION
# Merge user edits and frontmatter updates into single undo operation

Use undojoin before and after frontmatter updates in BufWritePre autocmd to combine user modifications and automatic frontmatter changes into a single undo step. This improves UX by allowing users to undo both changes with a single 'u' command.

Wrap undojoin calls with pcall to handle cases where it's not available (e.g., after fugitive operations).

Fixes #690

## Screenshots


## PR Checklist

- [X] The PR contains a description of the changes
- [X] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
