### PR TITLE
fix: create_new_note action should write to the new created note buff…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed checkbox toggle affecting incorrect lines when stale visual selection marks are present.
 - Goto definition should not throw error if templates.folder is not set.
 - Fixed completion insertion misaligned under CJK languages
-- Fixed completion references source unable to fetch by rolling back the `find_workspace` function in `Path.vault_relative_path`
+- Fixed completion references source unable to fetch by passing `Path` to `api.resolve_workspace_dir` function
+- Fixed `create_new_note` action should write to the new created note buffer instead of the previous one
 
 ## [v3.15.8](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.15.8) - 2026-02-04
 

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -388,6 +388,7 @@ M.new = function(id, callback)
   local note = Note.create {
     id = id,
     template = Obsidian.opts.note.template, -- TODO: maybe unneed when creating, or set as a field that note carries
+    should_write = true,
   }
 
   if callback then
@@ -395,9 +396,6 @@ M.new = function(id, callback)
   else
     -- Open the note in a new buffer.
     note:open { sync = true }
-    note:write_to_buffer {
-      template = Obsidian.opts.note.template,
-    }
   end
 end
 

--- a/lua/obsidian/lsp/handlers/_definition.lua
+++ b/lua/obsidian/lsp/handlers/_definition.lua
@@ -28,7 +28,6 @@ local function create_new_note(location, callback)
   if confirm == "Yes" then
     actions.new(location, function(note)
       callback { note:_location() }
-      note:write_to_buffer { template = Obsidian.opts.note.template }
     end)
   elseif confirm == "Yes With Template" then
     actions.new_from_template(location, nil, function(note)


### PR DESCRIPTION
 Fix #688
 But it might also makes `Note.write_to_buffer` obsolete


## PR Checklist

- [x] The PR contains a description of the changes
- [x] read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
