### PR TITLE
fix: deep merge template substitutions with defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Goto definition should not throw error if templates.folder is not set.
 - Fixed completion insertion misaligned under CJK languages
 - Fixed completion references source unable to fetch by rolling back the `find_workspace` function in `Path.vault_relative_path`
+- Fixed custom template substitutions silently replacing default substitutions
+  (`date`, `time`, `title`, `id`, `path`) due to shallow merge.
 
 ## [v3.15.8](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.15.8) - 2026-02-04
 
@@ -692,7 +694,7 @@ There's a lot of new features and improvements here that I'm really excited abou
    We also support links to headers within the same note, like for a table of contents, e.g. `[[#Heading 1]]`, `[[#heading-1|Heading]]`, `[[#^block-1]]`.
 
 1. 📲 A basic callback system to let you easily customize obisidian.nvim's behavior even more. There are currently 4 events: `post_setup`, `enter_note`, `pre_write_note`, and `post_set_workspace`. You can define a function for each of these in your config.
-2. 🔭 Improved picker integrations (especially for telescope), particular for the `:ObsidianTags` command. See <https://github.com/epwalsh/obsidian.nvim/discussions/450> for a demo.
+1. 🔭 Improved picker integrations (especially for telescope), particular for the `:ObsidianTags` command. See <https://github.com/epwalsh/obsidian.nvim/discussions/450> for a demo.
 
 Full changelog below 👇
 

--- a/lua/obsidian/config/init.lua
+++ b/lua/obsidian/config/init.lua
@@ -319,6 +319,8 @@ See: https://github.com/obsidian-nvim/obsidian.nvim/wiki/Keymaps]]
   opts.picker = tbl_override(defaults.picker, opts.picker)
   opts.daily_notes = tbl_override(defaults.daily_notes, opts.daily_notes)
   opts.templates = tbl_override(defaults.templates, opts.templates)
+  opts.templates.substitutions =
+    vim.tbl_extend("force", defaults.templates.substitutions, opts.templates.substitutions or {})
   opts.ui = tbl_override(defaults.ui, opts.ui)
   opts.attachments = tbl_override(defaults.attachments, opts.attachments)
   opts.statusline = tbl_override(defaults.statusline, opts.statusline)

--- a/tests/test_templates.lua
+++ b/tests/test_templates.lua
@@ -95,4 +95,30 @@ T["substitute_template_variables()"]["should pass suffix to substitution functio
   eq("value is hello", M.substitute_template_variables(text, tmp_template_context()))
 end
 
+T["config.normalize()"] = new_set()
+
+T["config.normalize()"]["custom substitutions should not clobber defaults"] = function()
+  local config = require "obsidian.config"
+  local opts = config.normalize {
+    workspaces = { { path = tostring(Obsidian.dir) } },
+    templates = {
+      substitutions = {
+        weekday = function()
+          return "Monday"
+        end,
+      },
+    },
+  }
+
+  -- User's custom substitution should be present.
+  eq("function", type(opts.templates.substitutions.weekday))
+
+  -- Default substitutions should also be present.
+  eq("function", type(opts.templates.substitutions.date))
+  eq("function", type(opts.templates.substitutions.time))
+  eq("function", type(opts.templates.substitutions.title))
+  eq("function", type(opts.templates.substitutions.id))
+  eq("function", type(opts.templates.substitutions.path))
+end
+
 return T


### PR DESCRIPTION
## Summary

- Custom `templates.substitutions` in user config silently replaces all default substitutions (`date`, `time`, `title`, `id`, `path`) because `tbl_override` uses `vim.tbl_extend` which is a shallow merge
- Users who add custom substitutions (e.g. `week`, `day`) get unexpected "Enter value for 'date'" prompts when templates contain `{{date}}`
- Fix: add a nested `vim.tbl_extend` for `substitutions` so user entries extend the defaults

## Reproduction

```lua
require("obsidian").setup({
  templates = {
    substitutions = {
      week = function() return os.date("%V") end,
    },
  },
})
```

Then use a template containing `{{date}}` — the user is prompted to enter a value because the default `date` substitution was lost.

## Test plan

- [x] Added test in `test_templates.lua` verifying custom substitutions don't clobber defaults
- [x] Full test suite passes (365 cases, 0 failures)