### PR TITLE
feat(note): consolidate note creation options under note.* and add note.info (#575)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `note.id_func`, `note.path_func`, and `note.info` configuration options.
+
+### Changed
+
+- Completion docs now use `note.info` (with fallback to `note:display_info()`).
+- Top-level `note_id_func` and `note_path_func` are now treated as legacy aliases for `note.id_func` and `note.path_func`.
+
 ### Fixed
 - `:Obsidian tags` support Unicode tags.
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,40 @@ vim.pack.add {
 
 To configure obsidian.nvim, pass your custom options that are different from [default options](https://github.com/obsidian-nvim/obsidian.nvim/blob/main/lua/obsidian/config/default.lua) to `require"obsidian".setup()`.
 
+### Note creation options
+
+You can configure note creation behavior under `note`:
+
+```lua
+require("obsidian").setup {
+  note = {
+    -- Generate IDs from note titles.
+    id_func = function(title)
+      return title or tostring(os.time())
+    end,
+
+    -- Optional custom path strategy.
+    path_func = function(spec)
+      return spec.dir / tostring(spec.id)
+    end,
+
+    -- Default template for `:Obsidian new`.
+    template = "default.md",
+
+    -- Preview text used for completion/hover docs.
+    info = function(note, opts)
+      return {
+        "# " .. note:display_name(),
+        "id: " .. tostring(note.id),
+        "path: " .. tostring(note.path),
+      }
+    end,
+  },
+}
+```
+
+Top-level `note_id_func` and `note_path_func` are still supported for backwards compatibility, but `note.id_func` and `note.path_func` are preferred.
+
 ## 🤝 Contributing
 
 Please read the [CONTRIBUTING](https://github.com/obsidian-nvim/obsidian.nvim/blob/main/CONTRIBUTING.md) guide before submitting a pull request.

--- a/lua/obsidian/completion/sources/base/new.lua
+++ b/lua/obsidian/completion/sources/base/new.lua
@@ -143,7 +143,7 @@ function NewNoteSourceBase:process_completion(cc)
     }
     local documentation = {
       kind = "markdown",
-      value = new_note:display_info {
+      value = new_note:info {
         label = "Create: " .. new_text,
       },
     }

--- a/lua/obsidian/completion/sources/base/refs.lua
+++ b/lua/obsidian/completion/sources/base/refs.lua
@@ -325,7 +325,7 @@ function RefsSourceBase:update_completion_options(cc, label, alt_label, matching
 
       documentation = {
         kind = "markdown",
-        value = note:display_info {
+        value = note:info {
           label = new_text,
           anchor = option.anchor,
           block = option.block,

--- a/lua/obsidian/config/default.lua
+++ b/lua/obsidian/config/default.lua
@@ -17,6 +17,7 @@ return {
 
   workspaces = {},
   log_level = vim.log.levels.INFO,
+  -- Legacy top-level aliases. Prefer `note.id_func` and `note.path_func`.
   note_id_func = require("obsidian.builtin").zettel_id,
   note_path_func = function(spec)
     local path = spec.dir / tostring(spec.id)
@@ -40,8 +41,19 @@ return {
   ------
   ---```
   ---
+  ---Function to generate note IDs.
+  ---@field id_func? (fun(title: string|?, path: obsidian.Path|?): string)
+  ---Function to generate note paths.
+  ---@field path_func? fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path
   ---@field template string|?
+  ---Function to build preview text for completion/hover.
+  ---@field info? fun(note: obsidian.Note, opts: { label: string|?, anchor: obsidian.note.HeaderAnchor|?, block: obsidian.note.Block|? }|?): string|string[]
   note = {
+    id_func = require("obsidian.builtin").zettel_id,
+    path_func = function(spec)
+      local path = spec.dir / tostring(spec.id)
+      return path
+    end,
     template = (function()
       local root = vim.iter(vim.api.nvim_list_runtime_paths()):find(function(path)
         return vim.endswith(path, "obsidian.nvim")
@@ -51,6 +63,9 @@ return {
       end
       return vim.fs.joinpath(root, "data/default_template.md")
     end)(),
+    info = function(note, opts)
+      return note:display_info(opts)
+    end,
   },
 
   ---@class obsidian.config.FrontmatterOpts
@@ -110,6 +125,8 @@ return {
     ---
     ---@field notes_subdir? string
     ---@field note_id_func? (fun(title: string|?, path: obsidian.Path|?): string)
+    ---@field note_path_func? (fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path)
+    ---@field template? string
     customizations = {},
   },
 

--- a/lua/obsidian/config/init.lua
+++ b/lua/obsidian/config/init.lua
@@ -220,6 +220,24 @@ See: https://github.com/obsidian-nvim/obsidian.nvim/wiki/Keymaps]]
     opts.templates.subdir = nil
   end
 
+  if opts.note_id_func ~= nil then
+    opts.note = opts.note or {}
+    if opts.note.id_func == nil then
+      opts.note.id_func = opts.note_id_func
+    end
+    opts.note_id_func = nil
+    deprecate("top-level 'note_id_func'", "note.id_func", "4.0")
+  end
+
+  if opts.note_path_func ~= nil then
+    opts.note = opts.note or {}
+    if opts.note.path_func == nil then
+      opts.note.path_func = opts.note_path_func
+    end
+    opts.note_path_func = nil
+    deprecate("top-level 'note_path_func'", "note.path_func", "4.0")
+  end
+
   if opts.ui and opts.ui.checkboxes then
     log.warn_once [[The 'ui.checkboxes' no longer effect the way checkboxes are ordered, use `checkbox.order`. See: https://github.com/obsidian-nvim/obsidian.nvim/issues/262]]
   end
@@ -329,6 +347,10 @@ See: https://github.com/obsidian-nvim/obsidian.nvim/wiki/Keymaps]]
   opts.frontmatter = tbl_override(defaults.frontmatter, opts.frontmatter)
   opts.search = tbl_override(defaults.search, opts.search)
   opts.note = tbl_override(defaults.note, opts.note)
+
+  -- Keep legacy aliases for backwards compatibility.
+  opts.note_id_func = opts.note.id_func
+  opts.note_path_func = opts.note.path_func
 
   ---------------
   -- Validate. --

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -128,13 +128,17 @@ end
 ---
 ---@param id string The note ID
 ---@param dir obsidian.Path The note path
+---@param title string|? The note title
+---@param path_func fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path
 ---@return obsidian.Path
 ---@private
-Note._generate_path = function(id, dir)
+Note._generate_path = function(id, dir, title, path_func)
   ---@type obsidian.Path
   local path
 
-  path = Path.new(Obsidian.opts.note_path_func { id = id, dir = dir })
+  path_func = path_func or Obsidian.opts.note_path_func
+
+  path = Path.new(path_func { id = id, dir = dir, title = title })
 
   -- NOTE: `opts.dir` should always be absolute, but for extra safety we handle the case where
   if not path:is_absolute() and (dir:is_absolute() or not dir:is_parent_of(path)) then
@@ -155,15 +159,21 @@ end
 ---@return obsidian.note.NoteCreationOpts The strategy to use for creating the note
 ---@private
 Note._get_creation_opts = function(opts)
+  opts = opts or {}
+
+  local note_opts = Obsidian.opts.note or {}
+
   --- @type obsidian.note.NoteCreationOpts
   local ret = {
     notes_subdir = Obsidian.opts.notes_subdir,
-    note_id_func = Obsidian.opts.note_id_func,
+    note_id_func = Obsidian.opts.note_id_func or note_opts.id_func,
+    note_path_func = Obsidian.opts.note_path_func or note_opts.path_func,
+    template = opts.template or note_opts.template,
     new_notes_location = Obsidian.opts.new_notes_location,
   }
 
   local resolve_template = require("obsidian.templates").resolve_template
-  local success, template_path = pcall(resolve_template, opts.template, api.templates_dir())
+  local success, template_path = pcall(resolve_template, ret.template, api.templates_dir())
 
   if not success then
     return ret
@@ -177,6 +187,8 @@ Note._get_creation_opts = function(opts)
       ret = {
         notes_subdir = cfg.notes_subdir or ret.notes_subdir,
         note_id_func = cfg.note_id_func or ret.note_id_func,
+        note_path_func = cfg.note_path_func or ret.note_path_func,
+        template = cfg.template or ret.template,
         new_notes_location = "notes_subdir",
       }
     end
@@ -213,13 +225,14 @@ end
 --- Resolves the ID, and path for a new note.
 ---
 ---@param opts obsidian.note.NoteOpts Strategy for resolving note path and title
+---@param creation_opts obsidian.note.NoteCreationOpts|?
 ---@return string id
 ---@return obsidian.Path path
 ---@return string|? title
 ---@private
-Note._resolve_id_path = function(opts)
+Note._resolve_id_path = function(opts, creation_opts)
   local id, dir = opts.id, opts.dir
-  local creation_opts = Note._get_creation_opts(opts or {})
+  creation_opts = creation_opts or Note._get_creation_opts(opts or {})
 
   if id then
     id = vim.trim(id)
@@ -279,7 +292,7 @@ Note._resolve_id_path = function(opts)
   dir = base_dir
 
   -- Generate path.
-  local path = Note._generate_path(id, dir)
+  local path = Note._generate_path(id, dir, title, creation_opts.note_path_func)
 
   return id, path, title
 end
@@ -289,7 +302,8 @@ end
 --- @param opts obsidian.note.NoteOpts
 --- @return obsidian.Note
 Note.create = function(opts)
-  local new_id, path, title = Note._resolve_id_path(opts)
+  local creation_opts = Note._get_creation_opts(opts)
+  local new_id, path, title = Note._resolve_id_path(opts, creation_opts)
   opts = vim.tbl_extend("keep", opts, { aliases = {}, tags = {} })
 
   -- Add the title as an alias.
@@ -304,7 +318,7 @@ Note.create = function(opts)
 
   -- Write to disk.
   if opts.should_write then
-    note:write { template = opts.template }
+    note:write { template = opts.template or creation_opts.template }
   end
 
   return note
@@ -374,6 +388,38 @@ Note.display_info = function(self, opts)
   end
 
   return table.concat(info, "\n")
+end
+
+--- Get preview information for this note.
+--- Uses the configured `note.info` callback and falls back to `display_info()`.
+---
+---@param opts { label: string|?, anchor: obsidian.note.HeaderAnchor|?, block: obsidian.note.Block|? }|?
+---@return string
+Note.info = function(self, opts)
+  local info_func = Obsidian.opts.note and Obsidian.opts.note.info
+  if type(info_func) ~= "function" then
+    return self:display_info(opts)
+  end
+
+  local ok, result = pcall(info_func, self, opts)
+  if not ok then
+    log.error("Error running note.info callback: %s", tostring(result))
+    return self:display_info(opts)
+  end
+
+  if type(result) == "string" then
+    return result
+  elseif type(result) == "table" then
+    local lines = {}
+    for _, line in ipairs(result) do
+      lines[#lines + 1] = tostring(line)
+    end
+    if #lines > 0 then
+      return table.concat(lines, "\n")
+    end
+  end
+
+  return self:display_info(opts)
 end
 
 --- Check if the note exists on the file system.
@@ -1241,7 +1287,9 @@ end
 
 ---@class (exact) obsidian.note.NoteCreationOpts
 ---@field notes_subdir string
----@field note_id_func fun()
+---@field note_id_func (fun(title: string|?, path: obsidian.Path|?): string)
+---@field note_path_func (fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path)
+---@field template string|?
 ---@field new_notes_location obsidian.config.NewNotesLocation
 
 ---@class (exact) obsidian.note.NoteOpts

--- a/lua/obsidian/types.lua
+++ b/lua/obsidian/types.lua
@@ -29,8 +29,8 @@
 ---@field notes_subdir? string
 ---@field templates? obsidian.config.TemplateOpts
 ---@field new_notes_location? obsidian.config.NewNotesLocation
----@field note_id_func? (fun(title: string|?, path: obsidian.Path|?): string)|?
----@field note_path_func? fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path
+---@field note_id_func? (fun(title: string|?, path: obsidian.Path|?): string)|? Deprecated, use `note.id_func`
+---@field note_path_func? fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path Deprecated, use `note.path_func`
 ---@field wiki_link_func? fun(opts: {path: string, label: string, id: string|?}): string
 ---@field markdown_link_func? fun(opts: {path: string, label: string, id: string|?}): string
 ---@field preferred_link_style? obsidian.config.LinkStyle
@@ -58,8 +58,8 @@
 ---@field notes_subdir string|?
 ---@field templates obsidian.config.TemplateOpts
 ---@field new_notes_location obsidian.config.NewNotesLocation
----@field note_id_func (fun(id: string|?, path: obsidian.Path|?): string)
----@field note_path_func (fun(spec: { id: string, dir: obsidian.Path }): string|obsidian.Path)
+---@field note_id_func (fun(title: string|?, path: obsidian.Path|?): string)
+---@field note_path_func (fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path)
 ---@field wiki_link_func (fun(opts: {path: string, label: string, id: string|?}): string)
 ---@field markdown_link_func (fun(opts: {path: string, label: string, id: string|?}): string)
 ---@field preferred_link_style obsidian.config.LinkStyle

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -263,6 +263,9 @@ local zettelConfig = {
   note_id_func = function()
     return "hummus"
   end,
+  note_path_func = function(spec)
+    return spec.dir / "hummus-path.md"
+  end,
 }
 
 T["_get_note_creation_opts"] = new_set {
@@ -280,6 +283,8 @@ T["_get_note_creation_opts"]["should not load customizations for non-existent te
 
   eq(spec.notes_subdir, Obsidian.opts.notes_subdir)
   eq(spec.note_id_func, Obsidian.opts.note_id_func)
+  eq(spec.note_path_func, Obsidian.opts.note_path_func)
+  eq(spec.template, "zettel")
   eq(spec.new_notes_location, Obsidian.opts.new_notes_location)
 end
 
@@ -291,6 +296,7 @@ T["_get_note_creation_opts"]["should load customizations for existing template"]
 
   eq(spec.notes_subdir, zettelConfig.notes_subdir)
   eq(spec.note_id_func, zettelConfig.note_id_func)
+  eq(spec.note_path_func, zettelConfig.note_path_func)
 end
 
 T["_get_note_creation_opts"]["should fallback to global note_id_func if customization omits it"] = function()
@@ -305,6 +311,12 @@ T["_get_note_creation_opts"]["should fallback to global note_id_func if customiz
   local spec = assert(M._get_creation_opts { template = "Partial" })
   eq(spec.notes_subdir, "partials")
   eq(spec.note_id_func, Obsidian.opts.note_id_func)
+  eq(spec.note_path_func, Obsidian.opts.note_path_func)
+end
+
+T["_get_note_creation_opts"]["should default template to opts.note.template"] = function()
+  local spec = assert(M._get_creation_opts {})
+  eq(spec.template, Obsidian.opts.note.template)
 end
 
 T["new_note_path"] = new_set()
@@ -425,6 +437,36 @@ T["resolve_id_path"]["should ensure result of 'note_path_func' is always an abso
   }
   eq("New Note", id)
   eq(Path.new(Obsidian.dir) / "notes" / "foo-bar-123.md", path)
+end
+
+T["note_info"] = new_set()
+
+T["note_info"]["should fallback to display_info"] = function()
+  local note = M.new("foo", { "Foo" }, { "bar" }, Obsidian.dir / "foo.md", "Foo")
+
+  local expected = note:display_info { label = "label" }
+  local actual = note:info { label = "label" }
+
+  eq(actual, expected)
+end
+
+T["note_info"]["should support custom callback returning lines"] = function()
+  local original = Obsidian.opts.note.info
+
+  local ok, err = pcall(function()
+    Obsidian.opts.note.info = function(note, opts)
+      return {
+        "note: " .. note.id,
+        "label: " .. (opts and opts.label or ""),
+      }
+    end
+
+    local note = M.new("foo", {}, {}, Obsidian.dir / "foo.md", "Foo")
+    eq(note:info { label = "my-link" }, "note: foo\nlabel: my-link")
+  end)
+
+  Obsidian.opts.note.info = original
+  assert(ok, err)
 end
 
 -- T["reference_paths"] = new_set()


### PR DESCRIPTION
feat(note): consolidate note creation options under note.* and add note.info (#575)

## What does the PR do?

This PR consolidates note-creation behavior under `opts.note` while preserving backward compatibility with legacy top-level options.
Related to #575 

 1) Store default note creation options under `note`
Added/normalized:
- `note.id_func`
- `note.path_func`
- `note.template`
- `note.info` (new, for preview text used in completion/hover-style docs)

 2) Keep legacy config working
Top-level:
- `note_id_func`
- `note_path_func`
are now treated as legacy aliases:
- migrated to `note.id_func` / `note.path_func` during config normalization
- deprecation warnings are shown
- runtime compatibility is preserved

 3) Normalize note creation pipeline
`Note._get_creation_opts()` now carries a complete creation strategy:
- `note_id_func`
- `note_path_func`
- `template`
- `notes_subdir`
- `new_notes_location`
Template customizations can now also override:
- `note_path_func`
- `template`

 4) Signature consistency
`note_path_func` is now consistently treated with spec:
`{ id, dir, title }`
so `title` is available in path generation logic and typing/docs are aligned.

 5) Preview customization
Added `Note.info()`:
- uses `opts.note.info` callback
- accepts callback return as `string` or `string[]`
- safely falls back to `Note.display_info()` if callback is missing/errors/returns invalid value
Completion docs now call `note:info(...)` instead of hardcoded `note:display_info(...)`.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
