### PR TITLE
feat: `api.resolve_attachment_path` will resolve file uri paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `:Obsidian tags` support Unicode tags.
 - `opts.checkbox.enabled` works.
 - Telescope picker filtering works with right ordinal value.
+- `api.resolve_attachment_path` will resolve file uri paths.
 
 ## [v3.15.10](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.15.10) - 2026-02-18
 

--- a/lua/obsidian/attachment.lua
+++ b/lua/obsidian/attachment.lua
@@ -61,6 +61,10 @@ M.resolve_attachment_path = function(src)
   local Path = require "obsidian.path"
   local attachment_folder = Obsidian.opts.attachments.folder
 
+  if vim.startswith(src, "file:/") then
+    return vim.uri_to_fname(src)
+  end
+
   ---@cast attachment_folder -nil
   if vim.startswith(attachment_folder, ".") then
     local dirname = Path.new(vim.fs.dirname(vim.api.nvim_buf_get_name(0)))


### PR DESCRIPTION
as titled, so that embeds like `![name](file://path)` can be previewed by `snacks.image`.
