### PR TITLE
fix: transfer title field in clone_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecated `preferred_link_style`, `wiki_link_func`, and `markdown_link_func` in favor of `link.style`.
 
+### Fixed
+
+- `note.title` is now correctly transferred when creating a note from a template, so custom `frontmatter.func` functions receive the user-entered title.
 ## [v3.15.11](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.15.11) - 2026-03-05
 
 ### Added

--- a/lua/obsidian/templates.lua
+++ b/lua/obsidian/templates.lua
@@ -110,6 +110,7 @@ M.clone_template = function(ctx)
   if ctx.partial_note ~= nil then
     -- Transfer fields from `ctx.partial_note`.
     new_note.id = ctx.partial_note.id
+    new_note.title = ctx.partial_note.title
     for _, alias in ipairs(ctx.partial_note.aliases) do
       new_note:add_alias(alias)
     end

--- a/tests/test_templates.lua
+++ b/tests/test_templates.lua
@@ -102,6 +102,25 @@ T["substitute_template_variables()"]["should pass suffix to substitution functio
   eq("value is hello", M.substitute_template_variables(text, tmp_template_context()))
 end
 
+T["clone_template()"] = new_set()
+
+T["clone_template()"]["should transfer title from partial_note"] = function()
+  vim.fn.writefile({}, tostring(Obsidian.dir / "templates" / "basic.md"))
+
+  local destination = Obsidian.dir / "test-note.md"
+  local partial = Note.new("1234-ABCD", {}, {}, nil, "My Note Title")
+
+  local result = M.clone_template {
+    type = "clone_template",
+    template_name = "basic.md",
+    destination_path = destination,
+    templates_dir = api.templates_dir(),
+    partial_note = partial,
+  }
+
+  eq("My Note Title", result.title)
+end
+
 T["config.normalize()"] = new_set()
 
 T["config.normalize()"]["custom substitutions should not clobber defaults"] = function()


### PR DESCRIPTION
## Summary

When creating a new note with a template (e.g. via `:Obsidian new`), the `title` field from `partial_note` was not being transferred to the cloned note in `clone_template()`. This caused `note.title` to be `nil` when the custom `frontmatter.func` runs, even though the user had entered a title.

The `id`, `aliases`, and `tags` fields were already being transferred — `title` was simply missing.

## Fix

One-line addition in `lua/obsidian/templates.lua`:

```lua
new_note.title = ctx.partial_note.title
```

## Steps to reproduce

1. Configure a custom `frontmatter.func` that uses `note.title`
2. Create a new note with `:Obsidian new` and enter a title when prompted
3. Observe that `note.title` is `nil` in the frontmatter output

## Test

A new test case was added to `tests/test_templates.lua` under `clone_template()` that confirms the title is correctly transferred from `partial_note` to the cloned note.