### PR TITLE
fix: respect disabled frontmatter on rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rename no longer inserts frontmatter when `frontmatter.enabled = false`.
 - Fzf-lua picker selections now honor multi-select consistently across files, grep, and list pickers.
 - Picker will apply `format_item` consistently.
 - Cache will be triggered by buffer writes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Checkbox detection and conceal now follow CommonMark/GFM list syntax (e.g. `-- [ ]` and `++ [ ]` are no longer treated as checkboxes) and support multi-byte checkbox states.
 
+### Fixed
+
+- Rename no longer inserts frontmatter when `frontmatter.enabled = false`.
+
 ## [v3.16.7](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.7) - 2026-09-01
 
 ### Added

--- a/lua/obsidian/lsp/handlers/_rename.lua
+++ b/lua/obsidian/lsp/handlers/_rename.lua
@@ -198,7 +198,7 @@ M.rename = function(note, new_name, callback, opts)
 
       note.id = new_name
       note.path = Path.new(new_path)
-      note:save_to_buffer { bufnr = note.bufnr }
+      note:update_frontmatter(note.bufnr)
 
       vim.cmd "silent! wall"
       require("obsidian.cache").notes.rename(old_path, new_path)

--- a/lua/obsidian/note/rename.lua
+++ b/lua/obsidian/note/rename.lua
@@ -303,7 +303,7 @@ local function finish_rename(note, new_name, meta)
 
   note.id = new_name
   note.path = Path.new(new_path)
-  note:save_to_buffer { bufnr = note.bufnr }
+  note:update_frontmatter(note.bufnr)
 
   vim.cmd "silent! wall"
   require("obsidian.cache").notes.rename(old_path, new_path)

--- a/tests/lsp/test_rename.lua
+++ b/tests/lsp/test_rename.lua
@@ -70,6 +70,23 @@ T["rename current note"] = function()
   eq(target_expected, table.concat(lines, "\n"))
 end
 
+T["rename current note does not insert frontmatter when disabled"] = function()
+  local root = child.Obsidian.dir
+  local files = h.mock_vault_contents(root, {
+    ["plain.md"] = "hello\nworld",
+  })
+
+  local new_target_path = root / "renamed-plain.md"
+
+  child.lua [[Obsidian.opts.frontmatter.enabled = false]]
+  child.cmd("edit " .. files["plain.md"])
+  rename "renamed-plain"
+  h.child_wait_for_path(child, new_target_path)
+  eq(true, new_target_path:exists())
+  local lines = child.api.nvim_buf_get_lines(1, 0, -1, false)
+  eq("hello\nworld", table.concat(lines, "\n"))
+end
+
 T["rename current note is no-op when name matches current note"] = function()
   local root = child.Obsidian.dir
   local files = h.mock_vault_contents(root, {


### PR DESCRIPTION
## Summary
- fix note rename so it no longer inserts frontmatter when `frontmatter.enabled = false`
- add a regression test and a changelog entry

## What changed
Rename updated the note through `save_to_buffer()`, which inserts YAML unless `insert_frontmatter` is false. That bypassed `frontmatter.enabled = false`.

The handler now calls `note:update_frontmatter()`, the same guard used elsewhere.

## Out of scope
Note-creation / template stripping from the earlier revision is dropped:
- `:Obsidian new` already skips the default template when frontmatter is disabled (#862)
- custom template frontmatter is preserved (#801)

Stale `id:` in notes that already have YAML is left as-is when management is off.

## Tests
- renaming the current plain note with `frontmatter.enabled = false` does not insert YAML

## PR Checklist
- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file (existing `frontmatter.enabled` docs already cover this)
- [x] The code complies with `make chores` (for style, lint, types, and tests) — Ubuntu and macOS are green; Windows is red on an unrelated completion test, see comment
