### PR TITLE
fix: `insert_tag` action will check for non-existing tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `:Obsidian tags` now respects `search.sort_by` and `search.sort_reversed` config options.
 - Wiki links in frontmatter will be properly quoted.
 - Numbers in `tags` and `aliases` will be preserved.
+- `insert_tag` action will check for non-existing tag.
 
 ## [v3.15.11](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.15.11) - 2026-03-05
 

--- a/lua/obsidian/picker/mappings.lua
+++ b/lua/obsidian/picker/mappings.lua
@@ -52,6 +52,10 @@ end
 ---@param entry obsidian.PickerEntry
 M.insert_tag = function(entry)
   local tag = entry.user_data
+  if tag == nil then
+    log.err "Tag does not exist"
+    return
+  end
   vim.api.nvim_put({ "#" .. tag }, "", false, true)
 end
 


### PR DESCRIPTION
closes #531 