### PR TITLE
feat: add `Note.insert_text` for inserting text under a specific section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `obsidian-ls` acts more properly like LSP
   - handle libuv scheduled callbacks
   - send progress messages
+- Add `Note.insert_text` for inserting text under a specific section
 
 ### Changed
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -1389,7 +1389,7 @@ end
 --- The level of the heading (H1, H2, H3, ...).
 ---@field level integer
 --- Decides what to do when the section is missing. Defaults to `create`.
----@field on_missing? 'create'|'error'|'abort'
+---@field on_missing? "create"|"error"|"cancel"
 
 ---@class obsidian.note.HeaderAnchor
 ---

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -1261,24 +1261,31 @@ end
 
 ---@param text string|string[] The text to insert into the note.
 ---@param opts obsidian.note.InsertTextOpts? The options for constraining where text can be inserted.
----@return integer new_text_idx of the inserted text, or `0` if insertion failed.
+---@return integer text_idx where the text begins in the file (_including_ frontmatter) or `0` when insert is cancelled.
 Note.insert_text = function(self, text, opts)
-  local new_text_idx = 0
+  local text_idx = 0
+
   opts = opts or {}
   opts.update_content = function(lines)
-    local idx, insert_before, insert_after = text_insertion.resolve(lines, opts)
+    local insert_idx, insert_before, insert_after = text_insertion.resolve(lines, opts)
 
-    if idx == 0 then
+    if insert_idx == 0 then
       return lines
     end
 
-    new_text_idx = idx + #insert_before
-    local head = vim.list_slice(lines, 1, idx - 1)
-    local tail = vim.list_slice(lines, idx, #lines)
+    text_idx = insert_idx + #insert_before
+    local head = vim.list_slice(lines, 1, insert_idx - 1)
+    local tail = vim.list_slice(lines, insert_idx, #lines)
     return vim.iter({ head, insert_before, text, insert_after, tail }):flatten():totable()
   end
+
   self:save(opts)
-  return new_text_idx
+
+  if self.has_frontmatter and text_idx > 0 then
+    return self.frontmatter_end_line + text_idx
+  end
+
+  return text_idx
 end
 
 ---@param other obsidian.Note
@@ -1381,7 +1388,7 @@ end
 --- of the file up to but not including the first heading). Defaults to `nil`.
 ---@field section? obsidian.note.Section
 --- Specifies where the text should be inserted relative to the section or preamble. Defaults to `top`.
----@field placement? 'top'|'bot'
+---@field placement? "top"|"bot"
 
 ---@class (exact) obsidian.note.Section
 --- The label of the heading.

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -12,6 +12,7 @@ local Path = require "obsidian.path"
 local yaml = require "obsidian.yaml"
 local log = require "obsidian.log"
 local util = require "obsidian.util"
+local text_insertion = require "obsidian.util.text_insertion"
 local iter = vim.iter
 local compat = require "obsidian.compat"
 local api = require "obsidian.api"
@@ -1258,6 +1259,28 @@ Note.body_lines = function(self)
   return lines
 end
 
+---@param text string|string[] The text to insert into the note.
+---@param opts obsidian.note.InsertTextOpts? The options for constraining where text can be inserted.
+---@return integer new_text_idx of the inserted text, or `0` if insertion failed.
+Note.insert_text = function(self, text, opts)
+  local new_text_idx = 0
+  opts = opts or {}
+  opts.update_content = function(lines)
+    local idx, insert_before, insert_after = text_insertion.resolve(lines, opts)
+
+    if idx == 0 then
+      return lines
+    end
+
+    new_text_idx = idx + #insert_before
+    local head = vim.list_slice(lines, 1, idx - 1)
+    local tail = vim.list_slice(lines, idx, #lines)
+    return vim.iter({ head, insert_before, text, insert_after, tail }):flatten():totable()
+  end
+  self:save(opts)
+  return new_text_idx
+end
+
 ---@param other obsidian.Note
 ---@return obsidian.Note
 Note.merge = function(self, other)
@@ -1352,6 +1375,21 @@ end
 --- When enabled, Neovim will warn the user if changes would be lost and/or reload each buffer's content.
 --- See `:help checktime` to learn more.
 ---@field check_buffers? boolean
+
+---@class (exact) obsidian.note.InsertTextOpts: obsidian.note.NoteSaveOpts
+--- Specifies the section to insert the text into, or `nil` to target the preamble (i.e. the area starting from the top
+--- of the file up to but not including the first heading). Defaults to `nil`.
+---@field section? obsidian.note.Section
+--- Specifies where the text should be inserted relative to the section or preamble. Defaults to `top`.
+---@field placement? 'top'|'bot'
+
+---@class (exact) obsidian.note.Section
+--- The label of the heading.
+---@field header string
+--- The level of the heading (H1, H2, H3, ...).
+---@field level integer
+--- Decides what to do when the section is missing. Defaults to `create`.
+---@field on_missing? 'create'|'error'|'abort'
 
 ---@class obsidian.note.HeaderAnchor
 ---

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -221,7 +221,7 @@ end
 
 ---@type table<string, OnSectionMissingHandler>
 H.on_section_missing_handlers = {
-  abort = function(_, _)
+  cancel = function(_, _)
     return 0, {}, {}
   end,
 

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -240,35 +240,35 @@ function H.get_line_details(lines)
   return line_details
 end
 
----@alias (exact) obsidian.note.OnSectionMissingHandler fun(sections: obsidian.note.SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
+---@alias obsidian.note.OnSectionMissingHandler fun(sections: obsidian.note.SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
 
----@class (exact) obsidian.note.SectionDetail
+---@class obsidian.note.SectionDetail
 ---@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }
 ---@field content? { beg_incl: integer, end_excl: integer }
 
----@alias (exact) obsidian.note.LineDetail
+---@alias obsidian.note.LineDetail
 ---|obsidian.note.LineTextDetail
 ---|obsidian.note.LineHeaderDetail
 ---|obsidian.note.LineHeaderUnderlineDetail
 ---|obsidian.note.LineCodeDetail
 ---|obsidian.note.LineEmptyDetail
 
----@class (exact) obsidian.note.LineTextDetail
+---@class obsidian.note.LineTextDetail
 ---@field type 'text'
 ---@field text string
 
----@class (exact) obsidian.note.LineHeaderDetail
+---@class obsidian.note.LineHeaderDetail
 ---@field type 'header'
 ---@field level integer
 ---@field label string
 
----@class (exact) obsidian.note.LineHeaderUnderlineDetail
+---@class obsidian.note.LineHeaderUnderlineDetail
 ---@field type 'header-underline'
 
----@class (exact) obsidian.note.LineCodeDetail
+---@class obsidian.note.LineCodeDetail
 ---@field type 'code'
 
----@class (exact) obsidian.note.LineEmptyDetail
+---@class obsidian.note.LineEmptyDetail
 ---@field type 'empty'
 
 return M

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -9,22 +9,22 @@ local H = {}
 --- Resolves the information needed to insert text into the given markdown document while preserving the desired layout.
 ---
 ---@param lines string[] The list of lines in the markdown document.
----@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
+---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints, or `0` when impossible.
 ---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
 ---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
 function M.resolve(lines, opts)
   local line_details = H.get_line_details(lines)
   local sections = H.collapse_into_sections(line_details)
-  local section_idx = H.find_desired_section(sections, opts)
+  local chosen_idx = H.choose_section(sections, opts)
 
-  if section_idx > 0 then
-    return H.expand_old_section(sections, section_idx, opts)
+  if chosen_idx > 0 then
+    return H.expand_old_section(sections, chosen_idx, opts)
+  else
+    local key = opts.section.on_missing or "create"
+    local handler = assert(H.on_section_missing_handlers[key], "unsupported `opts.section.on_missing` key: " .. key)
+    return handler(sections, opts)
   end
-
-  local key = opts.section.on_missing or "create"
-  local on_missing_handler = assert(H.on_missing_handler[key], "unsupported `opts.section.on_missing` option: " .. key)
-  return on_missing_handler(sections, opts)
 end
 
 --- Produces detail records for each line in the markdown document that meaningfully contributes to the document layout.
@@ -36,7 +36,7 @@ function H.get_line_details(lines)
   local line_details = {}
   local within_code_block = false
 
-  local function categorize_ith_line_using_early_return_statements(idx)
+  local function get_detail_for_idx_by_using_early_return_statements(idx)
     local line_str = vim.trim(lines[idx])
 
     if within_code_block then
@@ -67,7 +67,7 @@ function H.get_line_details(lines)
   end
 
   for idx = 1, #lines do
-    line_details[idx] = categorize_ith_line_using_early_return_statements(idx)
+    line_details[idx] = get_detail_for_idx_by_using_early_return_statements(idx)
   end
 
   return line_details
@@ -91,23 +91,23 @@ end
 function H.collapse_into_sections(line_details)
   local sections = { H.new_section_detail(1, 1) }
   local current = sections[1]
-  local current_content_is_empty = true
+  local current_content_empty = true
 
-  for idx_incl, ith_line in ipairs(line_details) do
+  for idx_incl, line_detail in ipairs(line_details) do
     local idx_excl = idx_incl + 1
 
-    if ith_line.type == "header" then
-      table.insert(sections, H.new_section_detail(idx_incl, idx_excl, ith_line.level, ith_line.label))
+    if line_detail.type == "header" then
+      table.insert(sections, H.new_section_detail(idx_incl, idx_excl, line_detail.level, line_detail.label))
       current = sections[#sections]
-      current_content_is_empty = true
-    elseif ith_line.type == "header-underline" then
+      current_content_empty = true
+    elseif line_detail.type == "header-underline" then
       current.heading.end_excl = idx_excl
       current.content.beg_incl = idx_excl
       current.content.end_excl = idx_excl
-    elseif ith_line.type ~= "empty" then
-      if current_content_is_empty then
+    elseif line_detail.type ~= "empty" then
+      if current_content_empty then
         current.content.beg_incl = idx_incl
-        current_content_is_empty = false
+        current_content_empty = false
       end
       current.content.end_excl = idx_excl
     end
@@ -119,76 +119,52 @@ function H.collapse_into_sections(line_details)
   return sections
 end
 
---- Finds the section index where text should be inserted.
+--- Chooses a section to insert new text into.
 ---
 ---@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
----@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
----@return integer section_idx where the the new text can be inserted while maintaining the layout, or `0` if not found.
-function H.find_desired_section(sections, opts)
+---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted.
+---@return integer chosen_idx where the the new text can be inserted while maintaining the layout, or `0` if not found.
+function H.choose_section(sections, opts)
   if not opts.section then
     return 1
   end
-
   for idx = 2, #sections - 1 do
     if sections[idx].heading.label == opts.section.header and sections[idx].heading.level == opts.section.level then
       return idx
     end
   end
-
   return 0
 end
-
----@type fun(beg_incl: integer, end_excl: integer, level?: integer, label?: string): SectionDetail
-function H.new_section_detail(beg_incl, end_excl, level, label)
-  return {
-    heading = { beg_incl = beg_incl, end_excl = end_excl, level = level or 0, label = label or "" },
-    content = { beg_incl = end_excl, end_excl = end_excl },
-  }
-end
-
----@type table<string, OnMissingHandler>
-H.on_missing_handler = {
-  abort = function(_, _)
-    return 0, {}, {}
-  end,
-
-  error = function(_, opts)
-    error(string.format("Failed to find the section: %s", vim.inspect(opts.section.header)))
-  end,
-
-  create = function(sections, opts)
-    -- NOTE: This is an arbitrary choice. Users might want more control over where new sections get positioned.
-    local create_at_idx = opts.placement == "bot" and #sections or 2
-    return H.create_new_section(sections, create_at_idx, opts)
-  end,
-}
 
 --- Creates a new heading and section at the specified index and then "pushes down" the section that is currently there.
 ---
 --- Assumes that `index > 1` because the preamble is _defined_ as the lines above all of the other headings in the file.
 ---
 ---@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
----@param section_idx integer The index where the new section will be inserted. Must NOT be the preamble (at `1`).
----@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
+---@param chosen_idx integer The index where the new section will be inserted. Must NOT be the preamble (at `1`).
+---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints.
 ---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
 ---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
-function H.create_new_section(sections, section_idx, opts)
-  assert(section_idx > 1, "the preamble cannot have headers placed before it.")
+function H.create_new_section(sections, chosen_idx, opts)
+  assert(chosen_idx > 1, "the preamble cannot have headers placed before it.")
 
-  local section = sections[section_idx]
-  local prev_section = sections[section_idx - 1]
+  local section_chosen = sections[chosen_idx]
+  local section_before = sections[chosen_idx - 1]
 
-  local insert_idx = section.heading.beg_incl
-  local insert_before = { string.rep("#", opts.section.level) .. " " .. opts.section.header, "" }
+  local insert_idx = section_chosen.heading.beg_incl
+  local insert_before = {}
   local insert_after = {}
 
-  if not H.is_section_empty(prev_section) and prev_section.content.end_excl == insert_idx then
-    table.insert(insert_before, 1, "")
+  if not H.is_section_empty(section_before) and section_before.content.end_excl == insert_idx then
+    table.insert(insert_before, "")
   end
 
-  if not H.is_section_empty(section) then
-    table.insert(insert_after, 1, "")
+  table.insert(insert_before, string.rep("#", opts.section.level) .. " " .. opts.section.header)
+  table.insert(insert_before, "")
+
+  if not H.is_section_empty(section_chosen) then
+    table.insert(insert_after, "")
   end
 
   return insert_idx, insert_before, insert_after
@@ -199,43 +175,68 @@ end
 --- Assumes that `index < #sections` because the EOF marker is _defined_ as the empty section of the bottom of the file.
 ---
 ---@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
----@param section_idx integer The index where the old section is located. Must NOT be the EOF marker (at `#sections`).
----@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
+---@param chosen_idx integer The index where the old section is located. Must NOT be the EOF marker (at `#sections`).
+---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints.
 ---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
 ---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
-function H.expand_old_section(sections, section_idx, opts)
-  assert(section_idx < #sections, "the EOF marker cannot have content placed after it.")
+function H.expand_old_section(sections, chosen_idx, opts)
+  assert(chosen_idx < #sections, "the EOF marker cannot have content placed after it.")
 
-  local section = sections[section_idx]
-  local next_section = sections[section_idx + 1]
+  local section_chosen = sections[chosen_idx]
+  local section_after = sections[chosen_idx + 1]
 
-  local insert_idx = opts.placement == "top" and section.content.beg_incl or section.content.end_excl
+  local insert_idx = opts.placement == "top" and section_chosen.content.beg_incl or section_chosen.content.end_excl
   local insert_before = {}
   local insert_after = {}
 
-  if H.is_content_empty(section) then
-    table.insert(insert_before, 1, "")
+  if H.is_section_content_empty(section_chosen) then
+    table.insert(insert_before, "")
   end
 
-  if not H.is_section_empty(next_section) and next_section.heading.beg_incl == insert_idx then
-    table.insert(insert_after, 1, "")
+  if not H.is_section_empty(section_after) and section_after.heading.beg_incl == insert_idx then
+    table.insert(insert_after, "")
   end
 
   return insert_idx, insert_before, insert_after
 end
 
----@type fun(section: SectionDetail): boolean
+---@type fun(beg_incl: integer, end_excl: integer, level?: integer, label?: string): SectionDetail
+function H.new_section_detail(beg_incl, end_excl, level, label)
+  return {
+    heading = { beg_incl = beg_incl, end_excl = end_excl, level = level or 0, label = label or "" },
+    content = { beg_incl = end_excl, end_excl = end_excl },
+  }
+end
+
+---@type fun(section?: SectionDetail): boolean
 function H.is_section_empty(section)
   return not section or section.heading.beg_incl == section.content.end_excl
 end
 
----@type fun(section: SectionDetail): boolean
-function H.is_content_empty(section)
+---@type fun(section?: SectionDetail): boolean
+function H.is_section_content_empty(section)
   return not section or section.content.beg_incl == section.content.end_excl
 end
 
----@alias (exact) OnMissingHandler fun(sections: SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
+---@type table<string, OnSectionMissingHandler>
+H.on_section_missing_handlers = {
+  abort = function(_, _)
+    return 0, {}, {}
+  end,
+
+  error = function(_, opts)
+    error(string.format("Failed to find the section: %s", vim.inspect(opts.section.header)))
+  end,
+
+  create = function(sections, opts)
+    -- NOTE: The choice made here is arbitrary; users might want to choose the position themselves (maybe w/ a picker?).
+    local chosen_idx = opts.placement == "bot" and #sections or 2
+    return H.create_new_section(sections, chosen_idx, opts)
+  end,
+}
+
+---@alias (exact) OnSectionMissingHandler fun(sections: SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
 
 ---@class (exact) SectionDetail
 ---@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -40,7 +40,7 @@ end
 --- the final lines in the document.
 ---
 ---@param lines string[] The list of lines in the markdown document.
----@return SectionDetail[] sections defining the document. There will always be at least two items.
+---@return obsidian.note.SectionDetail[] sections defining the document. There will always be at least two items.
 function H.collapse_into_sections(lines)
   local sections = { H.new_section_detail(1, 1) }
   local current = sections[1]
@@ -74,7 +74,7 @@ end
 
 --- Chooses a section to insert new text into.
 ---
----@param sections SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param sections obsidian.note.SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer chosen_idx where the new text can be inserted while maintaining the layout, or `0` if none are valid.
 function H.choose_section(sections, opts)
@@ -94,7 +94,7 @@ end
 
 --- Expands the section positioned at the specified index so that it can have more text inserted into it.
 ---
----@param sections SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param sections obsidian.note.SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
 ---@param chosen_idx integer The index where the old section is located. Must NOT be the EOF-marker (`idx = #sections`).
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints.
@@ -123,7 +123,7 @@ end
 
 --- Inserts a new heading and section at the specified index and "pushes down" the section that is currently there.
 ---
----@param sections SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param sections obsidian.note.SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
 ---@param chosen_idx integer The index where the new section will be inserted. Must NOT be the preamble (`idx = 1`).
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints.
@@ -153,7 +153,7 @@ function H.insert_new_section(sections, chosen_idx, opts)
   return insert_idx, insert_before, insert_after
 end
 
----@type table<string, OnSectionMissingHandler>
+---@type table<string, obsidian.note.OnSectionMissingHandler>
 H.on_section_missing_handlers = {
   cancel = function(_, _)
     return 0, {}, {}
@@ -171,7 +171,11 @@ H.on_section_missing_handlers = {
   end,
 }
 
----@type fun(beg_incl: integer, end_excl: integer, level?: integer, label?: string): SectionDetail
+---@param beg_incl integer
+---@param end_excl integer
+---@param level? integer
+---@param label? string
+---@return obsidian.note.SectionDetail
 function H.new_section_detail(beg_incl, end_excl, level, label)
   return {
     heading = { beg_incl = beg_incl, end_excl = end_excl, level = level or 0, label = label or "" },
@@ -179,21 +183,26 @@ function H.new_section_detail(beg_incl, end_excl, level, label)
   }
 end
 
----@type fun(section?: SectionDetail): boolean
+---@param section? obsidian.note.SectionDetail
+---@return boolean
 function H.is_section_empty(section)
   return not section or section.heading.beg_incl == section.content.end_excl
 end
 
----@type fun(section?: SectionDetail): boolean
+---@param section? obsidian.note.SectionDetail
+---@return boolean
 function H.is_content_empty(section)
   return not section or section.content.beg_incl == section.content.end_excl
 end
 
----@type fun(lines: string[]): LineDetail[]
+---@param lines string[]
+---@return obsidian.note.LineDetail[]
 function H.get_line_details(lines)
   local line_details = {}
   local within_code_block = false
 
+  ---@param idx integer
+  ---@return obsidian.note.LineDetail
   local function get_detail_for_idx_by_using_early_return_statements(idx)
     local line_str = vim.trim(lines[idx])
 
@@ -231,35 +240,35 @@ function H.get_line_details(lines)
   return line_details
 end
 
----@alias (exact) OnSectionMissingHandler fun(sections: SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
+---@alias (exact) obsidian.note.OnSectionMissingHandler fun(sections: obsidian.note.SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
 
----@class (exact) SectionDetail
+---@class (exact) obsidian.note.SectionDetail
 ---@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }
 ---@field content? { beg_incl: integer, end_excl: integer }
 
----@alias (exact) LineDetail
----|LineTextDetail
----|LineHeaderDetail
----|LineHeaderUnderlineDetail
----|LineCodeDetail
----|LineEmptyDetail
+---@alias (exact) obsidian.note.LineDetail
+---|obsidian.note.LineTextDetail
+---|obsidian.note.LineHeaderDetail
+---|obsidian.note.LineHeaderUnderlineDetail
+---|obsidian.note.LineCodeDetail
+---|obsidian.note.LineEmptyDetail
 
----@class (exact) LineTextDetail
+---@class (exact) obsidian.note.LineTextDetail
 ---@field type 'text'
 ---@field text string
 
----@class (exact) LineHeaderDetail
+---@class (exact) obsidian.note.LineHeaderDetail
 ---@field type 'header'
 ---@field level integer
 ---@field label string
 
----@class (exact) LineHeaderUnderlineDetail
+---@class (exact) obsidian.note.LineHeaderUnderlineDetail
 ---@field type 'header-underline'
 
----@class (exact) LineCodeDetail
+---@class (exact) obsidian.note.LineCodeDetail
 ---@field type 'code'
 
----@class (exact) LineEmptyDetail
+---@class (exact) obsidian.note.LineEmptyDetail
 ---@field type 'empty'
 
 return M

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -16,18 +16,15 @@ local H = {}
 function M.resolve(lines, opts)
   local line_details = H.get_line_details(lines)
   local sections = H.collapse_into_sections(line_details)
-  local section_idx, section_missing = H.get_section_idx(sections, opts)
+  local section_idx = H.find_desired_section(sections, opts)
 
-  if not section_missing then
-    return H.on_section_found(sections, section_idx, opts)
+  if section_idx > 0 then
+    return H.expand_old_section(sections, section_idx, opts)
   end
 
-  local on_missing_opt = opts.section.on_missing or "create"
-  local on_missing_handler = assert(
-    H.on_missing_handler[on_missing_opt],
-    string.format("unsupported `opts.section.on_missing` option: %s", vim.inspect(on_missing_opt))
-  )
-  return on_missing_handler(sections, section_idx, opts)
+  local key = opts.section.on_missing or "create"
+  local on_missing_handler = assert(H.on_missing_handler[key], "unsupported `opts.section.on_missing` option: " .. key)
+  return on_missing_handler(sections, opts)
 end
 
 --- Produces detail records for each line in the markdown document that meaningfully contributes to the document layout.
@@ -126,20 +123,19 @@ end
 ---
 ---@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
 ---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
----@return integer section_idx where the the new text can be inserted while maintaining the layout.
----@return boolean section_missing `true` if the specified section couldn't be found.
-function H.get_section_idx(sections, opts)
+---@return integer section_idx where the the new text can be inserted while maintaining the layout, or `0` if not found.
+function H.find_desired_section(sections, opts)
   if not opts.section then
-    return 1, false
+    return 1
   end
 
   for idx = 2, #sections - 1 do
     if sections[idx].heading.label == opts.section.header and sections[idx].heading.level == opts.section.level then
-      return idx, false
+      return idx
     end
   end
 
-  return opts.placement == "bot" and #sections or 2, true
+  return 0
 end
 
 ---@type fun(beg_incl: integer, end_excl: integer, level?: integer, label?: string): SectionDetail
@@ -150,38 +146,67 @@ function H.new_section_detail(beg_incl, end_excl, level, label)
   }
 end
 
----@type table<string, InsertHandler>
+---@type table<string, OnMissingHandler>
 H.on_missing_handler = {
-  abort = function(_, _, _)
+  abort = function(_, _)
     return 0, {}, {}
   end,
 
-  error = function(_, _, opts)
+  error = function(_, opts)
     error(string.format("Failed to find the section: %s", vim.inspect(opts.section.header)))
   end,
 
-  create = function(sections, section_idx, opts)
-    local section = sections[section_idx]
-    local prev_section = sections[section_idx - 1]
-
-    local insert_idx = section.heading.beg_incl
-    local insert_before = { string.rep("#", opts.section.level) .. " " .. opts.section.header, "" }
-    local insert_after = {}
-
-    if not H.is_section_empty(prev_section) and prev_section.content.end_excl == insert_idx then
-      table.insert(insert_before, 1, "")
-    end
-
-    if not H.is_section_empty(section) then
-      table.insert(insert_after, 1, "")
-    end
-
-    return insert_idx, insert_before, insert_after
+  create = function(sections, opts)
+    -- NOTE: This is an arbitrary choice. Users might want more control over where new sections get positioned.
+    local create_at_idx = opts.placement == "bot" and #sections or 2
+    return H.create_new_section(sections, create_at_idx, opts)
   end,
 }
 
----@type InsertHandler
-function H.on_section_found(sections, section_idx, opts)
+--- Creates a new heading and section at the specified index and then "pushes down" the section that is currently there.
+---
+--- Assumes that `index > 1` because the preamble is _defined_ as the lines above all of the other headings in the file.
+---
+---@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
+---@param section_idx integer The index where the new section will be inserted. Must NOT be the preamble (at `1`).
+---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
+---@return integer insert_idx where new text should be inserted to satisfy the constraints.
+---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
+---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
+function H.create_new_section(sections, section_idx, opts)
+  assert(section_idx > 1, "the preamble cannot have headers placed before it.")
+
+  local section = sections[section_idx]
+  local prev_section = sections[section_idx - 1]
+
+  local insert_idx = section.heading.beg_incl
+  local insert_before = { string.rep("#", opts.section.level) .. " " .. opts.section.header, "" }
+  local insert_after = {}
+
+  if not H.is_section_empty(prev_section) and prev_section.content.end_excl == insert_idx then
+    table.insert(insert_before, 1, "")
+  end
+
+  if not H.is_section_empty(section) then
+    table.insert(insert_after, 1, "")
+  end
+
+  return insert_idx, insert_before, insert_after
+end
+
+--- Expands the section positioned at the specified index so that it can have more text inserted into it.
+---
+--- Assumes that `index < #sections` because the EOF marker is _defined_ as the empty section of the bottom of the file.
+---
+---@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
+---@param section_idx integer The index where the old section is located. Must NOT be the EOF marker (at `#sections`).
+---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
+---@return integer insert_idx where new text should be inserted to satisfy the constraints.
+---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
+---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
+function H.expand_old_section(sections, section_idx, opts)
+  assert(section_idx < #sections, "the EOF marker cannot have content placed after it.")
+
   local section = sections[section_idx]
   local next_section = sections[section_idx + 1]
 
@@ -210,6 +235,19 @@ function H.is_content_empty(section)
   return not section or section.content.beg_incl == section.content.end_excl
 end
 
+---@alias (exact) OnMissingHandler fun(sections: SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
+
+---@class (exact) SectionDetail
+---@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }
+---@field content? { beg_incl: integer, end_excl: integer }
+
+---@alias (exact) LineDetail
+---|LineTextDetail
+---|LineHeaderDetail
+---|LineHeaderUnderlineDetail
+---|LineCodeDetail
+---|LineEmptyDetail
+
 ---@class (exact) LineTextDetail
 ---@field type 'text'
 ---@field text string
@@ -227,19 +265,5 @@ end
 
 ---@class (exact) LineEmptyDetail
 ---@field type 'empty'
-
----@class (exact) SectionDetail
----@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }
----@field content? { beg_incl: integer, end_excl: integer }
-
----@alias (exact) LineDetail
----|LineTextDetail
----|LineHeaderDetail
----|LineHeaderUnderlineDetail
----|LineCodeDetail
----|LineEmptyDetail
-
----@alias (exact) InsertHandler
----|fun(sections: SectionDetail[], section_idx: integer, opts: obsidian.note.InsertTextOpts): integer, string[], string[]
 
 return M

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -6,16 +6,15 @@ local CODE_BLOCK_PATTERN = "^```[%w_-]*$"
 local M = {}
 local H = {}
 
---- Resolves the information needed to insert text into the given markdown document while preserving the desired layout.
+--- Resolves the changes needed to insert text into the given markdown document while preserving the given constraints.
 ---
 ---@param lines string[] The list of lines in the markdown document.
----@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted.
+---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints, or `0` when impossible.
----@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
----@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
+---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the constraints.
+---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the constraints.
 function M.resolve(lines, opts)
-  local line_details = H.get_line_details(lines)
-  local sections = H.collapse_into_sections(line_details)
+  local sections = H.collapse_into_sections(lines)
   local chosen_idx = H.choose_section(sections, opts)
 
   if chosen_idx > 0 then
@@ -27,11 +26,170 @@ function M.resolve(lines, opts)
   end
 end
 
---- Produces detail records for each line in the markdown document that meaningfully contributes to the document layout.
---- Headings defined within codeblock fences (```) will _not_ contribute to the document layout.
+--- Collapses lines into a list of "sections". Each section is itself composed of two sub-sections: heading and content.
+--- The heading and content sub-sections are defined using a half-open `[beg_incl, end_excl)` range. When empty, they
+--- will use values such that `beg_incl == end_excl`.
+---
+--- IMPORTANT: There will always be AT LEAST TWO sections.
+---
+--- The FIRST section is the PREAMBLE. It contains the non-empty lines _before_ the first heading. If there aren't any
+--- headings, then it will contain ALL non-empty lines in the file. Otherwise, when the document is empty or when the
+--- first line in the document is a heading, then the content section of the preamble will be empty.
+---
+--- The FINAL section is the EOF-MARKER. Both its heading and content is always empty. This section can be used to find
+--- the final lines in the document.
 ---
 ---@param lines string[] The list of lines in the markdown document.
----@return LineDetail[] line_details for each line in the markdown document.
+---@return SectionDetail[] sections defining the document. There will always be at least two items.
+function H.collapse_into_sections(lines)
+  local sections = { H.new_section_detail(1, 1) }
+  local current = sections[1]
+  local current_content_empty = true
+
+  for idx_incl, line_detail in ipairs(H.get_line_details(lines)) do
+    local idx_excl = idx_incl + 1
+
+    if line_detail.type == "header" then
+      table.insert(sections, H.new_section_detail(idx_incl, idx_excl, line_detail.level, line_detail.label))
+      current = sections[#sections]
+      current_content_empty = true
+    elseif line_detail.type == "header-underline" then
+      current.heading.end_excl = idx_excl
+      current.content.beg_incl = idx_excl
+      current.content.end_excl = idx_excl
+    elseif line_detail.type ~= "empty" then
+      if current_content_empty then
+        current.content.beg_incl = idx_incl
+        current_content_empty = false
+      end
+      current.content.end_excl = idx_excl
+    end
+  end
+
+  local eof_excl = current.content.end_excl
+  table.insert(sections, H.new_section_detail(eof_excl, eof_excl))
+
+  return sections
+end
+
+--- Chooses a section to insert new text into.
+---
+---@param sections SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
+---@return integer chosen_idx where the new text can be inserted while maintaining the layout, or `0` if none are valid.
+function H.choose_section(sections, opts)
+  if not opts.section then
+    return 1
+  end
+
+  -- TODO: This loop returns the first match, but users may want more precise control (e.g., "heading is child of X").
+  for idx = 2, #sections - 1 do
+    if sections[idx].heading.label == opts.section.header and sections[idx].heading.level == opts.section.level then
+      return idx
+    end
+  end
+
+  return 0
+end
+
+--- Expands the section positioned at the specified index so that it can have more text inserted into it.
+---
+---@param sections SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param chosen_idx integer The index where the old section is located. Must NOT be the EOF-marker (`idx = #sections`).
+---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
+---@return integer insert_idx where new text should be inserted to satisfy the constraints.
+---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the constraints.
+---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the constraints.
+function H.expand_old_section(sections, chosen_idx, opts)
+  assert(chosen_idx < #sections, "EOF-marker cannot have content placed into it.")
+
+  local section_chosen = sections[chosen_idx]
+  local section_after = sections[chosen_idx + 1]
+
+  local insert_idx = opts.placement == "top" and section_chosen.content.beg_incl or section_chosen.content.end_excl
+  local insert_before = {}
+  local insert_after = {}
+
+  if H.is_content_empty(section_chosen) then
+    table.insert(insert_before, "")
+  end
+
+  if not H.is_section_empty(section_after) and section_after.heading.beg_incl == insert_idx then
+    table.insert(insert_after, "")
+  end
+
+  return insert_idx, insert_before, insert_after
+end
+
+--- Inserts a new heading and section at the specified index and "pushes down" the section that is currently there.
+---
+---@param sections SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param chosen_idx integer The index where the new section will be inserted. Must NOT be the preamble (`idx = 1`).
+---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
+---@return integer insert_idx where new text should be inserted to satisfy the constraints.
+---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the constraints.
+---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the constraints.
+function H.insert_new_section(sections, chosen_idx, opts)
+  assert(chosen_idx > 1, "Preamble cannot have header placed before it.")
+
+  local section_chosen = sections[chosen_idx]
+  local section_before = sections[chosen_idx - 1]
+
+  local insert_idx = section_chosen.heading.beg_incl
+  local insert_before = {}
+  local insert_after = {}
+
+  if not H.is_section_empty(section_before) and section_before.content.end_excl == insert_idx then
+    table.insert(insert_before, "")
+  end
+
+  table.insert(insert_before, string.rep("#", opts.section.level) .. " " .. opts.section.header)
+  table.insert(insert_before, "")
+
+  if not H.is_section_empty(section_chosen) then
+    table.insert(insert_after, "")
+  end
+
+  return insert_idx, insert_before, insert_after
+end
+
+---@type table<string, OnSectionMissingHandler>
+H.on_section_missing_handlers = {
+  cancel = function(_, _)
+    return 0, {}, {}
+  end,
+
+  error = function(_, opts)
+    error("Failed to find section: " .. vim.inspect { header = opts.section.header, level = opts.section.level })
+  end,
+
+  create = function(sections, opts)
+    -- TODO: The choice made here is arbitrary but users may want more precise control (e.g., "insert after section X").
+    local chosen_idx = opts.placement == "bot" and #sections or 2
+
+    return H.insert_new_section(sections, chosen_idx, opts)
+  end,
+}
+
+---@type fun(beg_incl: integer, end_excl: integer, level?: integer, label?: string): SectionDetail
+function H.new_section_detail(beg_incl, end_excl, level, label)
+  return {
+    heading = { beg_incl = beg_incl, end_excl = end_excl, level = level or 0, label = label or "" },
+    content = { beg_incl = end_excl, end_excl = end_excl },
+  }
+end
+
+---@type fun(section?: SectionDetail): boolean
+function H.is_section_empty(section)
+  return not section or section.heading.beg_incl == section.content.end_excl
+end
+
+---@type fun(section?: SectionDetail): boolean
+function H.is_content_empty(section)
+  return not section or section.content.beg_incl == section.content.end_excl
+end
+
+---@type fun(lines: string[]): LineDetail[]
 function H.get_line_details(lines)
   local line_details = {}
   local within_code_block = false
@@ -72,169 +230,6 @@ function H.get_line_details(lines)
 
   return line_details
 end
-
---- Collapses lines into a list of "sections". Each section is itself composed of two sub-sections: heading and content.
---- The heading and content sub-sections are defined using a half-open `[beg_incl, end_excl)` range. When empty, they
---- will use values such that `beg_incl == end_excl`.
----
---- IMPORTANT: There will always be AT LEAST TWO sections.
----
---- The FIRST section is the PREAMBLE. It contains the non-empty lines _before_ the first heading. If there aren't any
---- headings, then it will contain ALL non-empty lines in the file. Otherwise, when the document is empty or when the
---- first line in the document is a heading, then the content section of the preamble will be empty.
----
---- The FINAL section is the EOF-MARKER. Both its heading and content is always empty. This section can be used to find
---- the final lines in the document.
----
----@param line_details LineDetail[] The list of details categorizing each line in the document.
----@return SectionDetail[] sections defining the document. There will always be at least two items.
-function H.collapse_into_sections(line_details)
-  local sections = { H.new_section_detail(1, 1) }
-  local current = sections[1]
-  local current_content_empty = true
-
-  for idx_incl, line_detail in ipairs(line_details) do
-    local idx_excl = idx_incl + 1
-
-    if line_detail.type == "header" then
-      table.insert(sections, H.new_section_detail(idx_incl, idx_excl, line_detail.level, line_detail.label))
-      current = sections[#sections]
-      current_content_empty = true
-    elseif line_detail.type == "header-underline" then
-      current.heading.end_excl = idx_excl
-      current.content.beg_incl = idx_excl
-      current.content.end_excl = idx_excl
-    elseif line_detail.type ~= "empty" then
-      if current_content_empty then
-        current.content.beg_incl = idx_incl
-        current_content_empty = false
-      end
-      current.content.end_excl = idx_excl
-    end
-  end
-
-  local eof_excl = current.content.end_excl
-  table.insert(sections, H.new_section_detail(eof_excl, eof_excl))
-
-  return sections
-end
-
---- Chooses a section to insert new text into.
----
----@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
----@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted.
----@return integer chosen_idx where the the new text can be inserted while maintaining the layout, or `0` if not found.
-function H.choose_section(sections, opts)
-  if not opts.section then
-    return 1
-  end
-  for idx = 2, #sections - 1 do
-    if sections[idx].heading.label == opts.section.header and sections[idx].heading.level == opts.section.level then
-      return idx
-    end
-  end
-  return 0
-end
-
---- Creates a new heading and section at the specified index and then "pushes down" the section that is currently there.
----
---- Assumes that `index > 1` because the preamble is _defined_ as the lines above all of the other headings in the file.
----
----@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
----@param chosen_idx integer The index where the new section will be inserted. Must NOT be the preamble (at `1`).
----@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted.
----@return integer insert_idx where new text should be inserted to satisfy the constraints.
----@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
----@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
-function H.create_new_section(sections, chosen_idx, opts)
-  assert(chosen_idx > 1, "the preamble cannot have headers placed before it.")
-
-  local section_chosen = sections[chosen_idx]
-  local section_before = sections[chosen_idx - 1]
-
-  local insert_idx = section_chosen.heading.beg_incl
-  local insert_before = {}
-  local insert_after = {}
-
-  if not H.is_section_empty(section_before) and section_before.content.end_excl == insert_idx then
-    table.insert(insert_before, "")
-  end
-
-  table.insert(insert_before, string.rep("#", opts.section.level) .. " " .. opts.section.header)
-  table.insert(insert_before, "")
-
-  if not H.is_section_empty(section_chosen) then
-    table.insert(insert_after, "")
-  end
-
-  return insert_idx, insert_before, insert_after
-end
-
---- Expands the section positioned at the specified index so that it can have more text inserted into it.
----
---- Assumes that `index < #sections` because the EOF marker is _defined_ as the empty section of the bottom of the file.
----
----@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
----@param chosen_idx integer The index where the old section is located. Must NOT be the EOF marker (at `#sections`).
----@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted.
----@return integer insert_idx where new text should be inserted to satisfy the constraints.
----@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
----@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
-function H.expand_old_section(sections, chosen_idx, opts)
-  assert(chosen_idx < #sections, "the EOF marker cannot have content placed after it.")
-
-  local section_chosen = sections[chosen_idx]
-  local section_after = sections[chosen_idx + 1]
-
-  local insert_idx = opts.placement == "top" and section_chosen.content.beg_incl or section_chosen.content.end_excl
-  local insert_before = {}
-  local insert_after = {}
-
-  if H.is_section_content_empty(section_chosen) then
-    table.insert(insert_before, "")
-  end
-
-  if not H.is_section_empty(section_after) and section_after.heading.beg_incl == insert_idx then
-    table.insert(insert_after, "")
-  end
-
-  return insert_idx, insert_before, insert_after
-end
-
----@type fun(beg_incl: integer, end_excl: integer, level?: integer, label?: string): SectionDetail
-function H.new_section_detail(beg_incl, end_excl, level, label)
-  return {
-    heading = { beg_incl = beg_incl, end_excl = end_excl, level = level or 0, label = label or "" },
-    content = { beg_incl = end_excl, end_excl = end_excl },
-  }
-end
-
----@type fun(section?: SectionDetail): boolean
-function H.is_section_empty(section)
-  return not section or section.heading.beg_incl == section.content.end_excl
-end
-
----@type fun(section?: SectionDetail): boolean
-function H.is_section_content_empty(section)
-  return not section or section.content.beg_incl == section.content.end_excl
-end
-
----@type table<string, OnSectionMissingHandler>
-H.on_section_missing_handlers = {
-  cancel = function(_, _)
-    return 0, {}, {}
-  end,
-
-  error = function(_, opts)
-    error(string.format("Failed to find the section: %s", vim.inspect(opts.section.header)))
-  end,
-
-  create = function(sections, opts)
-    -- NOTE: The choice made here is arbitrary; users might want to choose the position themselves (maybe w/ a picker?).
-    local chosen_idx = opts.placement == "bot" and #sections or 2
-    return H.create_new_section(sections, chosen_idx, opts)
-  end,
-}
 
 ---@alias (exact) OnSectionMissingHandler fun(sections: SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
 

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -1,0 +1,245 @@
+local HEADER_PREFIX_PATTERN = "^(#+)%s*(%S.*)$"
+local H1_UNDERLINE_PATTERN = "^(=+)$"
+local H2_UNDERLINE_PATTERN = "^(-+)$"
+local CODE_BLOCK_PATTERN = "^```[%w_-]*$"
+
+local M = {}
+local H = {}
+
+--- Resolves the information needed to insert text into the given markdown document while preserving the desired layout.
+---
+---@param lines string[] The list of lines in the markdown document.
+---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
+---@return integer insert_idx where new text should be inserted to satisfy the constraints, or `0` when impossible.
+---@return string[] insert_before holds the lines needed _before_ the text in order to preserve the layout.
+---@return string[] insert_after holds the lines needed _after_ the text in order to preserve the layout.
+function M.resolve(lines, opts)
+  local line_details = H.get_line_details(lines)
+  local sections = H.collapse_into_sections(line_details)
+  local section_idx, section_missing = H.get_section_idx(sections, opts)
+
+  if not section_missing then
+    return H.on_section_found(sections, section_idx, opts)
+  end
+
+  local on_missing_opt = opts.section.on_missing or "create"
+  local on_missing_handler = assert(
+    H.on_missing_handler[on_missing_opt],
+    string.format("unsupported `opts.section.on_missing` option: %s", vim.inspect(on_missing_opt))
+  )
+  return on_missing_handler(sections, section_idx, opts)
+end
+
+--- Produces detail records for each line in the markdown document that meaningfully contributes to the document layout.
+--- Headings defined within codeblock fences (```) will _not_ contribute to the document layout.
+---
+---@param lines string[] The list of lines in the markdown document.
+---@return LineDetail[] line_details for each line in the markdown document.
+function H.get_line_details(lines)
+  local line_details = {}
+  local within_code_block = false
+
+  local function categorize_ith_line_using_early_return_statements(idx)
+    local line_str = vim.trim(lines[idx])
+
+    if within_code_block then
+      within_code_block = not line_str:match(CODE_BLOCK_PATTERN)
+      return { type = "code" }
+    elseif line_str:match(CODE_BLOCK_PATTERN) then
+      within_code_block = true
+      return { type = "code" }
+    end
+
+    if line_str == "" then
+      return { type = "empty" }
+    end
+
+    local level_str, label_str = line_str:match(HEADER_PREFIX_PATTERN)
+    if level_str and label_str and level_str ~= "" and label_str ~= "" then
+      return { type = "header", level = level_str:len(), label = label_str }
+    end
+
+    local prev_line = idx > 1 and line_details[idx - 1] or { type = "empty" }
+    local level = (line_str:match(H1_UNDERLINE_PATTERN) and 1) or (line_str:match(H2_UNDERLINE_PATTERN) and 2)
+    if level and prev_line.type == "text" then
+      line_details[idx - 1] = { type = "header", level = level, label = prev_line.text }
+      return { type = "header-underline" }
+    end
+
+    return { type = "text", text = line_str }
+  end
+
+  for idx = 1, #lines do
+    line_details[idx] = categorize_ith_line_using_early_return_statements(idx)
+  end
+
+  return line_details
+end
+
+--- Collapses lines into a list of "sections". Each section is itself composed of two sub-sections: heading and content.
+--- The heading and content sub-sections are defined using a half-open `[beg_incl, end_excl)` range. When empty, they
+--- will use values such that `beg_incl == end_excl`.
+---
+--- IMPORTANT: There will always be AT LEAST TWO sections.
+---
+--- The FIRST section is the PREAMBLE. It contains the non-empty lines _before_ the first heading. If there aren't any
+--- headings, then it will contain ALL non-empty lines in the file. Otherwise, when the document is empty or when the
+--- first line in the document is a heading, then the content section of the preamble will be empty.
+---
+--- The FINAL section is the EOF-MARKER. Both its heading and content is always empty. This section can be used to find
+--- the final lines in the document.
+---
+---@param line_details LineDetail[] The list of details categorizing each line in the document.
+---@return SectionDetail[] sections defining the document. There will always be at least two items.
+function H.collapse_into_sections(line_details)
+  local sections = { H.new_section_detail(1, 1) }
+  local current = sections[1]
+  local current_content_is_empty = true
+
+  for idx_incl, ith_line in ipairs(line_details) do
+    local idx_excl = idx_incl + 1
+
+    if ith_line.type == "header" then
+      table.insert(sections, H.new_section_detail(idx_incl, idx_excl, ith_line.level, ith_line.label))
+      current = sections[#sections]
+      current_content_is_empty = true
+    elseif ith_line.type == "header-underline" then
+      current.heading.end_excl = idx_excl
+      current.content.beg_incl = idx_excl
+      current.content.end_excl = idx_excl
+    elseif ith_line.type ~= "empty" then
+      if current_content_is_empty then
+        current.content.beg_incl = idx_incl
+        current_content_is_empty = false
+      end
+      current.content.end_excl = idx_excl
+    end
+  end
+
+  local eof_excl = current.content.end_excl
+  table.insert(sections, H.new_section_detail(eof_excl, eof_excl))
+
+  return sections
+end
+
+--- Finds the section index where text should be inserted.
+---
+---@param sections SectionDetail[] List of sections in the document. Must contain preamble and eof-marker.
+---@param opts obsidian.note.InsertTextOpts Options for constraining where text can be inserted into the document.
+---@return integer section_idx where the the new text can be inserted while maintaining the layout.
+---@return boolean section_missing `true` if the specified section couldn't be found.
+function H.get_section_idx(sections, opts)
+  if not opts.section then
+    return 1, false
+  end
+
+  for idx = 2, #sections - 1 do
+    if sections[idx].heading.label == opts.section.header and sections[idx].heading.level == opts.section.level then
+      return idx, false
+    end
+  end
+
+  return opts.placement == "bot" and #sections or 2, true
+end
+
+---@type fun(beg_incl: integer, end_excl: integer, level?: integer, label?: string): SectionDetail
+function H.new_section_detail(beg_incl, end_excl, level, label)
+  return {
+    heading = { beg_incl = beg_incl, end_excl = end_excl, level = level or 0, label = label or "" },
+    content = { beg_incl = end_excl, end_excl = end_excl },
+  }
+end
+
+---@type table<string, InsertHandler>
+H.on_missing_handler = {
+  abort = function(_, _, _)
+    return 0, {}, {}
+  end,
+
+  error = function(_, _, opts)
+    error(string.format("Failed to find the section: %s", vim.inspect(opts.section.header)))
+  end,
+
+  create = function(sections, section_idx, opts)
+    local section = sections[section_idx]
+    local prev_section = sections[section_idx - 1]
+
+    local insert_idx = section.heading.beg_incl
+    local insert_before = { string.rep("#", opts.section.level) .. " " .. opts.section.header, "" }
+    local insert_after = {}
+
+    if not H.is_section_empty(prev_section) and prev_section.content.end_excl == insert_idx then
+      table.insert(insert_before, 1, "")
+    end
+
+    if not H.is_section_empty(section) then
+      table.insert(insert_after, 1, "")
+    end
+
+    return insert_idx, insert_before, insert_after
+  end,
+}
+
+---@type InsertHandler
+function H.on_section_found(sections, section_idx, opts)
+  local section = sections[section_idx]
+  local next_section = sections[section_idx + 1]
+
+  local insert_idx = opts.placement == "top" and section.content.beg_incl or section.content.end_excl
+  local insert_before = {}
+  local insert_after = {}
+
+  if H.is_content_empty(section) then
+    table.insert(insert_before, 1, "")
+  end
+
+  if not H.is_section_empty(next_section) and next_section.heading.beg_incl == insert_idx then
+    table.insert(insert_after, 1, "")
+  end
+
+  return insert_idx, insert_before, insert_after
+end
+
+---@type fun(section: SectionDetail): boolean
+function H.is_section_empty(section)
+  return not section or section.heading.beg_incl == section.content.end_excl
+end
+
+---@type fun(section: SectionDetail): boolean
+function H.is_content_empty(section)
+  return not section or section.content.beg_incl == section.content.end_excl
+end
+
+---@class (exact) LineTextDetail
+---@field type 'text'
+---@field text string
+
+---@class (exact) LineHeaderDetail
+---@field type 'header'
+---@field level integer
+---@field label string
+
+---@class (exact) LineHeaderUnderlineDetail
+---@field type 'header-underline'
+
+---@class (exact) LineCodeDetail
+---@field type 'code'
+
+---@class (exact) LineEmptyDetail
+---@field type 'empty'
+
+---@class (exact) SectionDetail
+---@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }
+---@field content? { beg_incl: integer, end_excl: integer }
+
+---@alias (exact) LineDetail
+---|LineTextDetail
+---|LineHeaderDetail
+---|LineHeaderUnderlineDetail
+---|LineCodeDetail
+---|LineEmptyDetail
+
+---@alias (exact) InsertHandler
+---|fun(sections: SectionDetail[], section_idx: integer, opts: obsidian.note.InsertTextOpts): integer, string[], string[]
+
+return M

--- a/tests/test_note_insert_text.lua
+++ b/tests/test_note_insert_text.lua
@@ -1,0 +1,1254 @@
+local new_set, eq, has_error = MiniTest.new_set, MiniTest.expect.equality, MiniTest.expect.error
+
+local T = dofile("tests/helpers.lua").temp_vault
+local M = require "obsidian.note"
+local H = {}
+
+local EXPECTED_LINE = "> [!IMPORTANT] INSERTED TEXT."
+local EXPECTED_HEADING = "INSERTED HEADING"
+
+T["insert_text"] = new_set()
+T["insert_text"]["section nil"] = new_set()
+T["insert_text"]["section found"] = new_set()
+T["insert_text"]["section missing"] = new_set()
+T["insert_text"]["section missing"]["create"] = new_set()
+T["insert_text"]["section missing"]["error"] = new_set()
+T["insert_text"]["section missing"]["abort"] = new_set()
+T["insert_text"]["section missing"]["invalid key"] = new_set()
+
+T["insert_text"]["section nil"]["should insert at top of preamble_only"] = function()
+  local note = H.save_note {
+    "Body1.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = nil })
+
+  eq(H.load_note(note), {
+    EXPECTED_LINE,
+    "Body1.",
+  })
+end
+
+T["insert_text"]["section nil"]["should insert at bot of preamble_only"] = function()
+  local note = H.save_note {
+    "Body1.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = nil })
+
+  eq(H.load_note(note), {
+    "Body1.",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section nil"]["should insert at top of preamble in multi"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = nil })
+
+  eq(H.load_note(note), {
+    "",
+    EXPECTED_LINE,
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section nil"]["should insert at bot of preamble in multi"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = nil })
+
+  eq(H.load_note(note), {
+    "",
+    EXPECTED_LINE,
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section nil"]["should insert at top of preamble in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = nil })
+
+  eq(H.load_note(note), {
+    EXPECTED_LINE,
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section nil"]["should insert at bot of preamble in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = nil })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    EXPECTED_LINE,
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section nil"]["should replace empty content"] = function()
+  local note = H.save_note {
+    "# H1",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = nil })
+
+  eq(H.load_note(note), {
+    "",
+    EXPECTED_LINE,
+    "",
+    "# H1",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at top of H1 in multi"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "# H1",
+    "",
+    EXPECTED_LINE,
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at bot of H1 in multi"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "# H1",
+    "",
+    "Body1.",
+    EXPECTED_LINE,
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at top of H2 in multi"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 2, header = "H2" } })
+
+  eq(H.load_note(note), {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    EXPECTED_LINE,
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at bot of H2 in multi"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 2, header = "H2" } })
+
+  eq(H.load_note(note), {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section found"]["should insert at top of H1 in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    EXPECTED_LINE,
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at bot of H1 in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    EXPECTED_LINE,
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at top of H2 in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 2, header = "H2" } })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    EXPECTED_LINE,
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at bot of H2 in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 2, header = "H2" } })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section found"]["should insert at top of H1 w/ underline in multi"] = function()
+  local note = H.save_note {
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "H1",
+    "===",
+    "",
+    EXPECTED_LINE,
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at bot of H1 w/ underline in multi"] = function()
+  local note = H.save_note {
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    EXPECTED_LINE,
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at top of H2 w/ underline in multi"] = function()
+  local note = H.save_note {
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 2, header = "H2" } })
+
+  eq(H.load_note(note), {
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    EXPECTED_LINE,
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at bot of H2 w/ underline in multi"] = function()
+  local note = H.save_note {
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 2, header = "H2" } })
+
+  eq(H.load_note(note), {
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section found"]["should insert at top of H1 w/ underline in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "H1",
+    "===",
+    "",
+    EXPECTED_LINE,
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at bot of H1 w/ underline in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    EXPECTED_LINE,
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at top of H2 w/ underline in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 2, header = "H2" } })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    EXPECTED_LINE,
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section found"]["should insert at bot of H2 w/ underline in preamble_multi"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 2, header = "H2" } })
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "H1",
+    "===",
+    "",
+    "Body1.",
+    "",
+    "H2",
+    "---",
+    "",
+    "Body2.",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section found"]["should disregard headings within a code block"] = function()
+  local note = H.save_note {
+    "```markdown",
+    "# H1",
+    "",
+    "BodyInCodeBlock.",
+    "```",
+    "",
+    "# H1",
+    "",
+    "BodyOutsideCodeBlock.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "bot", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "```markdown",
+    "# H1",
+    "",
+    "BodyInCodeBlock.",
+    "```",
+    "",
+    "# H1",
+    "",
+    "BodyOutsideCodeBlock.",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section found"]["should replace empty content"] = function()
+  local note = H.save_note {
+    "# H1",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 1, header = "H1" } })
+
+  eq(H.load_note(note), {
+    "# H1",
+    "",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section found"]["should not treat fenced codeblock ticks as potential headers"] = function()
+  local note = H.save_note {
+    "```markdown",
+    "# ```",
+    "```",
+    "===",
+    "",
+    "# ```",
+    "",
+    "BodyUnderTickHeader.",
+  }
+
+  note:insert_text(EXPECTED_LINE, { placement = "top", section = { level = 1, header = "```" } })
+
+  eq(H.load_note(note), {
+    "```markdown",
+    "# ```",
+    "```",
+    "===",
+    "",
+    "# ```",
+    "",
+    EXPECTED_LINE,
+    "BodyUnderTickHeader.",
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should create in empty top"] = function()
+  local note = H.save_note {}
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+  )
+
+  eq(H.load_note(note), {
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should create in empty bot"] = function()
+  local note = H.save_note {}
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+  )
+
+  eq(H.load_note(note), {
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should create in preamble_only top"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "Ipsum.",
+    "",
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should create in preamble_only bot"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "Ipsum.",
+    "",
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should create in multi top"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+  )
+
+  eq(H.load_note(note), {
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should create in multi bot"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+  )
+
+  eq(H.load_note(note), {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+    "",
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should create in preamble_multi top"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should create in preamble_multi bot"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+    "",
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+  })
+end
+
+T["insert_text"]["section missing"]["error"]["should error w/ empty top"] = function()
+  local note = H.save_note {}
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+    )
+  end)
+end
+
+T["insert_text"]["section missing"]["error"]["should error w/ empty bot"] = function()
+  local note = H.save_note {}
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+    )
+  end)
+end
+
+T["insert_text"]["section missing"]["error"]["should error w/ preamble_only top"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  }
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+    )
+  end)
+end
+
+T["insert_text"]["section missing"]["error"]["should error w/ preamble_only bot"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  }
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+    )
+  end)
+end
+
+T["insert_text"]["section missing"]["error"]["should error w/ multi top"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+    )
+  end)
+end
+
+T["insert_text"]["section missing"]["error"]["should error w/ multi bot"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+    )
+  end)
+end
+
+T["insert_text"]["section missing"]["error"]["should error w/ preamble_multi top"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+    )
+  end)
+end
+
+T["insert_text"]["section missing"]["error"]["should error w/ preamble_multi bot"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+    )
+  end)
+end
+
+T["insert_text"]["section missing"]["abort"]["should abort in empty top"] = function()
+  local note = H.save_note { "" }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+  )
+
+  eq(H.load_note(note), { "" })
+end
+
+T["insert_text"]["section missing"]["abort"]["should abort in empty bot"] = function()
+  local note = H.save_note { "" }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+  )
+
+  eq(H.load_note(note), { "" })
+end
+
+T["insert_text"]["section missing"]["abort"]["should abort in preamble_only top"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  })
+end
+
+T["insert_text"]["section missing"]["abort"]["should abort in preamble_only bot"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  })
+end
+
+T["insert_text"]["section missing"]["abort"]["should abort in multi top"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+  )
+
+  eq(H.load_note(note), {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section missing"]["abort"]["should abort in multi bot"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+  )
+
+  eq(H.load_note(note), {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section missing"]["abort"]["should abort in preamble_multi top"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section missing"]["abort"]["should abort in preamble_multi bot"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section missing"]["invalid key"]["should error with invalid key details"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  has_error(function()
+    note:insert_text(
+      EXPECTED_LINE,
+      ---@diagnostic disable-next-line: assign-type-mismatch
+      { placement = "top", section = { level = 1, header = EXPECTED_HEADING, on_missing = "invalid key" } }
+    )
+  end)
+end
+
+function H.save_note(lines)
+  local path = vim.fn.tempname() .. ".md"
+  vim.fn.writefile(lines, path)
+  return M.from_file(path)
+end
+
+function H.load_note(note)
+  return vim.fn.readfile(tostring(note.path))
+end
+
+return T

--- a/tests/test_note_insert_text.lua
+++ b/tests/test_note_insert_text.lua
@@ -13,7 +13,7 @@ T["insert_text"]["section found"] = new_set()
 T["insert_text"]["section missing"] = new_set()
 T["insert_text"]["section missing"]["create"] = new_set()
 T["insert_text"]["section missing"]["error"] = new_set()
-T["insert_text"]["section missing"]["abort"] = new_set()
+T["insert_text"]["section missing"]["cancel"] = new_set()
 T["insert_text"]["section missing"]["invalid key"] = new_set()
 
 T["insert_text"]["section nil"]["should insert at top of preamble_only"] = function()
@@ -1043,29 +1043,29 @@ T["insert_text"]["section missing"]["error"]["should error w/ preamble_multi bot
   end)
 end
 
-T["insert_text"]["section missing"]["abort"]["should abort in empty top"] = function()
+T["insert_text"]["section missing"]["cancel"]["should cancel in empty top"] = function()
   local note = H.save_note { "" }
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
   )
 
   eq(H.load_note(note), { "" })
 end
 
-T["insert_text"]["section missing"]["abort"]["should abort in empty bot"] = function()
+T["insert_text"]["section missing"]["cancel"]["should cancel in empty bot"] = function()
   local note = H.save_note { "" }
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
   )
 
   eq(H.load_note(note), { "" })
 end
 
-T["insert_text"]["section missing"]["abort"]["should abort in preamble_only top"] = function()
+T["insert_text"]["section missing"]["cancel"]["should cancel in preamble_only top"] = function()
   local note = H.save_note {
     "Lorem.",
     "",
@@ -1074,26 +1074,7 @@ T["insert_text"]["section missing"]["abort"]["should abort in preamble_only top"
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
-  )
-
-  eq(H.load_note(note), {
-    "Lorem.",
-    "",
-    "Ipsum.",
-  })
-end
-
-T["insert_text"]["section missing"]["abort"]["should abort in preamble_only bot"] = function()
-  local note = H.save_note {
-    "Lorem.",
-    "",
-    "Ipsum.",
-  }
-
-  note:insert_text(
-    EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
   )
 
   eq(H.load_note(note), {
@@ -1103,7 +1084,26 @@ T["insert_text"]["section missing"]["abort"]["should abort in preamble_only bot"
   })
 end
 
-T["insert_text"]["section missing"]["abort"]["should abort in multi top"] = function()
+T["insert_text"]["section missing"]["cancel"]["should cancel in preamble_only bot"] = function()
+  local note = H.save_note {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+  )
+
+  eq(H.load_note(note), {
+    "Lorem.",
+    "",
+    "Ipsum.",
+  })
+end
+
+T["insert_text"]["section missing"]["cancel"]["should cancel in multi top"] = function()
   local note = H.save_note {
     "# H1",
     "",
@@ -1116,7 +1116,7 @@ T["insert_text"]["section missing"]["abort"]["should abort in multi top"] = func
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
   )
 
   eq(H.load_note(note), {
@@ -1130,7 +1130,7 @@ T["insert_text"]["section missing"]["abort"]["should abort in multi top"] = func
   })
 end
 
-T["insert_text"]["section missing"]["abort"]["should abort in multi bot"] = function()
+T["insert_text"]["section missing"]["cancel"]["should cancel in multi bot"] = function()
   local note = H.save_note {
     "# H1",
     "",
@@ -1143,7 +1143,7 @@ T["insert_text"]["section missing"]["abort"]["should abort in multi bot"] = func
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
   )
 
   eq(H.load_note(note), {
@@ -1157,7 +1157,7 @@ T["insert_text"]["section missing"]["abort"]["should abort in multi bot"] = func
   })
 end
 
-T["insert_text"]["section missing"]["abort"]["should abort in preamble_multi top"] = function()
+T["insert_text"]["section missing"]["cancel"]["should cancel in preamble_multi top"] = function()
   local note = H.save_note {
     "Lorem.",
     "",
@@ -1172,7 +1172,7 @@ T["insert_text"]["section missing"]["abort"]["should abort in preamble_multi top
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
   )
 
   eq(H.load_note(note), {
@@ -1188,7 +1188,7 @@ T["insert_text"]["section missing"]["abort"]["should abort in preamble_multi top
   })
 end
 
-T["insert_text"]["section missing"]["abort"]["should abort in preamble_multi bot"] = function()
+T["insert_text"]["section missing"]["cancel"]["should cancel in preamble_multi bot"] = function()
   local note = H.save_note {
     "Lorem.",
     "",
@@ -1203,7 +1203,7 @@ T["insert_text"]["section missing"]["abort"]["should abort in preamble_multi bot
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "abort" } }
+    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
   )
 
   eq(H.load_note(note), {


### PR DESCRIPTION
# Add `Note.insert_text` for inserting text under a specific section

Fixes #739.

This PR adds a high-level API to the `Note` class that makes it possible for users to insert text under a specific "section", with an option to create a new section when it doesn't exist. The user can also choose to place it at the top or bottom of the section.

"Section" is a term used in-code to make the logic simpler to reason about (for myself). They are already described in detail by the documentation comments, but here's a slightly-modified copy anyway for convenience:

> Each section is composed of two sub-sections: a heading and a content. Both are defined using a half-open `[beg_incl, end_excl)` range. When empty, they will use values such that `beg_incl == end_excl`.
>
> IMPORTANT: There will always be AT LEAST TWO sections.
>
> The FIRST section is the PREAMBLE. It contains the non-empty lines _before_ the first heading. If there aren't any headings, then it will contain ALL non-empty lines in the file. Otherwise, when the document is empty or when the first line in the document is a heading, then the content section of the preamble will be empty.
>
> The FINAL section is the EOF-MARKER. Both its heading and content is always empty. This section can be used to find the final lines in the document.

The API takes special care to maintain the section layout of the document. Specifically, it:
 
- Preserves the "preamble" by always inserting new sections *after* it.
- Ignores trailing blank lines and keeps new text adjacent to pre-existing text.
- Inserts extra blank lines to keep new text visually separated from surrounding sections.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] ~~The changes are documented in the `README.md` file~~
  - N/A - This PR introduces a class function, and those aren't documented by `README.md` AFAICT. Additionally, I think we need to put more consideration into how an "insert text command" should behave before committing to a more user-facing approach.
- [x] The code complies with `make chores` (for style, lint, types, and tests)
