### PR TITLE
fix: nil or empty in `frontmatter.func` means no inserting frontmatter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Deprecated `preferred_link_style`, `wiki_link_func`, and `markdown_link_func` in favor of `link.style`.
+- Returning nil or empty table in `opts.frontmatter.func` means no inserting frontmatter.
 
 ### Fixed
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -836,7 +836,12 @@ Note.frontmatter_lines = function(self, current_lines)
   end
   if syntax_ok or not has_frontmatter then -- if parse success or there's no frontmatter (and should insert)
     ---@diagnostic disable-next-line: param-type-mismatch
-    return Frontmatter.dump(Obsidian.opts.frontmatter.func(self), order)
+    local frontmatter_properties = Obsidian.opts.frontmatter.func(self)
+    if frontmatter_properties and not vim.tbl_isempty(frontmatter_properties) then
+      return Frontmatter.dump(frontmatter_properties, order)
+    else
+      return current_lines
+    end
   else
     log.info "invalid yaml syntax in frontmatter"
     return current_lines


### PR DESCRIPTION
allows more room for customization to avoid duplicates or just empty fields.
