### PR TITLE
fix: #777

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrong migration process for `opts.use_advanced_uri`.
 - Tag finding will not generate false positives of other list fields.
 - `toggle_checkbox` now works on blank/whitespace-only lines when `checkbox.create_new` is enabled.
+- Proper `filter_text` so that nvim-cmp's matcher don't rule out completion items.
 
 ## [v3.16.0](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.0) - 2026-03-16
 

--- a/lua/obsidian/completion/refs.lua
+++ b/lua/obsidian/completion/refs.lua
@@ -57,4 +57,10 @@ M.get_keyword_pattern = function()
   return [=[\%(^\|[^\[]\)\zs\[\{1,2}[^\]]\+\]\{,2}]=]
 end
 
+---@param label string
+---@return string
+M.get_filter_text = function(label)
+  return "[[" .. label
+end
+
 return M

--- a/lua/obsidian/completion/sources/base/new.lua
+++ b/lua/obsidian/completion/sources/base/new.lua
@@ -147,6 +147,7 @@ function NewNoteSourceBase:process_completion(cc)
     items[#items + 1] = {
       documentation = documentation,
       sortText = new_note_opts.label,
+      filterText = completion.get_filter_text(new_note_opts.label),
       label = label,
       kind = vim.lsp.protocol.CompletionItemKind.Reference,
       textEdit = {

--- a/lua/obsidian/completion/sources/base/refs.lua
+++ b/lua/obsidian/completion/sources/base/refs.lua
@@ -244,6 +244,7 @@ function RefsSourceBase:process_search_results(cc, results)
     table.insert(completion_items, {
       documentation = option.documentation,
       sortText = option.sort_text,
+      filterText = completion.get_filter_text(option.label),
       label = label,
       kind = vim.lsp.protocol.CompletionItemKind.Reference,
       textEdit = {


### PR DESCRIPTION
filter_text is necessary for nvim-cmp's matcher, since once `[[partial` is the trigger, markdown links in the label shaped `[name` will be filtered away

closes #777 #730 
