### PR TITLE
fix(yaml): proper handle of dashes and null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LSP client commands can run actions in actions.lua.
 - Add `Note.insert_text` for inserting text under a specific section
 
+### Fixed
+
+- YAML parser handling of null values and dashes.
+
 ## [v3.16.2](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.2) - 2026-04-08
 
 ### Added

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -812,7 +812,7 @@ end
 ---
 ---@private
 Note._is_frontmatter_boundary = function(line)
-  return line:match "^---+$" ~= nil
+  return line:match "^%-%-%-+$" ~= nil
 end
 
 Note.frontmatter = require("obsidian.builtin").frontmatter

--- a/lua/obsidian/yaml/init.lua
+++ b/lua/obsidian/yaml/init.lua
@@ -89,7 +89,11 @@ local function dumps(x, indent, order)
       for _, v in ipairs(x) do
         local item_lines = dumps(v, indent + 2)
         if #item_lines == 0 then
-          table.insert(out, indent_str .. "- []")
+          if v == vim.NIL then
+            table.insert(out, indent_str .. "-")
+          else
+            table.insert(out, indent_str .. "- []")
+          end
         else
           table.insert(out, indent_str .. "- " .. util.lstrip_whitespace(item_lines[1]))
           for i = 2, #item_lines do

--- a/lua/obsidian/yaml/parser.lua
+++ b/lua/obsidian/yaml/parser.lua
@@ -268,7 +268,11 @@ Parser._try_parse_field = function(self, lines, i, text)
     local out = {}
     local next_line = lines[i + 1]
     local j = i + 1
-    if next_line ~= nil and next_line.indent >= line.indent and (next_line.content == "-" or vim.startswith(next_line.content, "- ")) then
+    if
+      next_line ~= nil
+      and next_line.indent >= line.indent
+      and (next_line.content == "-" or vim.startswith(next_line.content, "- "))
+    then
       -- This is the start of an array.
       local array
       j, array = self:_parse_array(lines, j)

--- a/lua/obsidian/yaml/parser.lua
+++ b/lua/obsidian/yaml/parser.lua
@@ -268,7 +268,7 @@ Parser._try_parse_field = function(self, lines, i, text)
     local out = {}
     local next_line = lines[i + 1]
     local j = i + 1
-    if next_line ~= nil and next_line.indent >= line.indent and vim.startswith(next_line.content, "- ") then
+    if next_line ~= nil and next_line.indent >= line.indent and (next_line.content == "-" or vim.startswith(next_line.content, "- ")) then
       -- This is the start of an array.
       local array
       j, array = self:_parse_array(lines, j)
@@ -330,7 +330,10 @@ end
 Parser._try_parse_array_item = function(self, lines, i, text)
   local line = lines[i]
   text = text and text or yaml_util.strip_comments(line.content)
-  if vim.startswith(text, "- ") then
+  if text == "-" then
+    -- Bare dash is a null array item.
+    return true, i + 1, self:_new_null()
+  elseif vim.startswith(text, "- ") then
     local _, _, array_item_str = string.find(text, "- (.*)")
     local value
     -- Check for null entry.
@@ -355,7 +358,7 @@ Parser._parse_array = function(self, lines, i)
   local item_indent = lines[i].indent
   while i <= #lines do
     local line = lines[i]
-    if line.indent == item_indent and vim.startswith(line.content, "- ") then
+    if line.indent == item_indent and (line.content == "-" or vim.startswith(line.content, "- ")) then
       local is_array_item, value
       is_array_item, i, value = self:_try_parse_array_item(lines, i)
       assert(is_array_item, "not an array item")
@@ -394,7 +397,7 @@ Parser._parse_mapping = function(self, i, lines)
           end
         end
       else
-        error(self:_error_msg("unexpected value found found in table", i))
+        error(self:_error_msg("unexpected value found in table", i))
       end
     else
       break
@@ -625,7 +628,7 @@ end
 ---@param text string
 ---@return boolean, string|?, vim.NIL|nil
 Parser._parse_null = function(self, _, text)
-  if text == "null" or text == "" then
+  if text == "null" or text == "~" or text == "" then
     return true, nil, self:_new_null()
   else
     return false, nil, nil

--- a/tests/yaml/test_yaml.lua
+++ b/tests/yaml/test_yaml.lua
@@ -83,7 +83,21 @@ T["dump"]["should not unnecessarily escape double quotes in strings"] = function
   eq(yaml.dumps { a = 'his name is "Winny the Poo"' }, 'a: his name is "Winny the Poo"')
 end
 
+T["dump"]["should dump null array items as bare dash"] = function()
+  eq(yaml.dumps { vim.NIL, vim.NIL }, "-\n-")
+end
+
+T["dump"]["should dump mixed null and value array items"] = function()
+  eq(yaml.dumps { vim.NIL, "foo", vim.NIL }, "-\n- foo\n-")
+end
+
 T["loads"] = new_set()
+
+T["loads"]["should parse tilde as null"] = function()
+  local data = yaml.loads "a: ~"
+  eq(type(data), "table")
+  eq(data.a, vim.NIL)
+end
 
 T["loads"]["should parse inline lists with quotes on items"] = function()
   local data = yaml.loads 'aliases: ["Foo", "Bar", "Foo Baz"]'
@@ -136,6 +150,25 @@ T["loads"]["should parse implicit null values"] = function()
   eq(type(data), "table")
   eq(data.tags, vim.NIL)
   eq(data.complete, false)
+end
+
+T["loads"]["should parse bare dash as null array item"] = function()
+  local data = yaml.loads "tags:\n  -\n  -"
+  eq(type(data), "table")
+  eq(type(data.tags), "table")
+  eq(#data.tags, 2)
+  eq(data.tags[1], vim.NIL)
+  eq(data.tags[2], vim.NIL)
+end
+
+T["loads"]["should parse mixed bare dash and value array items"] = function()
+  local data = yaml.loads "tags:\n  -\n  - foo\n  -"
+  eq(type(data), "table")
+  eq(type(data.tags), "table")
+  eq(#data.tags, 3)
+  eq(data.tags[1], vim.NIL)
+  eq(data.tags[2], "foo")
+  eq(data.tags[3], vim.NIL)
 end
 
 T["loads"]["should parse wikilinks as strings"] = function()


### PR DESCRIPTION
closes #626 due to wrong frontmatter boundary detection

potentially fix #801 could be macos file reading difference and bare `-` is incorrectly handled.


