### PR TITLE
Add nix flakes support for a dev shell which contains all quality-check tools

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 package-lock.json
 package.json
 .agents/
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1773693634,
+        "narHash": "sha256-BtZ2dtkBdSUnFPPFc+n0kcMbgaTxzFNPv2iaO326Ffg=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "c41e7d58045f9057880b0d85e1152d6a4430dbf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776251070,
+        "narHash": "sha256-awT4MA3kEFeqJks7IMuJUOI41ZoJFC+w9NE0m0GN88A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1ba325b65d53b87872ddd16b9c225f1b290100f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "import-tree": "import-tree",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs";
+    };
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    import-tree.url = "github:vic/import-tree";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake {inherit inputs;}
+    (inputs.import-tree ./nix);
+}

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,14 @@
+{inputs, ...}: {
+  systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+    "x86_64-darwin"
+    "aarch64-darwin"
+  ];
+
+  perSystem = {system, ...}: {
+    _module.args.pkgs = import inputs.nixpkgs {
+      inherit system;
+    };
+  };
+}

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -1,0 +1,15 @@
+{...}: {
+  config = {
+    perSystem = {
+      config,
+      pkgs,
+      ...
+    }: {
+      devShells.default = pkgs.mkShell {
+        packages = [
+          pkgs.gnumake
+        ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
# Add nix flakes support for a dev shell which contains all quality-check tools

This PR adds a `flake.nix` file with the base setup of [flake-parts](https://github.com/hercules-ci/flake-parts) and sets up a dev shell which has all the dependencies for `make chores` available (from nixpkgs).

Additionally, the `.envrc` file for [direnv](https://direnv.net/) allows to enter the dev shell automatically when entering the repo directory.

## Screenshots

TODO Add screenshots to help explain your changes, if applicable.

## PR Checklist

- [x] The PR contains a description of the changes
- [ ] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
