### PR TITLE
fix(note.insert_text): add blank-line when inserting at top of note even when it is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Note.insert_text` for inserting text under a specific section
 - Support `workspace/symbol` to search through note, note aliases and headings.
 - `actions.move_note` to move current note to a folder in the current workspace.
+- Add `padding_top` option to `Note.insert_text` for configuring blank lines inserted at the top of notes.
 
 ### Fixed
 
 - YAML parser handling of null values and dashes.
 - Uses byte offsets consistently in completion sources.
+- Fix `Note.insert_text` to add blank-line when inserting at top of note even when it is empty.
 
 ## [v3.16.2](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.2) - 2026-04-08
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -1265,7 +1265,7 @@ end
 Note.insert_text = function(self, text, opts)
   local text_idx = 0
 
-  opts = opts or {}
+  opts = vim.tbl_extend("keep", opts or {}, { padding_top = self.has_frontmatter })
   opts.update_content = function(lines)
     local insert_idx, insert_before, insert_after = text_insertion.resolve(lines, opts)
 
@@ -1278,7 +1278,6 @@ Note.insert_text = function(self, text, opts)
     local tail = vim.list_slice(lines, insert_idx, #lines)
     return vim.iter({ head, insert_before, text, insert_after, tail }):flatten():totable()
   end
-  if opts.padding_top == nil then opts.padding_top = self.has_frontmatter end
 
   self:save(opts)
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -1278,6 +1278,7 @@ Note.insert_text = function(self, text, opts)
     local tail = vim.list_slice(lines, insert_idx, #lines)
     return vim.iter({ head, insert_before, text, insert_after, tail }):flatten():totable()
   end
+  if opts.padding_top == nil then opts.padding_top = self.has_frontmatter end
 
   self:save(opts)
 
@@ -1384,6 +1385,9 @@ end
 ---@field check_buffers? boolean
 
 ---@class (exact) obsidian.note.InsertTextOpts: obsidian.note.NoteSaveOpts
+--- Whether a blank line is inserted between frontmatter/top-of-file and the first heading of a note.
+--- Defaults to the expression: `note.has_frontmatter`.
+---@field padding_top? boolean
 --- Specifies the section to insert the text into, or `nil` to target the preamble (i.e. the area starting from the top
 --- of the file up to but not including the first heading). Defaults to `nil`.
 ---@field section? obsidian.note.Section

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -139,7 +139,7 @@ function H.insert_new_section(sections, chosen_idx, opts)
   local insert_before = {}
   local insert_after = {}
 
-  if not H.is_section_empty(section_before) and section_before.content.end_excl == insert_idx then
+  if (not H.is_section_empty(section_before) or opts.padding_top) and section_before.content.end_excl == insert_idx then
     table.insert(insert_before, "")
   end
 

--- a/tests/test_note_insert_text.lua
+++ b/tests/test_note_insert_text.lua
@@ -810,6 +810,63 @@ T["insert_text"]["section missing"]["create"]["should create in multi top"] = fu
   })
 end
 
+T["insert_text"]["section missing"]["create"]["should fix top padding"] = function()
+  local note = H.save_note {
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" }, padding_top = true }
+  )
+
+  eq(H.load_note(note), {
+    "",
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+    "",
+    "# H1",
+    "",
+    "Body1.",
+    "",
+    "## H2",
+    "",
+    "Body2.",
+  })
+end
+
+T["insert_text"]["section missing"]["create"]["should preserve correct padding"] = function()
+  local note = H.save_note {
+    "",
+    "# H1",
+    "",
+    "Body1.",
+  }
+
+  note:insert_text(
+    EXPECTED_LINE,
+    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" }, padding_top = true }
+  )
+
+  eq(H.load_note(note), {
+    "",
+    "### " .. EXPECTED_HEADING,
+    "",
+    EXPECTED_LINE,
+    "",
+    "# H1",
+    "",
+    "Body1.",
+  })
+end
+
 T["insert_text"]["section missing"]["create"]["should create in multi bot"] = function()
   local note = H.save_note {
     "# H1",


### PR DESCRIPTION
This PR fixes `Note.insert_text` so that a new-line is always added at the top of the file, even if there's no text in the preamble. This ensures that a new line will separate text from frontmatter at the top of the file.

Users can also control whether the newline is added or not by using the new `padding_top` option.

## Screenshots

Consider this note with just three lines:

````
---
id: lol
---
````

Before this PR, the heading would be placed in the line that immediately follows:

````
---
id: lol
---
# Heading

Lorem Ipsum!
````

After this PR, the heading will have one line of padding between them:

```
---
id: lol
---

# Heading

Lorem Ipsum!
```

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
