### PR TITLE
refactor(note.insert_text): flattened and flexible opts for more-expressive configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add code_actions with `require"obsidian".code_action.add`.
   - Delete code_actions with `require"obsidian".code_action.del`.
 - `Note.create` accept a `title` field for readable name for note.
+- Refactor `Note.insert_text` with flattened and flexible opts for more-expressive configs
 
 ### Fixed
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -1259,31 +1259,56 @@ Note.body_lines = function(self)
   return lines
 end
 
+---@param choice obsidian.note.insert_text.SectionChoice
+---@return { header?: string, level?: integer }
+local function normalize_section_choice(choice)
+  local norm = { header = nil, level = nil }
+
+  if type(choice) == "string" then
+    norm.header = choice
+  elseif type(choice) == "number" then
+    norm.level = choice
+  elseif type(choice) == "table" then
+    if vim.islist(choice) then
+      norm.header = choice[1]
+      norm.level = choice[2]
+    else
+      norm.header = choice.header
+      norm.level = choice.level
+    end
+    assert(norm.header == nil or type(norm.header) == "string", "`section.header` must be string or nil")
+    assert(norm.level == nil or type(norm.level) == "number", "`section.level` must be number or nil")
+  elseif choice ~= nil then
+    error("invalid `section`: " .. vim.inspect(choice))
+  end
+
+  return norm
+end
+
 ---@param text string|string[] The text to insert into the note.
 ---@param opts obsidian.note.InsertTextOpts? The options for constraining where text can be inserted.
 ---@return integer text_idx where the text begins in the file (_including_ frontmatter) or `0` when insert is cancelled.
 Note.insert_text = function(self, text, opts)
-  local text_idx = 0
+  local defaults = { padding_top = self.has_frontmatter }
+  local overrides = { section = normalize_section_choice(opts and opts.section) }
+  opts = vim.tbl_deep_extend("force", defaults, opts or {}, overrides)
 
-  opts = vim.tbl_extend("keep", opts or {}, { padding_top = self.has_frontmatter })
-  opts.update_content = function(lines)
-    local insert_idx, insert_before, insert_after = text_insertion.resolve(lines, opts)
+  local text_idx = self.has_frontmatter and self.frontmatter_end_line or 0
 
-    if insert_idx == 0 then
-      return lines
-    end
-
-    text_idx = insert_idx + #insert_before
-    local head = vim.list_slice(lines, 1, insert_idx - 1)
-    local tail = vim.list_slice(lines, insert_idx, #lines)
-    return vim.iter({ head, insert_before, text, insert_after, tail }):flatten():totable()
-  end
-
-  self:save(opts)
-
-  if self.has_frontmatter and text_idx > 0 then
-    return self.frontmatter_end_line + text_idx
-  end
+  self:save(vim.tbl_extend("error", opts, {
+    update_content = function(lines)
+      local insert_idx, insert_top, insert_bot = text_insertion.resolve(lines, opts)
+      if insert_idx == 0 then
+        text_idx = 0
+        return lines
+      else
+        text_idx = text_idx + insert_idx + #insert_top
+        local top_lines = vim.list_slice(lines, 1, insert_idx - 1)
+        local bot_lines = vim.list_slice(lines, insert_idx, #lines)
+        return vim.iter({ top_lines, insert_top, text, insert_bot, bot_lines }):flatten():totable()
+      end
+    end,
+  }))
 
   return text_idx
 end
@@ -1385,22 +1410,34 @@ end
 ---@field check_buffers? boolean
 
 ---@class (exact) obsidian.note.InsertTextOpts: obsidian.note.NoteSaveOpts
+--- Specifies the section to insert text under. When neither `header` nor `level` are provided, then the "preamble" will
+--- be targeted (i.e. everything from the beginning of the file up to, but not including, the first heading).
+--- Defaults to the preamble.
+---@field section? obsidian.note.insert_text.SectionChoice
+--- Decides what to do when the specified section is not found in the note. Defaults to `create`.
+---@field on_section_missing? obsidian.note.insert_text.OnSectionMissing
 --- Whether a blank line is inserted between frontmatter/top-of-file and the first heading of a note.
 --- Defaults to the expression: `note.has_frontmatter`.
 ---@field padding_top? boolean
---- Specifies the section to insert the text into, or `nil` to target the preamble (i.e. the area starting from the top
---- of the file up to but not including the first heading). Defaults to `nil`.
----@field section? obsidian.note.Section
 --- Specifies where the text should be inserted relative to the section or preamble. Defaults to `top`.
 ---@field placement? "top"|"bot"
 
----@class (exact) obsidian.note.Section
---- The label of the heading.
----@field header string
---- The level of the heading (H1, H2, H3, ...).
----@field level integer
---- Decides what to do when the section is missing. Defaults to `create`.
----@field on_missing? "create"|"error"|"cancel"
+---@alias obsidian.note.insert_text.SectionChoice
+--- Selects the "preamble" (i.e., all of the lines above the first heading in the note).
+---|(nil     | [ nil,     nil     ] | { header: nil,    level: nil     })
+--- Selects the first section with the given `header`, regardless of its `level`.
+--- When `on_section_missing == "create"`, then `level` will default to `2`.
+---|(string  | [ string,  nil     ] | { header: string, level: nil     })
+--- Selects the first section with the given `level`, regardless of its `header`.
+--- When `on_section_missing == "create"`, then `header` will default to `Untitled`.
+---|(integer | [ nil,     integer ] | { header: nil,    level: integer })
+--- Selects the first section with BOTH the given `header` and the given `level`.
+---|(          [ string,  integer ] | { header: string, level: integer })
+
+---@alias obsidian.note.insert_text.OnSectionMissing
+---| "create" Create the missing section where text will be inserted under.
+---| "error"  Force user to handle the missing section by raising an error.
+---| "cancel" Silently abandon the insert operation altogether.
 
 ---@class obsidian.note.HeaderAnchor
 ---

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -11,8 +11,8 @@ local H = {}
 ---@param lines string[] The list of lines in the markdown document.
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints, or `0` when impossible.
----@return string[] insert_before holds the lines needed _before_ the text in order to preserve the constraints.
----@return string[] insert_after holds the lines needed _after_ the text in order to preserve the constraints.
+---@return string[] insert_top holds the lines needed _before_ the text in order to preserve the constraints.
+---@return string[] insert_bot holds the lines needed _after_ the text in order to preserve the constraints.
 function M.resolve(lines, opts)
   local sections = H.collapse_into_sections(lines)
   local chosen_idx = H.choose_section(sections, opts)
@@ -20,8 +20,8 @@ function M.resolve(lines, opts)
   if chosen_idx > 0 then
     return H.expand_old_section(sections, chosen_idx, opts)
   else
-    local key = opts.section.on_missing or "create"
-    local handler = assert(H.on_section_missing_handlers[key], "unsupported `opts.section.on_missing` key: " .. key)
+    local key = opts.on_section_missing or "create"
+    local handler = assert(H.on_section_missing_handlers[key], "unknown `on_section_missing` key: " .. vim.inspect(key))
     return handler(sections, opts)
   end
 end
@@ -78,13 +78,19 @@ end
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer chosen_idx where the new text can be inserted while maintaining the layout, or `0` if none are valid.
 function H.choose_section(sections, opts)
-  if not opts.section then
+  local header_wanted = opts.section.header
+  local level_wanted = opts.section.level
+
+  if not header_wanted and not level_wanted then
     return 1
   end
 
-  -- TODO: This loop returns the first match, but users may want more precise control (e.g., "heading is child of X").
   for idx = 2, #sections - 1 do
-    if sections[idx].heading.label == opts.section.header and sections[idx].heading.level == opts.section.level then
+    local ith_heading = sections[idx].heading or {}
+    if
+      (not header_wanted or ith_heading.label == header_wanted)
+      and (not level_wanted or ith_heading.level == level_wanted)
+    then
       return idx
     end
   end
@@ -98,8 +104,8 @@ end
 ---@param chosen_idx integer The index where the old section is located. Must NOT be the EOF-marker (`idx = #sections`).
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints.
----@return string[] insert_before holds the lines needed _before_ the text in order to preserve the constraints.
----@return string[] insert_after holds the lines needed _after_ the text in order to preserve the constraints.
+---@return string[] insert_top holds the lines needed _before_ the text in order to preserve the constraints.
+---@return string[] insert_bot holds the lines needed _after_ the text in order to preserve the constraints.
 function H.expand_old_section(sections, chosen_idx, opts)
   assert(chosen_idx < #sections, "EOF-marker cannot have content placed into it.")
 
@@ -107,18 +113,18 @@ function H.expand_old_section(sections, chosen_idx, opts)
   local section_after = sections[chosen_idx + 1]
 
   local insert_idx = opts.placement == "top" and section_chosen.content.beg_incl or section_chosen.content.end_excl
-  local insert_before = {}
-  local insert_after = {}
+  local insert_top = {}
+  local insert_bot = {}
 
   if H.is_content_empty(section_chosen) then
-    table.insert(insert_before, "")
+    table.insert(insert_top, "")
   end
 
   if not H.is_section_empty(section_after) and section_after.heading.beg_incl == insert_idx then
-    table.insert(insert_after, "")
+    table.insert(insert_bot, "")
   end
 
-  return insert_idx, insert_before, insert_after
+  return insert_idx, insert_top, insert_bot
 end
 
 --- Inserts a new heading and section at the specified index and "pushes down" the section that is currently there.
@@ -127,8 +133,8 @@ end
 ---@param chosen_idx integer The index where the new section will be inserted. Must NOT be the preamble (`idx = 1`).
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints.
----@return string[] insert_before holds the lines needed _before_ the text in order to preserve the constraints.
----@return string[] insert_after holds the lines needed _after_ the text in order to preserve the constraints.
+---@return string[] insert_top holds the lines needed _before_ the text in order to preserve the constraints.
+---@return string[] insert_bot holds the lines needed _after_ the text in order to preserve the constraints.
 function H.insert_new_section(sections, chosen_idx, opts)
   assert(chosen_idx > 1, "Preamble cannot have header placed before it.")
 
@@ -136,21 +142,21 @@ function H.insert_new_section(sections, chosen_idx, opts)
   local section_before = sections[chosen_idx - 1]
 
   local insert_idx = section_chosen.heading.beg_incl
-  local insert_before = {}
-  local insert_after = {}
+  local insert_top = {}
+  local insert_bot = {}
 
   if (not H.is_section_empty(section_before) or opts.padding_top) and section_before.content.end_excl == insert_idx then
-    table.insert(insert_before, "")
+    table.insert(insert_top, "")
   end
 
-  table.insert(insert_before, string.rep("#", opts.section.level) .. " " .. opts.section.header)
-  table.insert(insert_before, "")
+  table.insert(insert_top, string.rep("#", opts.section.level or 2) .. " " .. (opts.section.header or "Untitled"))
+  table.insert(insert_top, "")
 
   if not H.is_section_empty(section_chosen) then
-    table.insert(insert_after, "")
+    table.insert(insert_bot, "")
   end
 
-  return insert_idx, insert_before, insert_after
+  return insert_idx, insert_top, insert_bot
 end
 
 ---@type table<string, obsidian.note.OnSectionMissingHandler>
@@ -240,7 +246,7 @@ function H.get_line_details(lines)
   return line_details
 end
 
----@alias obsidian.note.OnSectionMissingHandler fun(sections: obsidian.note.SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_before: string[], insert_after: string[]
+---@alias obsidian.note.OnSectionMissingHandler fun(sections: obsidian.note.SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_top: string[], insert_bot: string[]
 
 ---@class obsidian.note.SectionDetail
 ---@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }

--- a/tests/test_note_insert_text.lua
+++ b/tests/test_note_insert_text.lua
@@ -708,7 +708,7 @@ T["insert_text"]["section missing"]["create"]["should create in empty top"] = fu
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+    { placement = "top", on_section_missing = "create", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -723,7 +723,7 @@ T["insert_text"]["section missing"]["create"]["should create in empty bot"] = fu
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+    { placement = "bot", on_section_missing = "create", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -742,7 +742,7 @@ T["insert_text"]["section missing"]["create"]["should create in preamble_only to
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+    { placement = "top", on_section_missing = "create", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -765,7 +765,7 @@ T["insert_text"]["section missing"]["create"]["should create in preamble_only bo
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+    { placement = "bot", on_section_missing = "create", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -792,7 +792,7 @@ T["insert_text"]["section missing"]["create"]["should create in multi top"] = fu
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+    { placement = "top", on_section_missing = "create", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -821,10 +821,12 @@ T["insert_text"]["section missing"]["create"]["should fix top padding"] = functi
     "Body2.",
   }
 
-  note:insert_text(
-    EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" }, padding_top = true }
-  )
+  note:insert_text(EXPECTED_LINE, {
+    placement = "top",
+    on_section_missing = "create",
+    section = { level = 3, header = EXPECTED_HEADING },
+    padding_top = true,
+  })
 
   eq(H.load_note(note), {
     "",
@@ -850,10 +852,12 @@ T["insert_text"]["section missing"]["create"]["should preserve correct padding"]
     "Body1.",
   }
 
-  note:insert_text(
-    EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" }, padding_top = true }
-  )
+  note:insert_text(EXPECTED_LINE, {
+    placement = "top",
+    on_section_missing = "create",
+    section = { level = 3, header = EXPECTED_HEADING },
+    padding_top = true,
+  })
 
   eq(H.load_note(note), {
     "",
@@ -880,7 +884,7 @@ T["insert_text"]["section missing"]["create"]["should create in multi bot"] = fu
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+    { placement = "bot", on_section_missing = "create", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -913,7 +917,7 @@ T["insert_text"]["section missing"]["create"]["should create in preamble_multi t
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+    { placement = "top", on_section_missing = "create", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -948,7 +952,7 @@ T["insert_text"]["section missing"]["create"]["should create in preamble_multi b
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "create" } }
+    { placement = "bot", on_section_missing = "create", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -974,7 +978,7 @@ T["insert_text"]["section missing"]["error"]["should error w/ empty top"] = func
   has_error(function()
     note:insert_text(
       EXPECTED_LINE,
-      { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+      { placement = "top", on_section_missing = "error", section = { level = 3, header = EXPECTED_HEADING } }
     )
   end)
 end
@@ -985,7 +989,7 @@ T["insert_text"]["section missing"]["error"]["should error w/ empty bot"] = func
   has_error(function()
     note:insert_text(
       EXPECTED_LINE,
-      { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+      { placement = "bot", on_section_missing = "error", section = { level = 3, header = EXPECTED_HEADING } }
     )
   end)
 end
@@ -1000,7 +1004,7 @@ T["insert_text"]["section missing"]["error"]["should error w/ preamble_only top"
   has_error(function()
     note:insert_text(
       EXPECTED_LINE,
-      { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+      { placement = "top", on_section_missing = "error", section = { level = 3, header = EXPECTED_HEADING } }
     )
   end)
 end
@@ -1015,7 +1019,7 @@ T["insert_text"]["section missing"]["error"]["should error w/ preamble_only bot"
   has_error(function()
     note:insert_text(
       EXPECTED_LINE,
-      { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+      { placement = "bot", on_section_missing = "error", section = { level = 3, header = EXPECTED_HEADING } }
     )
   end)
 end
@@ -1034,7 +1038,7 @@ T["insert_text"]["section missing"]["error"]["should error w/ multi top"] = func
   has_error(function()
     note:insert_text(
       EXPECTED_LINE,
-      { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+      { placement = "top", on_section_missing = "error", section = { level = 3, header = EXPECTED_HEADING } }
     )
   end)
 end
@@ -1053,7 +1057,7 @@ T["insert_text"]["section missing"]["error"]["should error w/ multi bot"] = func
   has_error(function()
     note:insert_text(
       EXPECTED_LINE,
-      { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+      { placement = "bot", on_section_missing = "error", section = { level = 3, header = EXPECTED_HEADING } }
     )
   end)
 end
@@ -1074,7 +1078,7 @@ T["insert_text"]["section missing"]["error"]["should error w/ preamble_multi top
   has_error(function()
     note:insert_text(
       EXPECTED_LINE,
-      { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+      { placement = "top", on_section_missing = "error", section = { level = 3, header = EXPECTED_HEADING } }
     )
   end)
 end
@@ -1095,7 +1099,7 @@ T["insert_text"]["section missing"]["error"]["should error w/ preamble_multi bot
   has_error(function()
     note:insert_text(
       EXPECTED_LINE,
-      { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "error" } }
+      { placement = "bot", on_section_missing = "error", section = { level = 3, header = EXPECTED_HEADING } }
     )
   end)
 end
@@ -1105,7 +1109,7 @@ T["insert_text"]["section missing"]["cancel"]["should cancel in empty top"] = fu
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+    { placement = "top", on_section_missing = "cancel", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), { "" })
@@ -1116,7 +1120,7 @@ T["insert_text"]["section missing"]["cancel"]["should cancel in empty bot"] = fu
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+    { placement = "bot", on_section_missing = "cancel", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), { "" })
@@ -1131,7 +1135,7 @@ T["insert_text"]["section missing"]["cancel"]["should cancel in preamble_only to
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+    { placement = "top", on_section_missing = "cancel", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -1150,7 +1154,7 @@ T["insert_text"]["section missing"]["cancel"]["should cancel in preamble_only bo
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+    { placement = "bot", on_section_missing = "cancel", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -1173,7 +1177,7 @@ T["insert_text"]["section missing"]["cancel"]["should cancel in multi top"] = fu
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+    { placement = "top", on_section_missing = "cancel", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -1200,7 +1204,7 @@ T["insert_text"]["section missing"]["cancel"]["should cancel in multi bot"] = fu
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+    { placement = "bot", on_section_missing = "cancel", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -1229,7 +1233,7 @@ T["insert_text"]["section missing"]["cancel"]["should cancel in preamble_multi t
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "top", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+    { placement = "top", on_section_missing = "cancel", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -1260,7 +1264,7 @@ T["insert_text"]["section missing"]["cancel"]["should cancel in preamble_multi b
 
   note:insert_text(
     EXPECTED_LINE,
-    { placement = "bot", section = { level = 3, header = EXPECTED_HEADING, on_missing = "cancel" } }
+    { placement = "bot", on_section_missing = "cancel", section = { level = 3, header = EXPECTED_HEADING } }
   )
 
   eq(H.load_note(note), {
@@ -1293,7 +1297,7 @@ T["insert_text"]["section missing"]["invalid key"]["should error with invalid ke
     note:insert_text(
       EXPECTED_LINE,
       ---@diagnostic disable-next-line: assign-type-mismatch
-      { placement = "top", section = { level = 1, header = EXPECTED_HEADING, on_missing = "invalid key" } }
+      { placement = "top", on_section_missing = "invalid key", section = { level = 1, header = EXPECTED_HEADING } }
     )
   end)
 end


### PR DESCRIPTION
This PR flattens the opts for `Note.insert_text` and relaxes its requirements to improve the API's ergonomics. This was done after using the feature myself for a few weeks, so I feel OK with upstreaming these changes to share with others.

I also change some variable/parameter names in this PR so they appear more "symmetric" with related values.

NOTE: No care was taken to add backwards-compatibility. I didn't think it was necessary since an official release hasn't included the `insert_text` API yet, but do let me know if you'd like me to handle it differently!

## Screenshots

N/A

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
