### PR TITLE
feat(commands): add :Obsidian move_note to move current note across vault folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Note.insert_text` for inserting text under a specific section
 - Support `workspace/symbol` to search through note, note aliases and headings.
 - `actions.move_note` to move current note to a folder in the current workspace.
+- `:Obsidian move_note [FOLDER]` command to move the current note, with folder picker support and buffer path update.
 - Add `padding_top` option to `Note.insert_text` for configuring blank lines inserted at the top of notes.
 - `:Obsidian help` has cmdline completion for wiki pages.
 - Obsidian sync client will emit `ObsidianSyncChanged` autocmd event for better status rendering.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ There's one entry point user command for this plugin: `Obsidian`
   - runs `:wa` before renaming, and loads every note with backlinks into your buffer-list
   - after renaming you need to do `:wa` again for changes to take effect
   - alternatively, call `vim.lsp.buf.rename` or use `grn`
+- `:Obsidian move_note [FOLDER]` - move the current note to another folder in the current vault
+  - if `FOLDER` is omitted, opens a folder picker (works with any configured picker; falls back to `vim.ui.select`)
+  - updates the active buffer path to the moved note
 - `:Obsidian toggle_checkbox` - cycle through checkbox options
 
 #### Visual mode commands

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -305,6 +305,8 @@ M.register("toggle_checkbox", { nargs = 0, range = true, note_action = true })
 
 M.register("rename", { nargs = "?", note_action = true })
 
+M.register("move_note", { nargs = "?", complete = "dir", note_action = true })
+
 M.register("paste_img", { nargs = "?", note_action = true })
 
 M.register("extract_note", { mode = "v", nargs = "?", range = true, note_action = true })

--- a/lua/obsidian/commands/move_note.lua
+++ b/lua/obsidian/commands/move_note.lua
@@ -37,7 +37,7 @@ return function(data)
 
   local source_path = Path.buffer(0)
   local source_parent = assert(source_path:parent())
-  local source_filename = assert(source_path.name)
+  local source_filename = assert(source_path.name, "current buffer path has no filename")
 
   local ok = pcall(function()
     source_path:vault_relative_path { strict = true }
@@ -95,7 +95,7 @@ return function(data)
   if data.args and string.len(data.args) > 0 then
     local target_arg = vim.trim(data.args)
     local target_dir = target_arg == "/" and Obsidian.dir or (Obsidian.dir / target_arg)
-    move_to_dir({ text = target_arg, user_data = target_dir })
+    move_to_dir { text = target_arg, user_data = target_dir }
     return
   end
 

--- a/lua/obsidian/commands/move_note.lua
+++ b/lua/obsidian/commands/move_note.lua
@@ -1,0 +1,115 @@
+local api = require "obsidian.api"
+local Path = require "obsidian.path"
+local log = require "obsidian.log"
+
+---@param root obsidian.Path
+---@return obsidian.Path[]
+local function collect_dirs(root)
+  ---@type obsidian.Path[]
+  local dirs = { root }
+
+  ---@param dir obsidian.Path
+  local function walk(dir)
+    for name, kind in vim.fs.dir(tostring(dir)) do
+      if kind == "directory" then
+        local child = dir / name
+        dirs[#dirs + 1] = child
+        walk(child)
+      end
+    end
+  end
+
+  walk(root)
+  table.sort(dirs, function(a, b)
+    return tostring(a) < tostring(b)
+  end)
+
+  return dirs
+end
+
+---@param data obsidian.CommandArgs
+return function(data)
+  local note = api.current_note(0)
+  if not note then
+    log.err "Current buffer is not a markdown note"
+    return
+  end
+
+  local source_path = Path.buffer(0)
+  local source_parent = assert(source_path:parent())
+  local source_filename = assert(source_path.name)
+
+  local ok = pcall(function()
+    source_path:vault_relative_path { strict = true }
+  end)
+  if not ok then
+    log.err("Current note '%s' is outside of the current vault '%s'", source_path, Obsidian.dir)
+    return
+  end
+
+  ---@type obsidian.PickerEntry[]
+  local entries = {}
+  local all_dirs = collect_dirs(Obsidian.dir)
+  for _, dir in ipairs(all_dirs) do
+    local rel = dir == Obsidian.dir and "/" or assert(dir:vault_relative_path { strict = true })
+    entries[#entries + 1] = {
+      text = rel,
+      filename = tostring(dir),
+      user_data = dir,
+    }
+  end
+
+  local function move_to_dir(entry)
+    if not entry then
+      log.warn "Move aborted"
+      return
+    end
+
+    local target_dir = entry.user_data
+    if not target_dir then
+      log.err("Invalid target directory '%s'", tostring(entry.text))
+      return
+    end
+
+    if target_dir == source_parent then
+      log.info "Note is already in that directory"
+      return
+    end
+
+    local target_path = target_dir / source_filename
+    if target_path:exists() then
+      log.err("A note already exists at '%s'", target_path)
+      return
+    end
+
+    target_dir:mkdir { parents = true }
+
+    vim.cmd.write()
+    vim.cmd.saveas(vim.fn.fnameescape(tostring(target_path)))
+
+    vim.fn.delete(tostring(source_path))
+
+    log.info("Moved note to '%s'", target_path)
+  end
+
+  if data.args and string.len(data.args) > 0 then
+    local target_arg = vim.trim(data.args)
+    local target_dir = target_arg == "/" and Obsidian.dir or (Obsidian.dir / target_arg)
+    move_to_dir({ text = target_arg, user_data = target_dir })
+    return
+  end
+
+  if Obsidian.picker and Obsidian.picker.pick then
+    Obsidian.picker.pick(entries, {
+      prompt_title = "Move note to folder",
+      callback = move_to_dir,
+    })
+  else
+    vim.ui.select(entries, {
+      prompt = "Move note to folder",
+      format_item = function(item)
+        return item.text
+      end,
+    }, move_to_dir)
+  end
+end

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -620,13 +620,16 @@ T["move_note"]["should include vault root in folder picker options"] = function(
     end,
   }
 
-  require("obsidian.commands.move_note")({ args = "" })
+  require "obsidian.commands.move_note" { args = "" }
 
   Obsidian.picker = old_picker
 
-  local labels = vim.iter(entries):map(function(e)
-    return e.text
-  end):totable()
+  local labels = vim
+    .iter(entries)
+    :map(function(e)
+      return e.text
+    end)
+    :totable()
   eq(true, vim.tbl_contains(labels, "/"))
 end
 
@@ -641,7 +644,7 @@ T["move_note"]["should move note and update current buffer path"] = function()
   vim.fn.writefile({ "# Sample" }, tostring(source_path))
   vim.cmd.edit(vim.fn.fnameescape(tostring(source_path)))
 
-  require("obsidian.commands.move_note")({ args = "archive" })
+  require "obsidian.commands.move_note" { args = "archive" }
 
   eq(tostring(moved_path), vim.api.nvim_buf_get_name(0))
   eq(false, source_path:exists())

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -603,6 +603,51 @@ T["format_link"]["markdown should respect link.format"] = function()
   eq("[bar](sub/bar.md)", bar_note:format_link())
 end
 
+T["move_note"] = new_set()
+
+T["move_note"]["should include vault root in folder picker options"] = function()
+  local notes_dir = Obsidian.dir / "notes"
+  notes_dir:mkdir { parents = true }
+  local note_path = notes_dir / "sample.md"
+  vim.fn.writefile({ "# Sample" }, tostring(note_path))
+  vim.cmd.edit(vim.fn.fnameescape(tostring(note_path)))
+
+  local entries
+  local old_picker = Obsidian.picker
+  Obsidian.picker = {
+    pick = function(items, _)
+      entries = items
+    end,
+  }
+
+  require("obsidian.commands.move_note")({ args = "" })
+
+  Obsidian.picker = old_picker
+
+  local labels = vim.iter(entries):map(function(e)
+    return e.text
+  end):totable()
+  eq(true, vim.tbl_contains(labels, "/"))
+end
+
+T["move_note"]["should move note and update current buffer path"] = function()
+  local notes_dir = Obsidian.dir / "notes"
+  notes_dir:mkdir { parents = true }
+  local target_dir = Obsidian.dir / "archive"
+  target_dir:mkdir { parents = true }
+
+  local source_path = notes_dir / "sample.md"
+  local moved_path = target_dir / "sample.md"
+  vim.fn.writefile({ "# Sample" }, tostring(source_path))
+  vim.cmd.edit(vim.fn.fnameescape(tostring(source_path)))
+
+  require("obsidian.commands.move_note")({ args = "archive" })
+
+  eq(tostring(moved_path), vim.api.nvim_buf_get_name(0))
+  eq(false, source_path:exists())
+  eq(true, moved_path:exists())
+end
+
 -- T["reference_paths"] = new_set()
 --
 -- T["reference_paths"]["do four basic paths"] = function()


### PR DESCRIPTION
# Move Note Command

What does the PR do?
- Add a new note command: `:Obsidian move_note [FOLDER]`.
- Allow moving the current markdown note to another folder within the active vault.
- Support folder selection via any configured picker (`telescope`, `fzf-lua`, `mini.pick`, `snacks`) with `vim.ui.select` fallback.
- Keep the active buffer synchronized with the moved file path after the move completes.

## What changed
### New command
- Registered `move_note` as a note action command in `lua/obsidian/commands/init.lua`.
- Added optional `FOLDER` argument:
  - `:Obsidian move_note` opens an interactive folder picker.
  - `:Obsidian move_note archive` moves directly to `archive/` (vault-relative).
  - `:Obsidian move_note /` moves to vault root.
### Command behavior
- New implementation in `lua/obsidian/commands/move_note.lua`.
- Validates current buffer is a note in the active vault.
- Builds folder choices from vault root recursively (including `/` root entry).
- Handles safety cases:
  - no-op if destination is current folder,
  - abort if destination file already exists,
  - abort if selection is invalid.
- Saves current buffer, writes new file path via `:saveas`, deletes original file, and leaves user in the moved note buffer (updated buffer path).
## Documentation
- Added `:Obsidian move_note [FOLDER]` to command docs in `README.md` (Note commands).
- Documented picker compatibility and fallback behavior.
## Tests
- Added tests in `tests/test_note.lua`:
  - includes vault root (`/`) in picker options,
  - moves note to target folder and updates current buffer path,
  - verifies source path removal and destination file creation.
- Ran test suite with `make test`.
## Changelog
- Added an Unreleased entry in `CHANGELOG.md` for `:Obsidian move_note [FOLDER]`.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
