### PR TITLE
Fix case mismatch in create note with template dialog

### DIFF
--- a/lua/obsidian/lsp/handlers/_definition.lua
+++ b/lua/obsidian/lsp/handlers/_definition.lua
@@ -40,7 +40,7 @@ local function create_new_note(location, callback)
     actions.new(location, function(note)
       callback { note:_location() }
     end)
-  elseif confirm == "Yes With Template" then
+  elseif confirm == "Yes with Template" then
     actions.new_from_template(location, nil, function(note)
       -- TODO: maybe new_from_template should not have `should_write`
       callback { note:_location() }


### PR DESCRIPTION
creating a new note by following an unresolved link creates a confirmation dialog with an option "Yes with Template", which is then matched against "Yes With Template", the case mismatch causes that option to miss and fall through to the abort return. 

this PR  standardizes the template option with the lowercase "with" 

closes #819

# TODO Fill in Title

What does the PR do?

## Screenshots

TODO Add screenshots to help explain your changes, if applicable.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
