### PR TITLE
feat: update buffer links when creating notes from unresolved links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Update link in buffer when creating a new note via `follow_link`.
 - Add unique note creation prompt option for missing definitions.
 - LSP client commands can run actions in actions.lua.
 - Add `Note.insert_text` for inserting text under a specific section

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ There's one entry point user command for this plugin: `Obsidian`
   - `grr`/`vim.lsp.buf.references` to see references in quickfix list
 - `:Obsidian follow_link [STRATEGY]` - follow a note reference under the cursor
   - available strategies: `vsplit, hsplit, vsplit_force, hsplit_force`
+  - If the link does not exist, you will be prompted to create it. If you choose to create it, the link in the buffer will be automatically updated with the new note's ID and alias.
 - `:Obsidian toc` - get a picker list of table of contents for current note
 - `:Obsidian template [NAME]` - insert a template from the templates folder, selecting from a list using your preferred picker
   - [Template](https://github.com/obsidian-nvim/obsidian.nvim/wiki/Template)

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -10,6 +10,15 @@ local Note = require "obsidian.note"
 ---@param opts { open_strategy: obsidian.config.OpenStrategy|? }|?
 M.follow_link = function(link, opts)
   opts = opts and opts or {}
+  local range
+  if not link then
+    link, _, range = api.cursor_link()
+  end
+
+  if not link then
+    return log.warn "No link found under cursor"
+  end
+
   require("obsidian.lsp.handlers._definition").follow_link(link, function(_, locations)
     local items = vim.lsp.util.locations_to_items(locations, "utf-8")
     local cmd = opts.open_strategy or api.get_open_strategy(Obsidian.opts.open_notes_in)
@@ -18,7 +27,7 @@ M.follow_link = function(link, opts)
     else
       Obsidian.picker.pick(items, { prompt_title = "Resolve link" }) -- calls open_qf_entry by default
     end
-  end)
+  end, { range = range })
 end
 
 ---@param direction "next" | "prev"

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -145,6 +145,7 @@ end
 ---
 ---@return string? link
 ---@return obsidian.search.RefTypes? link_type
+---@return [integer, integer]? range
 M.cursor_link = function()
   local line = vim.api.nvim_get_current_line()
   local _, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
@@ -157,7 +158,7 @@ M.cursor_link = function()
     return cur_col >= open and cur_col <= close
   end)
   if match then
-    return line:sub(match[1], match[2]), match[3]
+    return line:sub(match[1], match[2]), match[3], { match[1], match[2] }
   end
 end
 

--- a/lua/obsidian/lsp/handlers/_definition.lua
+++ b/lua/obsidian/lsp/handlers/_definition.lua
@@ -19,8 +19,13 @@ end
 
 ---@param location string
 ---@param callback function
+---@param opts { range: [integer, integer]|?, label: string|? }|?
 ---@return lsp.Location?
-local function create_new_note(location, callback)
+local function create_new_note(location, callback, opts)
+  opts = opts or {}
+  local bufnr = vim.api.nvim_get_current_buf()
+  local cursor_row = vim.api.nvim_win_get_cursor(0)[1]
+
   local has_template = Obsidian.opts.templates.enabled and Obsidian.opts.templates.folder
   local has_unique = Obsidian.opts.unique_note.enabled
 
@@ -35,20 +40,36 @@ local function create_new_note(location, callback)
 
   local format_options = table.concat(options, "\n")
 
+  local function update_link(note)
+    if opts.range then
+      local new_link = note:format_link { label = opts.label or location }
+      vim.api.nvim_buf_set_text(
+        bufnr,
+        cursor_row - 1,
+        opts.range[1] - 1,
+        cursor_row - 1,
+        opts.range[2],
+        { new_link }
+      )
+    end
+  end
+
   local confirm = api.confirm(("Create new note '%s'?"):format(location), format_options)
   if confirm == "Yes" then
     actions.new(location, function(note)
+      update_link(note)
       callback { note:_location() }
     end)
-  elseif confirm == "Yes With Template" then
+  elseif confirm == "Yes with Template" then
     actions.new_from_template(location, nil, function(note)
-      -- TODO: maybe new_from_template should not have `should_write`
+      update_link(note)
       callback { note:_location() }
     end)
     return
   elseif confirm == "Yes as Unique Note" then
     local note = require("obsidian.unique").new_unique_note(nil, { title = location })
     if note then
+      update_link(note)
       callback { note:_location() }
     end
   else
@@ -59,7 +80,10 @@ end
 ---@type table<obsidian.search.RefTypes, function>
 local handlers = {}
 
-local function open_note(location, callback)
+---@param location string
+---@param callback function
+---@param opts { range: [integer, integer]|?, label: string|? }|?
+local function open_note(location, callback, opts)
   local block_link, anchor_link
   location, block_link = util.strip_block_links(location)
   location, anchor_link = util.strip_anchor_links(location)
@@ -82,7 +106,7 @@ local function open_note(location, callback)
   end
 
   if vim.tbl_isempty(notes) then
-    create_new_note(location, callback)
+    create_new_note(location, callback, opts)
   elseif #notes == 1 then
     callback { notes[1]:_location { block = block_link, anchor = anchor_link } }
   elseif #notes > 1 then
@@ -101,28 +125,28 @@ local function open_attachment(location)
   vim.ui.open(path)
 end
 
-handlers.Wiki = function(location, callback)
+handlers.Wiki = function(location, callback, opts)
   if api.is_attachment_path(location) then
     open_attachment(location)
   else
-    open_note(location, callback)
+    open_note(location, callback, opts)
   end
 end
 
 handlers.WikiWithAlias = handlers.Wiki
 
-handlers.Markdown = function(location, callback)
+handlers.Markdown = function(location, callback, opts)
   local is_uri, scheme = util.is_uri(location)
   if is_uri then
     open_uri(location, scheme)
   elseif api.is_attachment_path(location) then
     open_attachment(location)
   else
-    open_note(location, callback)
+    open_note(location, callback, opts)
   end
 end
 
-handlers.HeaderLink = function(location, callback)
+handlers.HeaderLink = function(location, callback, _)
   local note = api.current_note(0, { collect_anchor_links = true })
   if not note or vim.tbl_isempty(note.anchor_links) then
     return
@@ -143,7 +167,7 @@ handlers.HeaderLink = function(location, callback)
   }
 end
 
-handlers.BlockLink = function(location, callback)
+handlers.BlockLink = function(location, callback, _)
   local note = api.current_note(0, { collect_blocks = true })
   if not note or vim.tbl_isempty(note.blocks) then
     return
@@ -165,9 +189,10 @@ handlers.BlockLink = function(location, callback)
 end
 
 return {
-  follow_link = function(link, callback)
+  follow_link = function(link, callback, opts)
+    opts = opts or {}
     -- TODO: write an alternative treesitter link parser that finds, markdown link, wiki link, image embed
-    local location, _, link_type = util.parse_link(link, { exclude = { "Tag", "BlockID" } })
+    local location, label, link_type = util.parse_link(link, { exclude = { "Tag", "BlockID" } })
     location = vim.uri_decode(location)
 
     if not location then
@@ -186,6 +211,7 @@ return {
       end
     end
 
-    handler(location, wrapped_callback)
+    opts.label = label
+    handler(location, wrapped_callback, opts)
   end,
 }

--- a/lua/obsidian/lsp/handlers/_definition.lua
+++ b/lua/obsidian/lsp/handlers/_definition.lua
@@ -43,14 +43,7 @@ local function create_new_note(location, callback, opts)
   local function update_link(note)
     if opts.range then
       local new_link = note:format_link { label = opts.label or location }
-      vim.api.nvim_buf_set_text(
-        bufnr,
-        cursor_row - 1,
-        opts.range[1] - 1,
-        cursor_row - 1,
-        opts.range[2],
-        { new_link }
-      )
+      vim.api.nvim_buf_set_text(bufnr, cursor_row - 1, opts.range[1] - 1, cursor_row - 1, opts.range[2], { new_link })
     end
   end
 

--- a/lua/obsidian/lsp/handlers/definition.lua
+++ b/lua/obsidian/lsp/handlers/definition.lua
@@ -3,10 +3,10 @@ local api = require("obsidian").api
 ---@param _ lsp.DefinitionParams
 ---@param handler fun(_:any, locations: lsp.Location[])
 return function(_, handler)
-  local link = api.cursor_link()
+  local link, _, range = api.cursor_link()
 
   if not link then
     return handler(nil, {})
   end
-  require("obsidian.lsp.handlers._definition").follow_link(link, handler)
+  require("obsidian.lsp.handlers._definition").follow_link(link, handler, { range = range })
 end

--- a/tests/test_follow_link_create.lua
+++ b/tests/test_follow_link_create.lua
@@ -42,7 +42,7 @@ T["follow link to non-existing note and create it"] = function()
 
   -- Check if the new note was opened
   local current_buf_name = child.api.nvim_buf_get_name(0)
-  assert(current_buf_name:match("fixed%-id%-new note%.md$"), "New note should be opened, but got " .. current_buf_name)
+  assert(current_buf_name:match "fixed%-id%-new note%.md$", "New note should be opened, but got " .. current_buf_name)
 end
 
 T["follow link with alias to non-existing note and create it"] = function()

--- a/tests/test_follow_link_create.lua
+++ b/tests/test_follow_link_create.lua
@@ -1,0 +1,76 @@
+local h = dofile "tests/helpers.lua"
+local T, child = h.child_vault {
+  pre_case = [[M = require"obsidian.api"]],
+}
+local eq = MiniTest.expect.equality
+
+T["cursor_link returns range"] = function()
+  child.api.nvim_buf_set_lines(0, 0, -1, false, { "The [[new note]] link" })
+  child.api.nvim_win_set_cursor(0, { 1, 5 })
+  local link, t, range = unpack(child.lua_get [[{ M.cursor_link() }]])
+  eq("[[new note]]", link)
+  eq("Wiki", t)
+  eq({ 5, 16 }, range)
+end
+
+T["follow link to non-existing note and create it"] = function()
+  child.lua [[
+    Obsidian.opts.note_id_func = function(title)
+      return "fixed-id-" .. (title or "none")
+    end
+    M.confirm = function()
+      return "Yes"
+    end
+  ]]
+
+  local files = h.mock_vault_contents(child.Obsidian.dir, {
+    ["referencer.md"] = [==[
+[[new note]]
+]==],
+  })
+
+  child.cmd("edit " .. files["referencer.md"])
+  local ref_bufnr = child.api.nvim_get_current_buf()
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+
+  -- Trigger follow_link via actions.follow_link which is accessible via M.follow_link
+  child.lua "M.follow_link()"
+
+  -- Switch back to the referencer buffer to check content
+  local lines = child.api.nvim_buf_get_lines(ref_bufnr, 0, -1, false)
+  eq("[[fixed-id-new note|new note]]", lines[1])
+
+  -- Check if the new note was opened
+  local current_buf_name = child.api.nvim_buf_get_name(0)
+  assert(current_buf_name:match("fixed%-id%-new note%.md$"), "New note should be opened, but got " .. current_buf_name)
+end
+
+T["follow link with alias to non-existing note and create it"] = function()
+  child.lua [[
+    Obsidian.opts.note_id_func = function(title)
+      return "fixed-id-" .. (title or "none")
+    end
+    M.confirm = function()
+      return "Yes"
+    end
+  ]]
+
+  local files = h.mock_vault_contents(child.Obsidian.dir, {
+    ["referencer.md"] = [==[
+[[new note|some alias]]
+]==],
+  })
+
+  child.cmd("edit " .. files["referencer.md"])
+  local ref_bufnr = child.api.nvim_get_current_buf()
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+
+  -- Trigger follow_link via actions.follow_link which is accessible via M.follow_link
+  child.lua "M.follow_link()"
+
+  -- Switch back to the referencer buffer to check content
+  local lines = child.api.nvim_buf_get_lines(ref_bufnr, 0, -1, false)
+  eq("[[fixed-id-new note|some alias]]", lines[1])
+end
+
+return T


### PR DESCRIPTION
  This PR fixes a common friction point when creating new notes from unresolved links.

  The Problem (Before this PR):
  When a user follows a link to a non-existent note (e.g., [[non-existent-note]]) and chooses to create it, the plugin creates the note using the configured note_id_func. However, the original link in the buffer remains unchanged. Since the new note's filename is based on an ID (like 1778168421-CXBI.md) and not the original title, the link in the buffer becomes "broken" in both Neovim and the Obsidian app because it no longer points to the correct file.

  The Solution (After this PR):
  When a new note is created via follow_link, the plugin now automatically replaces the placeholder link in your current buffer with a properly formatted link that includes the new Note ID and the original title as an alias.

   * Before: [[non-existent-note]]
   * After: [[1778168421-CXBI|non-existent-note]]
   
This ensures that the link remains functional in the Obsidian app and Neovim immediately after creation.

<img width="1265" height="484" alt="Screenshot From 2026-05-07 18-01-36" src="https://github.com/user-attachments/assets/db2bf121-ef50-45e9-9575-317ecfc2f5df" />

<img width="2501" height="447" alt="Screenshot From 2026-05-07 18-02-25" src="https://github.com/user-attachments/assets/9f0d1814-b323-4013-8493-0e866ed93471" />

<img width="1142" height="511" alt="Screenshot From 2026-05-07 18-05-21" src="https://github.com/user-attachments/assets/4f008cd6-a9e7-481d-9a9c-e66be40dc59e" />

<img width="1018" height="451" alt="Screenshot From 2026-05-07 18-02-42" src="https://github.com/user-attachments/assets/ce2c3e72-1e13-4b1f-9c0d-d9ef7e3fb2ae" />

  Key Changes
   - Link Range Tracking: Updated api.cursor_link() to return the exact buffer range of the link.
   - Unified Creation Logic: Refactored create_new_note in _definition.lua to ensure links are updated regardless of the creation method (Standard, Template, or Unique Note).
   - Alias Preservation: Automatically uses the original link text as the alias in the updated link.

  PR Checklist
   - [x] Description: Clear explanation included.
   - [x] Changelog: CHANGELOG.md updated.
   - [x] Documentation: README.md updated to reflect the new behavior.
   - [x] Tests: New test cases added in tests/test_follow_link_create.lua to verify buffer updates for both plain and aliased links.
   - [x] Verification: All 551 tests passed.