### PR TITLE
docs: fix note_id_func example in preset guide

### DIFF
--- a/docs/Note.md
+++ b/docs/Note.md
@@ -36,9 +36,7 @@ If you want readable UTF-8 title-based IDs (works across scripts), use the built
 
 ```lua
 require("obsidian").setup {
-  note = {
-    id_func = require("obsidian.builtin").title_id,
-  },
+  note_id_func = require("obsidian.builtin").title_id,
 }
 ```
 


### PR DESCRIPTION
# Note ID Presets

I’m not sure whether this is a bug or an intentional schema change, but I found that it needs to be configured this way in order to set the note ID preset. I noticed this was inconsistent with the documentation, so I updated it. If this is not the intended behavior, I’ll close the PR.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
