### PR TITLE
Update picker enum values and add picker documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set `opts.sync.configs = {}` to disable obsidian.nvim from racing to sync config with obsidian app using the same folder.
 - Removes unnecessary sync log messages.
 - Unique note creation through link gets a proper readable title instead of id.
+- Updated picker enum values to use correct module names and added picker configuration documentation in README.md.
 
 ## [v3.16.2](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.2) - 2026-04-08
 

--- a/README.md
+++ b/README.md
@@ -170,12 +170,13 @@ There's no required dependency, but there are a number of optional dependencies 
 
 To use a specific picker, set `picker.name` in your config, e.g.:
 ```lua
-picker = {
-  name = "snacks.picker",  -- use snacks picker
-  -- name = "telescope.nvim",   -- or telescope
-  -- name = "fzf-lua",     -- or fzf-lua
-  -- name = "mini.pick",   -- or mini.pick
-}
+require"obsidian".setup {
+   picker = {
+    name = "snacks.picker",  -- use snacks picker
+    -- name = "telescope.nvim",   -- or telescope
+    -- name = "fzf-lua",     -- or fzf-lua
+    -- name = "mini.pick",   -- or mini.pick
+}}
 ```
 
 **Image viewing:**

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ There's no required dependency, but there are a number of optional dependencies 
 - [mini.pick](https://github.com/echasnovski/mini.pick)
 - [snacks.picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md)
 
+To use a specific picker, set `picker.name` in your config, e.g.:
+```lua
+picker = {
+  name = "snacks.picker",  -- use snacks picker
+  -- name = "telescope.nvim",   -- or telescope
+  -- name = "fzf-lua",     -- or fzf-lua
+  -- name = "mini.pick",   -- or mini.pick
+}
+```
+
 **Image viewing:**
 
 - [snacks.image](https://github.com/folke/snacks.nvim/blob/main/docs/image.md)

--- a/lua/obsidian/config/init.lua
+++ b/lua/obsidian/config/init.lua
@@ -25,7 +25,7 @@ config.Picker = {
   telescope = "telescope.nvim",
   fzf_lua = "fzf-lua",
   mini = "mini.pick",
-  snacks = "snacks.pick",
+  snacks = "snacks.picker",
 }
 
 config.default = require "obsidian.config.default"

--- a/lua/obsidian/picker/init.lua
+++ b/lua/obsidian/picker/init.lua
@@ -278,7 +278,8 @@ M.get = function(picker_name)
     patch "obsidian.picker._mini"
   elseif picker_name == string.lower(PickerName.fzf_lua) then
     patch "obsidian.picker._fzf"
-  elseif picker_name == string.lower(PickerName.snacks) then
+    -- or statement added for backwards compatibility
+  elseif picker_name == string.lower(PickerName.snacks) or picker_name == "snacks.pick" then
     patch "obsidian.picker._snacks"
   else
     patch "obsidian.picker._default"


### PR DESCRIPTION
To close [Issue #821](https://github.com/obsidian-nvim/obsidian.nvim/issues/821)

Related [Disscussion #524](https://github.com/orgs/obsidian-nvim/discussions/524)

This pull request updates documentation and configuration to clarify and correct the usage of picker plugins. The main changes ensure that users can easily select their preferred picker and that the correct module names are referenced.

I decided against adding an alias in favor of keeping the PR as small as possible, it would require touching more than I first assumed.

Configuration and documentation improvements:

* Updated the example configuration in `README.md` to show how to set the `picker.name` for various pickers, making it clearer for users to choose and configure their preferred picker plugin.
* Fixed the `snacks` picker module name in `lua/obsidian/config/init.lua` from `snacks.pick` to the correct `snacks.picker`, ensuring proper integration.

# TODO Fill in Title

What does the PR do?

Changes `snacks.pick` to `snacks.picker` and add a small note into the README.md to show how to use your picker.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
