### PR TITLE
Fix: preserve anchors and blocks when creating notes from unresolved links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update link in buffer when creating a new note via `follow_link`.
 - Minimal `.base` support, definition, references and quick_switch will work.
 
+### Fixed
+
+- Preserve anchors and blocks when creating notes from unresolved links.
+
 ## [v3.16.3](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.3) - 2026-05-08
 
 ### Added

--- a/lua/obsidian/builtin.lua
+++ b/lua/obsidian/builtin.lua
@@ -86,11 +86,19 @@ M.wiki_link = function(opts)
   local anchor = ""
   local header = ""
   if opts.anchor then
-    anchor = opts.anchor.anchor
-    header = format_anchor_label(opts.anchor)
+    if type(opts.anchor) == "table" then
+      anchor = opts.anchor.anchor
+      header = format_anchor_label(opts.anchor)
+    else
+      anchor = opts.anchor
+    end
   elseif opts.block then
-    anchor = "#" .. opts.block.id
-    header = "#" .. opts.block.id
+    if type(opts.block) == "table" then
+      anchor = "#" .. opts.block.id
+      header = "#" .. opts.block.id
+    else
+      anchor = opts.block
+    end
   end
 
   local path = tostring(opts.path or "")
@@ -112,11 +120,19 @@ M.markdown_link = function(opts)
   local anchor = ""
   local header = ""
   if opts.anchor then
-    anchor = opts.anchor.anchor
-    header = format_anchor_label(opts.anchor)
+    if type(opts.anchor) == "table" then
+      anchor = opts.anchor.anchor
+      header = format_anchor_label(opts.anchor)
+    else
+      anchor = opts.anchor
+    end
   elseif opts.block then
-    anchor = "#" .. opts.block.id
-    header = "#" .. opts.block.id
+    if type(opts.block) == "table" then
+      anchor = "#" .. opts.block.id
+      header = "#" .. opts.block.id
+    else
+      anchor = opts.block
+    end
   end
 
   local util = require "obsidian.util"

--- a/lua/obsidian/lsp/handlers/_definition.lua
+++ b/lua/obsidian/lsp/handlers/_definition.lua
@@ -42,7 +42,7 @@ local function create_new_note(location, callback, opts)
 
   local function update_link(note)
     if opts.range then
-      local new_link = note:format_link { label = opts.label or location }
+      local new_link = note:format_link { label = opts.label or location, anchor = opts.anchor, block = opts.block }
       vim.api.nvim_buf_set_text(bufnr, cursor_row - 1, opts.range[1] - 1, cursor_row - 1, opts.range[2], { new_link })
     end
   end
@@ -77,9 +77,9 @@ local handlers = {}
 ---@param callback function
 ---@param opts { range: [integer, integer]|?, label: string|? }|?
 local function open_note(location, callback, opts)
-  local block_link, anchor_link
+  local block_link, anchor_link, raw_anchor
   location, block_link = util.strip_block_links(location)
-  location, anchor_link = util.strip_anchor_links(location)
+  location, anchor_link, raw_anchor = util.strip_anchor_links(location)
 
   local notes = search.resolve_note(location, {
     notes = { collect_anchor_links = anchor_link ~= nil, collect_blocks = block_link ~= nil },
@@ -99,6 +99,8 @@ local function open_note(location, callback, opts)
   end
 
   if vim.tbl_isempty(notes) then
+    opts.anchor = raw_anchor
+    opts.block = block_link
     create_new_note(location, callback, opts)
   elseif #notes == 1 then
     callback { notes[1]:_location { block = block_link, anchor = anchor_link } }

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -445,11 +445,11 @@ util.strip_anchor_links = function(line)
   end
 
   if #parts == 0 then
-    return line, nil
+    return line, nil, nil
   end
 
   local anchor = table.concat(parts, "")
-  return line, util.standardize_anchor(anchor)
+  return line, util.standardize_anchor(anchor), anchor
 end
 
 --- Parse a block line from a line.

--- a/tests/test_follow_link_create.lua
+++ b/tests/test_follow_link_create.lua
@@ -73,4 +73,37 @@ T["follow link with alias to non-existing note and create it"] = function()
   eq("[[fixed-id-new note|some alias]]", lines[1])
 end
 
+T["follow link with anchor to non-existing note and create it"] = function()
+  child.lua [[
+    Obsidian.opts.note_id_func = function(title)
+      return "fixed-id-" .. (title or "none")
+    end
+    M.confirm = function()
+      return "Yes"
+    end
+  ]]
+
+  local files = h.mock_vault_contents(child.Obsidian.dir, {
+    ["referencer.md"] = [==[
+[[new note#Some Header]]
+]==],
+  })
+
+  child.cmd("edit " .. files["referencer.md"])
+  local ref_bufnr = child.api.nvim_get_current_buf()
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+
+  -- Trigger follow_link
+  child.lua "M.follow_link()"
+
+  -- The link should be updated to point to the new ID,
+  -- but keep the anchor and the original title as the alias.
+  local lines = child.api.nvim_buf_get_lines(ref_bufnr, 0, -1, false)
+  eq("[[fixed-id-new note#Some Header|new note#Some Header]]", lines[1])
+
+  -- Check if the new note was actually opened (ignoring the anchor for the filename)
+  local current_buf_name = child.api.nvim_buf_get_name(0)
+  assert(current_buf_name:match "fixed%-id%-new note%.md$", "New note should be opened, but got " .. current_buf_name)
+end
+
 return T


### PR DESCRIPTION
This PR fixes a bug where anchors (e.g., [[note#Header]]) and block links (e.g., [[note#^block]]) were lost when a user followed an unresolved link and chose to create the new note.

  Previously, the plugin would strip the anchor/block to resolve the filename for the new note but would then use that stripped name to update the link in the original buffer. This resulted in
  the anchor/block being permanently removed from the link.

  Key changes:
   - Updated util.strip_anchor_links to return the raw anchor string (preserving original casing).
   - Enhanced wiki_link and markdown_link to support string-based anchor and block options. This is necessary because when creating a new note, we don't yet have a HeaderAnchor object from the
     unwritten file's content.
   - Modified open_note and create_new_note to pass through and apply these anchors/blocks when updating the buffer.
   - Added a regression test in tests/test_follow_link_create.lua.

  Screenshots
  
<img width="3455" height="417" alt="01" src="https://github.com/user-attachments/assets/0dc6ccf3-a0f2-4315-8c29-336ca0dd55bc" />
<img width="3455" height="437" alt="02" src="https://github.com/user-attachments/assets/d311b5ad-d9d4-4e5f-82f0-860a23ea4b85" />
<img width="3455" height="454" alt="03" src="https://github.com/user-attachments/assets/be0b54e9-4c7d-495a-ae7f-cd0c5b97d523" />
<img width="3455" height="454" alt="04" src="https://github.com/user-attachments/assets/877cee29-7800-4042-9f6c-d4421f2c947b" />
<img width="3455" height="467" alt="05" src="https://github.com/user-attachments/assets/59522ebf-2973-4c62-bcc9-c37408d9101c" />
<img width="3455" height="417" alt="06" src="https://github.com/user-attachments/assets/8c47de11-a2cc-4850-93c7-22207e59e4be" />


  Before: [[New Note#Some Header]] -> [[fixed-id-new-note|New Note]] (Anchor lost)
  After: [[New Note#Some Header]] -> [[fixed-id-new-note#Some Header|New Note#Some Header]] (Anchor preserved)

  PR Checklist

   - [x] The PR contains a description of the changes
   - [x] I read the [CONTRIBUTING.md] file
   - [x] The CHANGELOG.md is updated
   - [x] The changes are documented in the README.md file (Existing documentation for follow_link already covers this behavior, but the fix ensures it works as described)
   - [x] The code complies with make chores (style and tests passed)
