### PR TITLE
Fix dailies command typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ There's one entry point user command for this plugin: `Obsidian`
 #### Top level commands
 
 - `:Obsidian check` - check for common issues in your vault and plugin setup
-- `:Obsidian ailies [OFFSET ...]` - open a picker list of daily notes
+- `:Obsidian dailies [OFFSET ...]` - open a picker list of daily notes
   - `:Obsidian dailies -2 1` to list daily notes from 2 days ago until tomorrow
 - `:Obsidian help` - find files in the help wiki
 - `:Obsidian helpgrep` - grep files in the help wiki


### PR DESCRIPTION
Fixes #837

What does the PR do?

This corrects the top-level README command from `:Obsidian ailies` to `:Obsidian dailies`, matching the existing command name and example below it.

## Screenshots

Not applicable; this is a README-only typo fix.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)

Verification:

- `rg -n ailies|dailies README.md docs lua --glob !vendor/** --glob !node_modules/**`
- `git diff --check` (clean, with Windows LF/CRLF warning only)