### PR TITLE
refactor: simplify job impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Preserve anchors and blocks when creating notes from unresolved links.
+- WIP: proper async jobs and no `block_on` calls which performs bad on windows.
 
 ## [v3.16.3](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.3) - 2026-05-08
 

--- a/lua/obsidian/async.lua
+++ b/lua/obsidian/async.lua
@@ -8,7 +8,6 @@ local M = {}
 ---@param on_exit function|? (integer) -> nil
 M.run_job_async = function(cmds, on_stdout, on_exit)
   local stderr_lines = false
-  local cancelled = false
 
   local on_obj = function(obj)
     --- NOTE: commands like `rg` return a non-zero exit code when there are no matches, which is okay.

--- a/lua/obsidian/async.lua
+++ b/lua/obsidian/async.lua
@@ -6,9 +6,9 @@ local M = {}
 ---@param cmds string[]
 ---@param on_stdout function|? (string) -> nil
 ---@param on_exit function|? (integer) -> nil
----@param sync boolean
-local init_job = function(cmds, on_stdout, on_exit, sync)
+M.run_job_async = function(cmds, on_stdout, on_exit)
   local stderr_lines = false
+  local cancelled = false
 
   local on_obj = function(obj)
     --- NOTE: commands like `rg` return a non-zero exit code when there are no matches, which is okay.
@@ -46,34 +46,11 @@ local init_job = function(cmds, on_stdout, on_exit, sync)
     end
   end
 
-  return function()
-    log.debug("Initializing job '%s'", cmds)
+  log.debug("Initializing job '%s'", cmds)
 
-    if sync then
-      local obj = vim.system(cmds, { stdout = stdout, stderr = stderr }):wait()
-      on_obj(obj)
-      return obj
-    else
-      vim.system(cmds, { stdout = stdout, stderr = stderr }, on_obj)
-    end
-  end
-end
+  local sys_obj = vim.system(cmds, { stdout = stdout, stderr = stderr }, on_obj)
 
----@param cmds string[]
----@param on_stdout function|? (string) -> nil
----@param on_exit function|? (integer) -> nil
----@return integer exit_code
-M.run_job = function(cmds, on_stdout, on_exit)
-  local job = init_job(cmds, on_stdout, on_exit, true)
-  return job().code
-end
-
----@param cmds string[]
----@param on_stdout function|? (string) -> nil
----@param on_exit function|? (integer) -> nil
-M.run_job_async = function(cmds, on_stdout, on_exit)
-  local job = init_job(cmds, on_stdout, on_exit, false)
-  job()
+  return sys_obj
 end
 
 ---@param fn function
@@ -120,25 +97,38 @@ M.throttle = function(fn, timeout)
 end
 
 ---Run an async function in a non-async context. The async function is expected to take a single
----callback parameters with the results. This function returns those results.
----@param async_fn_with_callback function (function,) -> any
+---callback parameter with the results. This function returns those results.
+---
+---On timeout, returns nil and (when supported) cancels the underlying job. The async function may
+---optionally return an `obsidian.async.JobHandle` (or any table with a `kill` method) so that
+---`block_on` can terminate the in-flight work instead of letting it run on past the timeout.
+---
+---@param async_fn_with_callback fun(cb: fun(...:any)): any
 ---@param timeout integer|?
 ---@return ...any results
 M.block_on = function(async_fn_with_callback, timeout)
   local done = false
-  local result
-  timeout = timeout and timeout or 2000
+  local result = {}
+  timeout = timeout or 2000
 
   local function collect_result(...)
     result = { ... }
     done = true
   end
 
-  async_fn_with_callback(collect_result)
+  local handle = async_fn_with_callback(collect_result)
 
   vim.wait(timeout, function()
     return done
   end, 20, false)
+
+  if not done then
+    log.warn("block_on timed out after %dms; cancelling job", timeout)
+    if handle and type(handle) == "table" and type(handle.kill) == "function" then
+      pcall(handle.kill, handle, "sigterm")
+    end
+    return nil
+  end
 
   return unpack(result)
 end

--- a/lua/obsidian/img_paste.lua
+++ b/lua/obsidian/img_paste.lua
@@ -1,6 +1,5 @@
 local Path = require "obsidian.path"
 local log = require "obsidian.log"
-local run_job = require("obsidian.async").run_job
 local api = require "obsidian.api"
 local util = require "obsidian.util"
 
@@ -96,7 +95,7 @@ end
 ---@param path string
 ---@param img_type "png" | "jpeg"
 ---
----@return boolean|integer|? result
+---@return boolean|? result
 local function save_clipboard_image(path, img_type)
   local this_os = api.get_os()
 
@@ -106,19 +105,19 @@ local function save_clipboard_image(path, img_type)
     local display_server = os.getenv "XDG_SESSION_TYPE"
     if display_server == "x11" or display_server == "tty" then
       cmd = string.format("xclip -selection clipboard -t %s -o > '%s'", mime_type, path)
-      return run_job { "bash", "-c", cmd }
+      return vim.system({ "bash", "-c", cmd }):wait() ~= 0
     elseif display_server == "wayland" then
       cmd = string.format("wl-paste --no-newline --type %s > %s", mime_type, vim.fn.shellescape(path))
-      return run_job { "bash", "-c", cmd }
+      return vim.system({ "bash", "-c", cmd }):wait() ~= 0
     end
   elseif this_os == api.OSType.Windows or this_os == api.OSType.Wsl then
     local cmd = 'powershell.exe -c "'
       .. string.format("(get-clipboard -format image).save('%s', 'png')", string.gsub(path, "/", "\\"))
       .. '"'
-    local ret = os.execute(cmd)
+    local ret = os.execute(cmd) -- TODO:
     return ret
   elseif this_os == api.OSType.Darwin then
-    return run_job { "pngpaste", path }
+    return vim.system({ "pngpaste", path }):wait() ~= 0
   else
     error("image saving not implemented for OS '" .. this_os .. "'")
   end

--- a/lua/obsidian/search/init.lua
+++ b/lua/obsidian/search/init.lua
@@ -224,9 +224,10 @@ end
 ---@param opts obsidian.search.SearchOpts|?
 ---@param on_match fun(match: MatchData)
 ---@param on_exit fun(exit_code: integer)|?
+---@return vim.SystemObj handle
 M.search_async = function(dir, term, opts, on_match, on_exit)
   local cmd = M.build_search_cmd(dir, term, opts)
-  async.run_job_async(cmd, function(line)
+  return async.run_job_async(cmd, function(line)
     local data = vim.json.decode(line)
     if data["type"] == "match" then
       local match_data = data.data
@@ -246,10 +247,11 @@ end
 ---@param opts obsidian.search.SearchOpts|?
 ---@param on_match fun(path: string)
 ---@param on_exit fun(exit_code: integer)|?
+---@return vim.SystemObj handle
 M.find_async = function(dir, term, opts, on_match, on_exit)
   local norm_dir = Path.new(dir):resolve { strict = true }
   local cmd = M.build_find_cmd(tostring(norm_dir), term, opts)
-  async.run_job_async(cmd, on_match, function(code)
+  return async.run_job_async(cmd, on_match, function(code)
     if on_exit ~= nil then
       on_exit(code)
     end
@@ -381,12 +383,14 @@ end
 ---
 ---@param term string The term to search for
 ---@param opts { search: obsidian.SearchOpts|?, notes: obsidian.note.LoadOpts|?, dir: obsidian.Path|?, timeout: integer|? }
+---@return obsidian.Note[] notes always returns a list (empty on timeout)
 M.find_notes = function(term, opts)
   opts = opts or {}
   opts.timeout = opts.timeout or 1000
-  return async.block_on(function(cb)
+  local result = async.block_on(function(cb)
     return M.find_notes_async(term, cb, { search = opts.search, notes = opts.notes })
   end, opts.timeout)
+  return result or {}
 end
 
 -- TODO: filter blocks and anchors in here, see _definition, but how does it interact with the shortcut stuff?
@@ -659,6 +663,7 @@ end
 ---@param note obsidian.Note
 ---@param callback fun(matches: obsidian.BacklinkMatch[])
 ---@param opts { search: obsidian.SearchOpts, on_match: fun(match: obsidian.BacklinkMatch), anchor: string, block: string, dir: string|obsidian.Path, refs: string[]|? }
+---@return vim.SystemObj handle
 M.find_backlinks_async = function(note, callback, opts)
   -- vim.validate("note", note, "table")
   -- vim.validate("callback", callback, "function")
@@ -740,7 +745,7 @@ M.find_backlinks_async = function(note, callback, opts)
     end
   end
 
-  M.search_async(
+  return M.search_async(
     dir,
     build_backlink_search_term(note, anchor, block, opts.refs),
     { fixed_strings = true, ignore_case = true },
@@ -753,17 +758,18 @@ end
 
 ---@param note obsidian.Note
 ---@param opts { search: obsidian.SearchOpts, anchor: string, block: string, timeout: integer, dir: string|obsidian.Path, refs: string[]|? }?
----@return obsidian.BacklinkMatch
+---@return obsidian.BacklinkMatch[] matches always returns a list (empty on timeout)
 M.find_backlinks = function(note, opts)
   opts = opts or {}
   opts.timeout = opts.timeout or 1000
-  return async.block_on(function(cb)
+  local result = async.block_on(function(cb)
     return M.find_backlinks_async(
       note,
       cb,
       { search = opts.search, anchor = opts.anchor, block = opts.block, dir = opts.dir, refs = opts.refs }
     )
   end, opts.timeout)
+  return result or {}
 end
 
 ---@class obsidian.TagLocation
@@ -781,12 +787,13 @@ end
 ---@param term string|string[] The search term.
 ---@param opts { search: obsidian.SearchOpts|?, timeout: integer|? }|?
 ---
----@return obsidian.TagLocation[]
+---@return obsidian.TagLocation[] tags always returns a list (empty on timeout)
 M.find_tags = function(term, opts)
   opts = opts or {}
-  return async.block_on(function(cb)
+  local result = async.block_on(function(cb)
     return M.find_tags_async(term, cb, { search = opts.search })
   end, opts.timeout)
+  return result or {}
 end
 
 --- An async version of 'find_tags()'.

--- a/tests/paste_img/test_03_paste.lua
+++ b/tests/paste_img/test_03_paste.lua
@@ -154,9 +154,11 @@ T["resolve_image_path"]["Test based on user settings"] = function(case)
     end
 
     -- Used by Linux & MacOS to run save clipboard image command
-    async.run_job = function(cmds)
+    vim.system = function(cmds)
         _G.captured_cmd = cmds
-        return 0
+        local obj = { code = 0 }
+        obj.wait = function() end
+        return obj
     end
 
     vim.api.nvim_put = function() end


### PR DESCRIPTION
first in a series of refactors to have proper async, eventually no `block_on` usage, to resolve #656 and the persistent `nil self` bug.