### PR TITLE
fix(picker/snacks): honor query_mappings so note_mappings.new works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Preserve anchors and blocks when creating notes from unresolved links.
 - WIP: proper async jobs and no `block_on` calls which performs bad on windows.
+- snacks picker now honors `picker.note_mappings.new` (and any other query mappings) for `find_files`, `grep` and `pick`, so creating a new note from the typed query (e.g. `<C-x>`) works on par with the telescope/fzf integrations.
 
 ## [v3.16.3](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.3) - 2026-05-08
 

--- a/lua/obsidian/picker/_snacks.lua
+++ b/lua/obsidian/picker/_snacks.lua
@@ -6,6 +6,42 @@ local Picker = obsidian.Picker
 local Path = obsidian.Path
 local ut = require "obsidian.picker.util"
 
+--- Build snacks pick opts (keymaps + actions) for query-style mappings. The
+--- callback receives the currently typed query string, mirroring the behavior
+--- of the telescope/fzf integrations.
+---
+---@param mapping obsidian.PickerMappingTable|?
+---@param live boolean Whether the picker runs in live mode (grep). When true
+---  the query is read from `picker.input.filter.search`, otherwise from
+---  `picker.input.filter.pattern`.
+---@return table
+local function query_mappings(mapping, live)
+  if type(mapping) ~= "table" then
+    return {}
+  end
+  local opts = {
+    win = {
+      input = {
+        keys = {},
+      },
+    },
+    actions = {},
+  }
+  for k, v in pairs(mapping) do
+    local name = "obsidian_query_" .. string.gsub(v.desc, " ", "_")
+    ---@diagnostic disable-next-line: assign-type-mismatch
+    opts.win.input.keys[k] = { name, mode = { "n", "i" }, desc = v.desc }
+    opts.actions[name] = function(picker)
+      local query = live and picker.input.filter.search or picker.input.filter.pattern
+      picker:close()
+      vim.schedule(function()
+        v.callback(query)
+      end)
+    end
+  end
+  return opts
+end
+
 ---@param mapping obsidian.PickerMappingTable|?
 ---@return table
 local function notes_mappings(mapping)
@@ -77,7 +113,12 @@ M.find_files = function(opts)
   ---@type obsidian.Path
   local dir = opts.dir and Path.new(opts.dir) or Obsidian.dir
 
-  local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
+  local map = vim.tbl_deep_extend(
+    "force",
+    {},
+    notes_mappings(opts.selection_mappings),
+    query_mappings(opts.query_mappings, false)
+  )
 
   local args = search.build_find_cmd(nil, nil, { include_non_markdown = opts.include_non_markdown })
   local cmd = table.remove(args, 1)
@@ -105,7 +146,8 @@ M.grep = function(opts)
 
   ---@type obsidian.Path
   local dir = opts.dir and Path.new(opts.dir) or Obsidian.dir
-  local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
+  local map =
+    vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings), query_mappings(opts.query_mappings, true))
   local callback = opts.callback or obsidian.api.open_note
 
   local args = search.build_grep_cmd()
@@ -166,7 +208,12 @@ M.pick = function(values, opts)
     })
   end
 
-  local map = vim.tbl_deep_extend("force", {}, notes_mappings(opts.selection_mappings))
+  local map = vim.tbl_deep_extend(
+    "force",
+    {},
+    notes_mappings(opts.selection_mappings),
+    query_mappings(opts.query_mappings, false)
+  )
 
   local pick_opts = vim.tbl_extend("force", map or {}, {
     title = opts.prompt_title,


### PR DESCRIPTION
## Summary

Fixes a bug where `picker.note_mappings.new` (and any other query-style mapping) is silently ignored by the snacks picker integration. Pressing the configured key (e.g. `<C-x>`) inside `Obsidian search` / `Obsidian quick_switch` with `picker.name = "snacks.pick"` did nothing.

## Root cause

`lua/obsidian/picker/_snacks.lua` only consumed `opts.selection_mappings` (via the `notes_mappings()` helper) and dropped `opts.query_mappings` entirely. The `new` action, however, is registered as a **query** mapping in `lua/obsidian/picker/init.lua` (`_note_query_mappings`) because its callback (`Mappings.new_note`) takes the typed query string, not a `PickerEntry`. The telescope and fzf integrations already wire up both kinds of mappings; only snacks was missing this.

## Fix

- Add a `query_mappings(mapping, live)` helper that translates an `obsidian.PickerMappingTable` into snacks `win.input.keys` + matching `actions`. The action reads the current query from `picker.input.filter.search` when the picker runs in live mode (grep) and from `picker.input.filter.pattern` otherwise, then closes the picker and invokes the user callback with the query string.
- Wire it into `M.find_files` (non-live), `M.grep` (live), and `M.pick` (non-live), merged alongside the existing `notes_mappings()` selection wiring via `vim.tbl_deep_extend`.

## Verification

- `make style` — clean (stylua).
- `make lint` — clean (selene + typos: 0 errors / 0 warnings).
- `make types` — no new diagnostics introduced; the 12 pre-existing warnings in `_snacks.lua` are unchanged from `main`.
- `make test` — full mini.test suite passes (0 fails / 0 notes).
- Manual: with `picker = { name = "snacks.pick", note_mappings = { new = "<C-x>", insert_link = "<C-l>" } }`, `<C-x>` in `Obsidian search` / `Obsidian quick_switch` now creates a new note titled with the typed query, matching telescope/fzf behavior.

## Tests

The repo does not currently contain tests for the picker integrations (they are interactive UI). No new tests are added, consistent with the existing pattern.

## Changelog

Added an entry under `## Unreleased` → `### Fixed`.
