### PR TITLE
fix(note): respect frontmatter.sort over parsed key order (closes #818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Preserve anchors and blocks when creating notes from unresolved links.
 - WIP: proper async jobs and no `block_on` calls which performs bad on windows.
+- Respect `frontmatter.sort` for notes that already have frontmatter (the parsed key order was silently overwriting the configured sort). Closes #818.
 
 ## [v3.16.3](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.3) - 2026-05-08
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -833,7 +833,12 @@ Note.frontmatter_lines = function(self, current_lines)
     local yaml_body_lines = vim.tbl_filter(function(line)
       return not Note._is_frontmatter_boundary(line)
     end, current_lines or {})
-    syntax_ok, _, order = pcall(yaml.loads, table.concat(yaml_body_lines, "\n"))
+    -- Preserve the existing frontmatter's key order only when the user hasn't
+    -- configured an explicit sort. Otherwise the user's `frontmatter.sort`
+    -- would be silently overwritten by the parsed order on every save.
+    local parsed_order
+    syntax_ok, _, parsed_order = pcall(yaml.loads, table.concat(yaml_body_lines, "\n"))
+    if order == nil then order = parsed_order end
   end
   if syntax_ok or not has_frontmatter then -- if parse success or there's no frontmatter (and should insert)
     ---@diagnostic disable-next-line: param-type-mismatch

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -838,7 +838,9 @@ Note.frontmatter_lines = function(self, current_lines)
     -- would be silently overwritten by the parsed order on every save.
     local parsed_order
     syntax_ok, _, parsed_order = pcall(yaml.loads, table.concat(yaml_body_lines, "\n"))
-    if order == nil then order = parsed_order end
+    if order == nil then
+      order = parsed_order
+    end
   end
   if syntax_ok or not has_frontmatter then -- if parse success or there's no frontmatter (and should insert)
     ---@diagnostic disable-next-line: param-type-mismatch

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -638,7 +638,7 @@ T["frontmatter_lines"]["respects opts.frontmatter.sort over parsed key order"] =
     return out
   end
 
-  local note = from_str([[---
+  local note = from_str [[---
 tags:
   - foo
 created: 2026-05-20
@@ -646,7 +646,7 @@ start: morning
 ---
 
 # n
-]])
+]]
   local current_lines = { "---", "tags:", "  - foo", "created: 2026-05-20", "start: morning", "---" }
   local lines = note:frontmatter_lines(current_lines)
 
@@ -658,7 +658,7 @@ start: morning
     end
     return nil
   end
-  local start_i, created_i, tags_i = find("start"), find("created"), find("tags")
+  local start_i, created_i, tags_i = find "start", find "created", find "tags"
   eq(true, start_i < created_i)
   eq(true, created_i < tags_i)
 

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -619,4 +619,51 @@ end
 --   eq({ "hi", "sub/hi", "sub%2Fhi", "sub%2Fhi.md", "sub/hi.md", "hi.md" }, note:get_reference_paths())
 -- end
 
+T["frontmatter_lines"] = new_set()
+
+T["frontmatter_lines"]["respects opts.frontmatter.sort over parsed key order"] = function()
+  -- Regression test for #818: when a note already has frontmatter, the parsed
+  -- key order was being assigned to the same `order` local, silently
+  -- overwriting the user's configured `opts.frontmatter.sort`.
+  local prev_sort = Obsidian.opts.frontmatter.sort
+  local prev_func = Obsidian.opts.frontmatter.func
+  Obsidian.opts.frontmatter.sort = { "id", "aliases", "start", "created", "modified", "tags" }
+  Obsidian.opts.frontmatter.func = function(note)
+    local out = { tags = note.tags }
+    if note.metadata ~= nil and not vim.tbl_isempty(note.metadata) then
+      for k, v in pairs(note.metadata) do
+        out[k] = v
+      end
+    end
+    return out
+  end
+
+  local note = from_str([[---
+tags:
+  - foo
+created: 2026-05-20
+start: morning
+---
+
+# n
+]])
+  local current_lines = { "---", "tags:", "  - foo", "created: 2026-05-20", "start: morning", "---" }
+  local lines = note:frontmatter_lines(current_lines)
+
+  local function find(key)
+    for i, line in ipairs(lines) do
+      if line:match("^" .. key .. ":") then
+        return i
+      end
+    end
+    return nil
+  end
+  local start_i, created_i, tags_i = find("start"), find("created"), find("tags")
+  eq(true, start_i < created_i)
+  eq(true, created_i < tags_i)
+
+  Obsidian.opts.frontmatter.sort = prev_sort
+  Obsidian.opts.frontmatter.func = prev_func
+end
+
 return T


### PR DESCRIPTION
## What

Fixes #818. \`Note.frontmatter_lines\` declares a local \`order\` from \`Obsidian.opts.frontmatter.sort\`, then unconditionally reassigns it to the third return value of \`pcall(yaml.loads, ...)\` — the parsed key order from the existing frontmatter. So whenever a note already has frontmatter (effectively every note that goes through this path), the user's configured sort is silently discarded.

## Fix

Use a separate local for the parsed order and only fall back to it when no sort is configured.

\`\`\`diff
-     syntax_ok, _, order = pcall(yaml.loads, table.concat(yaml_body_lines, \"\n\"))
+     local parsed_order
+     syntax_ok, _, parsed_order = pcall(yaml.loads, table.concat(yaml_body_lines, \"\n\"))
+     if order == nil then order = parsed_order end
\`\`\`

## Reproduction

Config from #818 reporter: \`frontmatter.sort = { \"id\", \"aliases\", \"start\", \"created\", \"modified\", \"tags\" }\`, custom \`func\` that returns \`tags\` first plus metadata. Note already on disk with \`tags\`/\`created\`/\`start\` keys in that order.

- **Pre-fix**: output order is \`tags\`, \`created\`, \`start\` (matches buffer's parsed order, ignoring config).
- **Post-fix**: output order is \`start\`, \`created\`, \`tags\` (matches config).

Verified end-to-end with a headless reproduction script against the reporter's config.

## PR Checklist

- [x] Description of changes
- [x] Read \`CONTRIBUTING.md\`
- [x] \`CHANGELOG.md\` updated
- [ ] README.md docs — n/a, internal behavior fix with no user-facing API change
- [ ] \`make chores\` — no stylua / selene / make on my local env; relying on CI