### PR TITLE
Fix backlink handling and improve item selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `should_write` option on `Note.create` is removed. Call `note:write {}` explicitly instead.
 
 ### Fixed
-
+- Backlink command supports 3rd party "quickfix/qf" pickers. No dual windows. Auto enter parent link unless parents > 1. Parents < 1 no empty quickpick window.
 - Preserve anchors and blocks when creating notes from unresolved links.
 - WIP: proper async jobs and no `block_on` calls which performs bad on windows.
 - snacks picker now honors `picker.note_mappings.new` (and any other query mappings) for `find_files`, `grep` and `pick`, so creating a new note from the typed query (e.g. `<C-x>`) works on par with the telescope/fzf integrations.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ There's one entry point user command for this plugin: `Obsidian`
 
 - `:Obsidian backlinks` - get a picker list of references to the current note
   - `grr`/`vim.lsp.buf.references` to see references in quickfix list
+  - no supports 3rd party pickers see CHANGELOG.MD
 - `:Obsidian follow_link [STRATEGY]` - follow a note reference under the cursor
   - available strategies: `vsplit, hsplit, vsplit_force, hsplit_force`
   - If the link does not exist, you will be prompted to create it. If you choose to create it, the link in the buffer will be automatically updated with the new note's ID and alias.

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -2,24 +2,25 @@ local obsidian = require "obsidian"
 
 return function()
   require "obsidian.lsp.handlers._references"(nil, { tag = false }, function(_, locations)
-        local items = vim.lsp.util.locations_toi_items(locations, "utf-8")
-      if #items == 0 then
-        obsidian.log.info ("No backlinks")
-        return
-      end
-      if #items == 1 then
-        obsidian.api.open_note(items[1])
+    local items = vim.lsp.util.locations_toi_items(locations, "utf-8")
+    if #items == 0 then
+      obsidian.log.info "No backlinks"
+      return
+    end
+    if #items == 1 then
+      obsidian.api.open_note(items[1])
     else
-      Obsidian.picker.pick(items, { prompt_title = "Resolve link",
-          format_item = function (item)
-            return vim.fs.basename(item.filename) .. ":" .. item.lnum .. " - " .. vim.trim(item.text)
-          end,
-          callback = function(selected_item)
-            if selected_item then
-              obsidian.api.open_note(selected_item)
-            end
+      Obsidian.picker.pick(items, {
+        prompt_title = "Resolve link",
+        format_item = function(item)
+          return vim.fs.basename(item.filename) .. ":" .. item.lnum .. " - " .. vim.trim(item.text)
+        end,
+        callback = function(selected_item)
+          if selected_item then
+            obsidian.api.open_note(selected_item)
           end
-        })
+        end,
+      })
     end
   end)
 end

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -2,7 +2,7 @@ local obsidian = require "obsidian"
 
 return function()
   require "obsidian.lsp.handlers._references"(nil, { tag = false }, function(_, locations)
-    local items = vim.lsp.util.locations_toi_items(locations, "utf-8")
+    local items = vim.lsp.util.locations_to_items(locations, "utf-8")
     if #items == 0 then
       obsidian.log.info "No backlinks"
       return

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -8,7 +8,7 @@ return function()
         return
       end
       if #items == 1 then
-        obsidian.api.open)note(items[1])
+        obsidian.api.open_note(items[1])
     else
       Obsidian.picker.pick(items, { prompt_title = "Resolve link",
           format_item = function (item)

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -2,11 +2,24 @@ local obsidian = require "obsidian"
 
 return function()
   require "obsidian.lsp.handlers._references"(nil, { tag = false }, function(_, locations)
-    local items = vim.lsp.util.locations_to_items(locations, "utf-8")
-    if #items == 1 then
-      obsidian.api.open_note(items[1])
+        local items = vim.lsp.util.locations_toi_items(locations, "utf-8")
+      if #items == 0 then
+        obsidian.log.info ("No backlinks")
+        return
+      end
+      if #items == 1 then
+        obsidian.api.open)note(items[1])
     else
-      Obsidian.picker.pick(items, { prompt_title = "Resolve link" }) -- calls open_qf_entry by default
+      Obsidian.picker.pick(items, { prompt_title = "Resolve link",
+          format_item = function (item)
+            return vim.fs.basename(item.filename) .. ":" .. item.lnum .. " - " .. vim.trim(item.text)
+          end,
+          callback = function(selected_item)
+            if selected_item then
+              obsidian.api.open_note(selected_item)
+            end
+          end
+        })
     end
   end)
 end


### PR DESCRIPTION
Backlinks command quickfix widows resolved.
Now, on use of the command, you are not stuck with the native nvim quickfix ui also displaying along with the users set picker. Also replaced empty ui, with notification of "No backlink" instead.

Before when using snacks.picker, the native horizontal quickfix select menu would display along with whatever picker you decide to use. This means after you make a selection the native window would also have to be exited. The pickers also would display if no backlinks were present. I've been nesting snack.picker logic nested in my keybinds however, im not sure if this is the intended use? example ``` vim.keymap.set("n", "<leader>ob" function() Snacks.picker.<whateverpicker>opts = {}```