### PR TITLE
fix(note): E94 from :checktime in save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Note.save` no longer raises `E94: No matching buffer` when the save path contains Vim regex-special characters (e.g. `[`, `]`, `*`). The `:checktime` call now passes a bufnr instead of the path string.
 - Preserve anchors and blocks when creating notes from unresolved links.
 - WIP: proper async jobs and no `block_on` calls which performs bad on windows.
 - snacks picker now honors `picker.note_mappings.new` (and any other query mappings) for `find_files`, `grep` and `pick`, so creating a new note from the typed query (e.g. `<C-x>`) works on par with the telescope/fzf integrations.

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -1035,10 +1035,13 @@ Note.save = function(self, opts)
   util.write_file(tostring(save_path), file_content)
 
   if opts.check_buffers then
-    -- `vim.fn.bufnr` returns the **max** bufnr loaded from the same path.
-    if vim.fn.bufnr(save_path.filename) ~= -1 then
-      -- But we want to call |checktime| on **all** buffers loaded from the path.
-      vim.cmd.checktime(save_path.filename)
+    -- `:checktime <name>` parses {name} as a Vim regex, so paths with `[`,
+    -- `*`, etc. raise E94. Pass the bufnr instead, iterating to cover
+    -- every buffer loaded from this path.
+    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_get_name(bufnr) == save_path.filename then
+        vim.cmd.checktime(bufnr)
+      end
     end
   end
 end

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -115,6 +115,23 @@ T["save"]["should preserve noeol status"] = function()
   vim.fn.delete(temp_path)
 end
 
+T["save"]["should not error on :checktime when save path contains regex-special characters"] = function()
+  -- Regression: the old code passed `save_path.filename` as a string to
+  -- `:checktime`, which treats it as a Vim regex pattern. Paths with `[`,
+  -- `]`, `*`, etc. (legal in note filenames, e.g. `[[wiki]] title.md`)
+  -- would raise E94 even when a buffer was loaded for the exact path.
+  local path = "/tmp/" .. util.zettel_id() .. " [draft].md"
+  local note = M.new("FOO", {}, {}, path)
+  note:save()
+
+  vim.cmd.edit(vim.fn.fnameescape(path))
+
+  note:save() -- must not raise E94
+
+  vim.cmd "bwipeout!"
+  vim.fn.delete(path)
+end
+
 T["add_alias"] = new_set()
 
 T["add_alias"]["should be able to add an alias"] = function()


### PR DESCRIPTION
# fix(note): E94 from :checktime in Note.save

## What does the PR do?

`Note.save` (`lua/obsidian/note.lua`) writes the file to disk and then runs `:checktime <save_path.filename>` so any buffer loaded from that path picks up the new contents. The problem is that `:checktime {bufname}` interprets its argument as a **Vim regex** matching buffer names — so when the note's path contains regex metacharacters (e.g. `[`, `]`, `*`, `?`), the call raises `E94: No matching buffer` even though `vim.fn.bufnr(name)` (substring match) finds the buffer fine. Note filenames with brackets are legitimate (e.g. titles like `Some Topic [draft]`, or note IDs containing wiki-link punctuation).

Reproducer (also added as a regression test, `tests/test_note.lua`):

```lua
local Note = require("obsidian.note")
local path = "/tmp/foo [draft].md"

local note = Note.new("FOO", {}, {}, path)
note:save()                  -- creates the file
vim.cmd.edit(vim.fn.fnameescape(path))
note:save()                  -- E94: No matching buffer for /tmp/foo [draft].md
```

The fix iterates `vim.api.nvim_list_bufs()` and calls `:checktime <bufnr>` on every buffer whose name is exactly `save_path.filename`. This preserves the original intent (re-check **all** buffers loaded from the path — preserved from the original comment) while sidestepping the regex parsing entirely.

### AI-assisted

This change was AI-assisted (Claude Code), but the diagnosis, the test, and the empirical fix verification were done manually.

## Screenshots

N/A — internal fix.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated (entry under `Unreleased` → `Fixed`)
- [ ] The changes are documented in the `README.md` file **N/A**, no user-facing API change
- [x] The code complies with `make chores`
