### PR TITLE
fix(notes): fallback to cwd for current_dir new note creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Raise minimum supported version to `0.11`
+- Raise minimum supported version to `0.11`.
+- `new_notes_location` when `current_dir` but the current buffer is not valid note file, fallback to current working directory.
 
 ## [v3.16.4](https://github.com/obsidian-nvim/obsidian.nvim/releases/tag/v3.16.4) - 2026-06-03
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -250,19 +250,35 @@ Note._resolve_id_path = function(opts)
       base_dir = base_dir:resolve()
     end
   else
-    local bufpath = Path.buffer(0):resolve()
-    if
-      creation_opts.new_notes_location == "current_dir"
-      -- note is actually in the workspace.
-      and Obsidian.dir:is_parent_of(bufpath)
-      -- note is not in dailies folder
-      and (
-        Obsidian.opts.daily_notes.folder == nil
-        or not (Obsidian.dir / Obsidian.opts.daily_notes.folder):is_parent_of(bufpath)
-      )
-    then
-      base_dir = Obsidian.buf_dir or assert(bufpath:parent())
-    else
+    local function is_in_vault(path)
+      return path == Obsidian.dir or Obsidian.dir:is_parent_of(path)
+    end
+
+    local function is_in_daily_notes(path)
+      local daily_notes_folder = Obsidian.opts.daily_notes.folder
+      if daily_notes_folder == nil then
+        return false
+      end
+
+      local daily_notes_dir = Obsidian.dir / daily_notes_folder
+      return path == daily_notes_dir or daily_notes_dir:is_parent_of(path)
+    end
+
+    if creation_opts.new_notes_location == "current_dir" then
+      local bufname = vim.api.nvim_buf_get_name(0)
+      local bufpath = bufname ~= "" and Path.new(bufname):resolve() or nil
+      local cwd = Path.new(vim.fn.getcwd(0, 0)):resolve()
+
+      if bufpath ~= nil and api.path_is_note(bufpath) then
+        if not is_in_daily_notes(bufpath) then
+          base_dir = assert(bufpath:parent())
+        end
+      elseif is_in_vault(cwd) and not is_in_daily_notes(cwd) then
+        base_dir = cwd
+      end
+    end
+
+    if base_dir == nil then
       base_dir = Obsidian.dir
       if creation_opts.notes_subdir ~= nil then
         base_dir = base_dir / creation_opts.notes_subdir

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -524,6 +524,65 @@ T["resolve_id_path"]["should ensure result of 'note_path_func' is always an abso
   eq(Path.new(Obsidian.dir) / "notes" / "foo-bar-123.md", path)
 end
 
+T["resolve_id_path"]["should use cwd for non-note buffers when cwd is in vault"] = function()
+  local previous_cwd = vim.fn.getcwd()
+  local notes_dir = Obsidian.dir / "notes"
+  local stale_dir = Obsidian.dir / "stale"
+  notes_dir:mkdir { exist_ok = true }
+  stale_dir:mkdir { exist_ok = true }
+
+  vim.cmd "enew!"
+  Obsidian.buf_dir = stale_dir
+  vim.cmd("cd " .. vim.fn.fnameescape(tostring(notes_dir)))
+
+  local id, path = M._resolve_id_path { id = "Foo" }
+
+  vim.cmd("cd " .. vim.fn.fnameescape(previous_cwd))
+  eq("Foo", id)
+  eq(notes_dir / "Foo.md", path)
+end
+
+T["resolve_id_path"]["should prefer current note directory over cwd"] = function()
+  local previous_cwd = vim.fn.getcwd()
+  local notes_dir = Obsidian.dir / "notes"
+  local other_dir = Obsidian.dir / "other"
+  notes_dir:mkdir { exist_ok = true }
+  other_dir:mkdir { exist_ok = true }
+
+  local current_note = notes_dir / "Current.md"
+  vim.fn.writefile({}, tostring(current_note))
+  vim.cmd("edit " .. vim.fn.fnameescape(tostring(current_note)))
+  vim.cmd("cd " .. vim.fn.fnameescape(tostring(other_dir)))
+
+  local id, path = M._resolve_id_path { id = "Foo" }
+
+  vim.cmd("cd " .. vim.fn.fnameescape(previous_cwd))
+  vim.cmd "enew!"
+  eq("Foo", id)
+  eq(notes_dir / "Foo.md", path)
+end
+
+T["resolve_id_path"]["should not use cwd when current buffer is a daily note"] = function()
+  local previous_cwd = vim.fn.getcwd()
+  Obsidian.opts.daily_notes.folder = "daily"
+  local daily_dir = Obsidian.dir / "daily"
+  local other_dir = Obsidian.dir / "other"
+  daily_dir:mkdir { exist_ok = true }
+  other_dir:mkdir { exist_ok = true }
+
+  local current_note = daily_dir / "Today.md"
+  vim.fn.writefile({}, tostring(current_note))
+  vim.cmd("edit " .. vim.fn.fnameescape(tostring(current_note)))
+  vim.cmd("cd " .. vim.fn.fnameescape(tostring(other_dir)))
+
+  local id, path = M._resolve_id_path { id = "Foo" }
+
+  vim.cmd("cd " .. vim.fn.fnameescape(previous_cwd))
+  vim.cmd "enew!"
+  eq("Foo", id)
+  eq(Obsidian.dir / "Foo.md", path)
+end
+
 T["format_link"] = new_set()
 
 T["format_link"]["should respect link.style"] = function()


### PR DESCRIPTION
resolves #864 

this is a bit of a harder issue conceptually

since the `current_dir` stuff inherited from obsidian app means `same folder as the current file`:

<img width="1582" height="264" alt="Image" src="https://github.com/user-attachments/assets/fc7237d3-682b-40de-a3e2-6ce0214e5a86" />

because the app itself don't have a notion of current working directory, and specially buffers

I did a quick check, the fix will work for `snacks_dashboard` but not for things like `oil` buffers, since they have special `oil:/` uri prefixes in the buffer path.

so just using `vim.fn.getcwd` for a stable fallback.
