### PR TITLE
refactor: anchor and block point to unified section and blinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Navigating to an anchor or block link now briefly highlights the full referenced section, like the Obsidian app. The highlight group is `ObsidianBlink` (defaults to `Visual`) and the duration is controlled by `vim.g.obsidian_blink_duration` (ms, defaults to 500).
+- `note.sections` and the `obsidian.Section` type: header anchors and blocks now carry the full section/paragraph range (`anchor.section`, `block.section`). Anchors are also collected for setext (`===`/`---` underline) headings now.
+- `obsidian.Range`, a minimal shim of the experimental `vim.range()` API (0-based, end-exclusive) used by `obsidian.Section`.
+- LSP document symbols now report real section ranges instead of zero-width ranges.
 - Add `opts.file.ignore_filters` to exclude directories completely from the plug-in.
 - Sync supports switching backend and one shot sync on file write
   - `opts.sync.backend` -> `obsidian` / `git` (WIP)

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -740,11 +740,16 @@ end
 ---@return obsidian.PickerEntry
 local function symbol_to_entry(symbol)
   local range = symbol.location.range
+  local user_data = type(symbol.data) == "table" and symbol.data or {}
+  if range then
+    user_data = vim.tbl_extend("force", user_data, { range = range })
+  end
+
   return {
     filename = vim.uri_to_fname(symbol.location.uri),
     text = symbol.name,
     lnum = range and range.start.line + 1 or nil,
-    user_data = symbol.data,
+    user_data = user_data,
   }
 end
 

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -740,16 +740,12 @@ end
 ---@return obsidian.PickerEntry
 local function symbol_to_entry(symbol)
   local range = symbol.location.range
-  local user_data = type(symbol.data) == "table" and symbol.data or {}
-  if range then
-    user_data = vim.tbl_extend("force", user_data, { range = range })
-  end
-
   return {
     filename = vim.uri_to_fname(symbol.location.uri),
     text = symbol.name,
     lnum = range and range.start.line + 1 or nil,
-    user_data = user_data,
+    range = range,
+    user_data = symbol.data,
   }
 end
 

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -237,7 +237,7 @@ M.open_buffer = function(path, opts)
   }, opts.cmd)
 end
 
-local blink_ns = vim.api.nvim_create_namespace "obsidian_blink"
+local blink_counter = 0
 
 --- Briefly highlight a range in a buffer, like the Obsidian app does after
 --- navigating to a heading or block link.
@@ -246,12 +246,14 @@ local blink_ns = vim.api.nvim_create_namespace "obsidian_blink"
 ---
 ---@param bufnr integer
 ---@param range lsp.Range end-exclusive, 0-based
-M.blink_range = function(bufnr, range)
+local blink_range = function(bufnr, range)
+  blink_counter = blink_counter + 1
+  local ns = vim.api.nvim_create_namespace("obsidian_blink_" .. blink_counter)
   local hl = vim.hl or vim.highlight
   vim.api.nvim_set_hl(0, "ObsidianBlink", { link = "Visual", default = true })
   hl.range(
     bufnr,
-    blink_ns,
+    ns,
     "ObsidianBlink",
     { range.start.line, range.start.character },
     { range["end"].line, range["end"].character },
@@ -259,9 +261,28 @@ M.blink_range = function(bufnr, range)
   )
   vim.defer_fn(function()
     if vim.api.nvim_buf_is_valid(bufnr) then
-      vim.api.nvim_buf_clear_namespace(bufnr, blink_ns, 0, -1)
+      vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
     end
-  end, vim.g.obsidian_blink_duration or 500)
+  end, 500) -- NOTE: configurable timeout?
+end
+
+---@param entry obsidian.PickerEntry|vim.quickfix.entry
+---@return lsp.Range|?
+local function entry_range(entry)
+  if type(entry.user_data) == "table" and type(entry.user_data.range) == "table" then
+    return entry.user_data.range
+  end
+
+  local lnum = tonumber(entry.lnum)
+  local col = tonumber(entry.col) or 1
+  local end_lnum = tonumber(entry.end_lnum)
+  local end_col = tonumber(entry.end_col)
+  if lnum and end_lnum and end_col then
+    return {
+      start = { line = lnum - 1, character = math.max(col - 1, 0) },
+      ["end"] = { line = end_lnum - 1, character = math.max(end_col - 1, 0) },
+    }
+  end
 end
 
 --- Open a quickfix entry in buffer, with open strategy
@@ -302,10 +323,10 @@ M.open_note = function(entry, cmd)
 
   -- Blink the target range, e.g. the full section of an anchor/block link.
   -- Quickfix items built from lsp locations carry the location in `user_data`.
-  if type(entry) == "table" and type(entry.user_data) == "table" and type(entry.user_data.range) == "table" then
-    local range = entry.user_data.range
-    if range["end"].line > range.start.line or range["end"].character > range.start.character then
-      M.blink_range(result_bufnr, range)
+  if type(entry) == "table" then
+    local range = entry_range(entry)
+    if range and (range["end"].line > range.start.line or range["end"].character > range.start.character) then
+      blink_range(result_bufnr, range)
     end
   end
 

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -8,6 +8,7 @@ local Path = require "obsidian.path"
 local search = require "obsidian.search"
 local config = require "obsidian.config"
 local attachment = require "obsidian.attachment"
+local Range = require "obsidian.range"
 
 M.dir = require("obsidian.fs").dir
 
@@ -245,20 +246,13 @@ local blink_counter = 0
 --- Uses the `ObsidianBlink` highlight group (defaults to a link to `Visual`).
 ---
 ---@param bufnr integer
----@param range lsp.Range end-exclusive, 0-based
+---@param range obsidian.Range end-exclusive, 0-based
 local blink_range = function(bufnr, range)
   blink_counter = blink_counter + 1
   local ns = vim.api.nvim_create_namespace("obsidian_blink_" .. blink_counter)
   local hl = vim.hl or vim.highlight
   vim.api.nvim_set_hl(0, "ObsidianBlink", { link = "Visual", default = true })
-  hl.range(
-    bufnr,
-    ns,
-    "ObsidianBlink",
-    { range.start.line, range.start.character },
-    { range["end"].line, range["end"].character },
-    {}
-  )
+  hl.range(bufnr, ns, "ObsidianBlink", { range.start_row, range.start_col }, { range.end_row, range.end_col }, {})
   vim.defer_fn(function()
     if vim.api.nvim_buf_is_valid(bufnr) then
       vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
@@ -266,11 +260,23 @@ local blink_range = function(bufnr, range)
   end, 500) -- NOTE: configurable timeout?
 end
 
+---@param range obsidian.Range|lsp.Range|?
+---@return obsidian.Range|?
+local function normalize_range(range)
+  if not range then
+    return nil
+  elseif range.start_row then
+    return range
+  elseif range.start then
+    return Range.lsp(range)
+  end
+end
+
 ---@param entry obsidian.PickerEntry|vim.quickfix.entry
----@return lsp.Range|?
+---@return obsidian.Range|?
 local function entry_range(entry)
   if type(entry.user_data) == "table" and type(entry.user_data.range) == "table" then
-    return entry.user_data.range
+    return normalize_range(entry.user_data.range)
   end
 
   local lnum = tonumber(entry.lnum)
@@ -278,10 +284,7 @@ local function entry_range(entry)
   local end_lnum = tonumber(entry.end_lnum)
   local end_col = tonumber(entry.end_col)
   if lnum and end_lnum and end_col then
-    return {
-      start = { line = lnum - 1, character = math.max(col - 1, 0) },
-      ["end"] = { line = end_lnum - 1, character = math.max(end_col - 1, 0) },
-    }
+    return Range.new(lnum - 1, math.max(col - 1, 0), end_lnum - 1, math.max(end_col - 1, 0))
   end
 end
 
@@ -325,7 +328,7 @@ M.open_note = function(entry, cmd)
   -- Quickfix items built from lsp locations carry the location in `user_data`.
   if type(entry) == "table" then
     local range = entry_range(entry)
-    if range and (range["end"].line > range.start.line or range["end"].character > range.start.character) then
+    if range and not Range.is_empty(range) then
       blink_range(result_bufnr, range)
     end
   end

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -238,28 +238,6 @@ M.open_buffer = function(path, opts)
   }, opts.cmd)
 end
 
-local blink_counter = 0
-
---- Briefly highlight a range in a buffer, like the Obsidian app does after
---- navigating to a heading or block link.
----
---- Uses the `ObsidianBlink` highlight group (defaults to a link to `Visual`).
----
----@param bufnr integer
----@param range obsidian.Range end-exclusive, 0-based
-local blink_range = function(bufnr, range)
-  blink_counter = blink_counter + 1
-  local ns = vim.api.nvim_create_namespace("obsidian_blink_" .. blink_counter)
-  local hl = vim.hl or vim.highlight
-  vim.api.nvim_set_hl(0, "ObsidianBlink", { link = "Visual", default = true })
-  hl.range(bufnr, ns, "ObsidianBlink", { range.start_row, range.start_col }, { range.end_row, range.end_col }, {})
-  vim.defer_fn(function()
-    if vim.api.nvim_buf_is_valid(bufnr) then
-      vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
-    end
-  end, 500) -- NOTE: configurable timeout?
-end
-
 ---@param range obsidian.Range|lsp.Range|?
 ---@return obsidian.Range|?
 local function normalize_range(range)
@@ -275,8 +253,8 @@ end
 ---@param entry obsidian.PickerEntry|vim.quickfix.entry
 ---@return obsidian.Range|?
 local function entry_range(entry)
-  if type(entry.user_data) == "table" and type(entry.user_data.range) == "table" then
-    return normalize_range(entry.user_data.range)
+  if type(entry.range) == "table" then
+    return normalize_range(entry.range)
   end
 
   local lnum = tonumber(entry.lnum)
@@ -325,11 +303,10 @@ M.open_note = function(entry, cmd)
   end
 
   -- Blink the target range, e.g. the full section of an anchor/block link.
-  -- Quickfix items built from lsp locations carry the location in `user_data`.
   if type(entry) == "table" then
     local range = entry_range(entry)
     if range and not Range.is_empty(range) then
-      blink_range(result_bufnr, range)
+      Range.blink(range, result_bufnr)
     end
   end
 

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -237,6 +237,33 @@ M.open_buffer = function(path, opts)
   }, opts.cmd)
 end
 
+local blink_ns = vim.api.nvim_create_namespace "obsidian_blink"
+
+--- Briefly highlight a range in a buffer, like the Obsidian app does after
+--- navigating to a heading or block link.
+---
+--- Uses the `ObsidianBlink` highlight group (defaults to a link to `Visual`).
+---
+---@param bufnr integer
+---@param range lsp.Range end-exclusive, 0-based
+M.blink_range = function(bufnr, range)
+  local hl = vim.hl or vim.highlight
+  vim.api.nvim_set_hl(0, "ObsidianBlink", { link = "Visual", default = true })
+  hl.range(
+    bufnr,
+    blink_ns,
+    "ObsidianBlink",
+    { range.start.line, range.start.character },
+    { range["end"].line, range["end"].character },
+    {}
+  )
+  vim.defer_fn(function()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_clear_namespace(bufnr, blink_ns, 0, -1)
+    end
+  end, vim.g.obsidian_blink_duration or 500)
+end
+
 --- Open a quickfix entry in buffer, with open strategy
 ---@param entry obsidian.PickerEntry|vim.quickfix.entry|string
 ---@param cmd string?
@@ -271,6 +298,15 @@ M.open_note = function(entry, cmd)
 
   if not result_bufnr then
     result_bufnr = vim.api.nvim_get_current_buf()
+  end
+
+  -- Blink the target range, e.g. the full section of an anchor/block link.
+  -- Quickfix items built from lsp locations carry the location in `user_data`.
+  if type(entry) == "table" and type(entry.user_data) == "table" and type(entry.user_data.range) == "table" then
+    local range = entry.user_data.range
+    if range["end"].line > range.start.line or range["end"].character > range.start.character then
+      M.blink_range(result_bufnr, range)
+    end
   end
 
   return result_bufnr

--- a/lua/obsidian/bookmarks.lua
+++ b/lua/obsidian/bookmarks.lua
@@ -2,6 +2,7 @@ local log = require "obsidian.log"
 local Note = require "obsidian.note"
 local picker = require "obsidian.picker"
 local api = require "obsidian.api"
+local Range = require "obsidian.range"
 
 local M = {}
 
@@ -29,12 +30,20 @@ local function bookmark_to_picker_entry(bookmark)
     local ok, note = pcall(Note.from_file, entry.filename)
     if ok and note then
       ---@cast note -string
+      ---@type obsidian.Section|?
+      local section
       if vim.startswith(bookmark.subpath, "#^") then
         local block = note:resolve_block(bookmark.subpath:sub(2))
-        entry.lnum = block and block.line or nil
+        section = block and block.section
+        entry.lnum = section and section.range.start_row + 1 or (block and block.line or nil)
       elseif vim.startswith(bookmark.subpath, "#") then
         local anchor = note:resolve_anchor_link(bookmark.subpath)
-        entry.lnum = anchor and anchor.line or nil
+        section = anchor and anchor.section
+        entry.lnum = section and section.range.start_row + 1 or (anchor and anchor.line or nil)
+      end
+
+      if section then
+        entry.user_data = vim.tbl_extend("force", entry.user_data or {}, { range = Range.to_lsp(section.range) })
       end
     else
       log.err("Failed to resolve bookmark path to note: %s", note)

--- a/lua/obsidian/bookmarks.lua
+++ b/lua/obsidian/bookmarks.lua
@@ -2,7 +2,6 @@ local log = require "obsidian.log"
 local Note = require "obsidian.note"
 local picker = require "obsidian.picker"
 local api = require "obsidian.api"
-local Range = require "obsidian.range"
 
 local M = {}
 
@@ -43,7 +42,7 @@ local function bookmark_to_picker_entry(bookmark)
       end
 
       if section then
-        entry.user_data = vim.tbl_extend("force", entry.user_data or {}, { range = Range.to_lsp(section.range) })
+        entry.range = section.range
       end
     else
       log.err("Failed to resolve bookmark path to note: %s", note)

--- a/lua/obsidian/commands/follow_link.lua
+++ b/lua/obsidian/commands/follow_link.lua
@@ -30,11 +30,8 @@ return function(data)
       local items = dedupe_items(t.items)
       if #items == 1 then
         api.open_note(items[1], open_strategy)
-      elseif Obsidian.picker then
-        Obsidian.picker.pick(items, { prompt_title = "Resolve link" })
       else
-        vim.fn.setqflist({}, " ", { title = t.title, items = items })
-        vim.cmd "copen"
+        Obsidian.picker.pick(items, { prompt_title = "Resolve link" })
       end
     end,
   }

--- a/lua/obsidian/commands/follow_link.lua
+++ b/lua/obsidian/commands/follow_link.lua
@@ -26,12 +26,15 @@ return function(data)
   end
 
   vim.lsp.buf.definition {
-    on_list = Obsidian.picker and function(t)
+    on_list = function(t)
       local items = dedupe_items(t.items)
       if #items == 1 then
         api.open_note(items[1], open_strategy)
-      else
+      elseif Obsidian.picker then
         Obsidian.picker.pick(items, { prompt_title = "Resolve link" })
+      else
+        vim.fn.setqflist({}, " ", { title = t.title, items = items })
+        vim.cmd "copen"
       end
     end,
   }

--- a/lua/obsidian/lsp/handlers/_definition.lua
+++ b/lua/obsidian/lsp/handlers/_definition.lua
@@ -154,16 +154,7 @@ handlers.HeaderLink = function(location, callback, _)
   if not anchor_obj then
     return
   end
-  local line = anchor_obj.line - 1
-  callback {
-    {
-      uri = vim.uri_from_fname(tostring(note.path)),
-      range = {
-        start = { line = line, character = 0 },
-        ["end"] = { line = line, character = 0 },
-      },
-    },
-  }
+  callback { note:_location { anchor = location } }
 end
 
 handlers.Footnote = function(location, callback, _)
@@ -210,16 +201,7 @@ handlers.BlockLink = function(location, callback, _)
   if not block_obj then
     return
   end
-  local line = block_obj.line - 1
-  callback {
-    {
-      uri = vim.uri_from_fname(tostring(note.path)),
-      range = {
-        start = { line = line, character = 0 },
-        ["end"] = { line = line, character = 0 },
-      },
-    },
-  }
+  callback { note:_location { block = location } }
 end
 
 return {

--- a/lua/obsidian/lsp/handlers/_workspace_symbol.lua
+++ b/lua/obsidian/lsp/handlers/_workspace_symbol.lua
@@ -1,11 +1,13 @@
 local search = require "obsidian.search"
 local async = require "obsidian.async"
 local util = require "obsidian.util"
+local Range = require "obsidian.range"
 local SymbolKind = vim.lsp.protocol.SymbolKind
 
 ---@class obsidian.lsp.SymbolMetadata
 ---@field note obsidian.Note
----@field section obsidian.note.HeaderAnchor -- TODO: use note.Section later when it is formalized
+---@field section obsidian.Section|?
+---@field range lsp.Range|?
 
 --- Compute the vault-relative path without the .md extension.
 ---@param abs_path string|obsidian.Path
@@ -66,68 +68,61 @@ local function note_to_symbols(note)
 end
 
 ---@param note obsidian.Note
----@param heading obsidian.note.HeaderAnchor
+---@param section obsidian.Section
 ---@return lsp.WorkspaceSymbol
-local function heading_to_symbol(note, heading)
+local function section_to_symbol(note, section)
   assert(note.path, "Note must have a path")
   local container = relative_path_no_ext(note.path)
-  local name = container .. "#" .. heading.header
+  local name = container .. "#" .. section.header
   local uri = vim.uri_from_fname(tostring(note.path))
-  local line = heading.line - 1 -- 0-indexed
+  local range = Range.to_lsp(section.range)
+
   return {
     name = name,
     kind = SymbolKind.String,
     location = {
       uri = uri,
-      range = {
-        start = { line = line, character = 0 },
-        ["end"] = { line = line, character = 0 },
-      },
+      range = range,
     },
     containerName = container,
     data = {
       note = note,
-      section = heading,
+      section = section,
+      range = range,
     },
   }
 end
 
----@param heading obsidian.note.HeaderAnchor
----@return boolean
-local function is_standalone_heading_anchor(heading)
-  return string.find(heading.anchor, "#", 2, true) == nil
-end
-
----@param heading obsidian.note.HeaderAnchor
+---@param section obsidian.Section
 ---@param query string
 ---@return boolean
-local function heading_matches_query(heading, query)
-  return query == "" or string.find(string.lower(heading.header), string.lower(query), 1, true) ~= nil
+local function section_matches_query(section, query)
+  return query == "" or string.find(string.lower(section.header or ""), string.lower(query), 1, true) ~= nil
 end
 
 ---@param note obsidian.Note
 ---@param query string
 ---@return lsp.WorkspaceSymbol[]
-local function note_heading_symbols(note, query)
-  ---@type obsidian.note.HeaderAnchor[]
-  local headings = {}
+local function note_section_symbols(note, query)
+  ---@type obsidian.Section[]
+  local sections = {}
 
-  for _, heading in pairs(note.anchor_links or {}) do
-    if is_standalone_heading_anchor(heading) and heading_matches_query(heading, query) then
-      headings[#headings + 1] = heading
+  for _, section in ipairs(note.sections or {}) do
+    if section.header and section_matches_query(section, query) then
+      sections[#sections + 1] = section
     end
   end
 
-  table.sort(headings, function(a, b)
-    if a.line ~= b.line then
-      return a.line < b.line
+  table.sort(sections, function(a, b)
+    if a.heading_range.start_row ~= b.heading_range.start_row then
+      return a.heading_range.start_row < b.heading_range.start_row
     end
-    return a.anchor < b.anchor
+    return (a.anchor or "") < (b.anchor or "")
   end)
 
-  return vim.tbl_map(function(heading)
-    return heading_to_symbol(note, heading)
-  end, headings)
+  return vim.tbl_map(function(section)
+    return section_to_symbol(note, section)
+  end, sections)
 end
 
 ---@param query string
@@ -142,12 +137,12 @@ return function(query, callback)
 
     local notes = async.await(2, search.find_notes_async, query, nil, {
       search = { ignore_case = true },
-      notes = { collect_anchor_links = true },
+      notes = { collect_sections = true },
     })
 
     for _, note in ipairs(notes) do
       vim.list_extend(symbols, note_to_symbols(note))
-      vim.list_extend(symbols, note_heading_symbols(note, query))
+      vim.list_extend(symbols, note_section_symbols(note, query))
     end
 
     callback(symbols)

--- a/lua/obsidian/lsp/handlers/document_symbol.lua
+++ b/lua/obsidian/lsp/handlers/document_symbol.lua
@@ -5,31 +5,23 @@ local Range = require "obsidian.range"
 return function(_, handler)
   ---@type lsp.DocumentSymbol[]
   local symbols = {}
-  local lookup = {}
 
-  local note = obsidian.Note.from_buffer(0, { collect_anchor_links = true })
+  local note = obsidian.Note.from_buffer(0, { collect_sections = true })
   if not note then -- HACK: somehow DocumentSymbol gets called with no valid note
     return handler(nil, symbols)
   end
 
-  for _, anchor in pairs(note.anchor_links or {}) do
-    if anchor.section and not lookup[anchor.line] then
-      local display = string.rep("#", anchor.level) .. " " .. anchor.header
-      local symbol = {
-        name = display,
+  for _, section in ipairs(note.sections or {}) do
+    if section.header then
+      symbols[#symbols + 1] = {
+        name = string.rep("#", section.level) .. " " .. section.header,
         kind = 1,
         filename = note.path.filename,
-        range = Range.to_lsp(anchor.section.range),
-        selectionRange = Range.to_lsp(anchor.section.heading_range),
+        range = Range.to_lsp(section.range),
+        selectionRange = Range.to_lsp(section.heading_range),
       }
-      symbols[#symbols + 1] = symbol
-      lookup[anchor.line] = true
     end
   end
-
-  table.sort(symbols, function(a, b)
-    return a.range.start.line < b.range.start.line
-  end)
 
   handler(nil, symbols)
 end

--- a/lua/obsidian/lsp/handlers/document_symbol.lua
+++ b/lua/obsidian/lsp/handlers/document_symbol.lua
@@ -12,9 +12,9 @@ return function(_, handler)
     return handler(nil, symbols)
   end
 
-  for _, anchor in pairs(note.anchor_links) do
-    local display = string.rep("#", anchor.level) .. " " .. anchor.header
-    if not lookup[anchor.line] then
+  for _, anchor in pairs(note.anchor_links or {}) do
+    if anchor.section and not lookup[anchor.line] then
+      local display = string.rep("#", anchor.level) .. " " .. anchor.header
       local symbol = {
         name = display,
         kind = 1,

--- a/lua/obsidian/lsp/handlers/document_symbol.lua
+++ b/lua/obsidian/lsp/handlers/document_symbol.lua
@@ -1,4 +1,5 @@
 local obsidian = require "obsidian"
+local Range = require "obsidian.range"
 
 ---@param _ lsp.DocumentSymbolParams
 return function(_, handler)
@@ -13,17 +14,13 @@ return function(_, handler)
 
   for _, anchor in pairs(note.anchor_links) do
     local display = string.rep("#", anchor.level) .. " " .. anchor.header
-    local rge = {
-      start = { line = anchor.line - 1, character = 0 },
-      ["end"] = { line = anchor.line - 1, character = 0 },
-    }
     if not lookup[anchor.line] then
       local symbol = {
         name = display,
         kind = 1,
         filename = note.path.filename,
-        range = rge,
-        selectionRange = rge,
+        range = Range.to_lsp(anchor.section.range),
+        selectionRange = Range.to_lsp(anchor.section.heading_range),
       }
       symbols[#symbols + 1] = symbol
       lookup[anchor.line] = true

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -30,9 +30,9 @@ local DEFAULT_MAX_LINES = 500
 ---@param anchor string|?
 ---@return obsidian.note.HeaderAnchor
 local function new_header_anchor(section, parent, anchor)
-  local section_anchor = assert(section.anchor)
-  local header = assert(section.header)
-  local level = assert(section.level)
+  local section_anchor = assert(section.anchor, "section anchor is required")
+  local header = assert(section.header, "section header is required")
+  local level = assert(section.level, "section level is required")
 
   return {
     anchor = anchor or section_anchor,

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -25,6 +25,25 @@ local SKIP_UPDATING_FRONTMATTER = { "README.md", "CONTRIBUTING.md", "CHANGELOG.m
 
 local DEFAULT_MAX_LINES = 500
 
+---@param section obsidian.Section
+---@param parent obsidian.note.HeaderAnchor|?
+---@param anchor string|?
+---@return obsidian.note.HeaderAnchor
+local function new_header_anchor(section, parent, anchor)
+  local section_anchor = assert(section.anchor)
+  local header = assert(section.header)
+  local level = assert(section.level)
+
+  return {
+    anchor = anchor or section_anchor,
+    line = section.heading_range.start_row + 1,
+    header = header,
+    level = level,
+    parent = parent,
+    section = section,
+  }
+end
+
 --- A class that represents a note within a vault.
 ---
 ---@toc_entry obsidian.Note
@@ -420,7 +439,7 @@ Note.uri = function(self)
   return vim.uri_from_fname(tostring(self.path))
 end
 
----@param opts { block: string|?, anchor: string|?, range: lsp.Range|? }|?-- TODO: vim.Range in the future
+---@param opts { block: string|?, anchor: string|?, range: lsp.Range|obsidian.Range|? }|?
 ---@return lsp.Location
 Note._location = function(self, opts)
   opts = opts or {}
@@ -441,7 +460,7 @@ Note._location = function(self, opts)
     section = anchor_match and anchor_match.section
   end
 
-  local range = opts.range
+  local range = opts.range and (opts.range.start_row and Range.to_lsp(opts.range) or opts.range)
     or (section and Range.to_lsp(section.range))
     or {
       start = { line = 0, character = 0 },
@@ -718,26 +737,19 @@ Note.from_lines = function(lines, path, opts)
       if section.header then
         -- We collect up to two anchors for each header. One standalone, e.g. '#header1', and
         -- one with the parents, e.g. '#header1#header2'.
-        ---@type obsidian.note.HeaderAnchor
-        local data = {
-          anchor = section.anchor,
-          line = section.heading_range.start_row + 1,
-          header = section.header,
-          level = section.level,
-          parent = section.parent and section_to_anchor[section.parent],
-          section = section,
-        }
+        local data = new_header_anchor(section, section.parent and section_to_anchor[section.parent], nil)
         section_to_anchor[section] = data
         anchor_links[section.anchor] = data
 
         if data.parent ~= nil then
           local nested_anchor = data.anchor
+          ---@type obsidian.note.HeaderAnchor|?
           local parent = data.parent
           while parent ~= nil do
             nested_anchor = parent.anchor .. nested_anchor
             parent = parent.parent
           end
-          anchor_links[nested_anchor] = vim.tbl_extend("force", data, { anchor = nested_anchor })
+          anchor_links[nested_anchor] = new_header_anchor(section, data.parent, nested_anchor)
         end
       end
     end

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -18,12 +18,12 @@ local api = require "obsidian.api"
 local Frontmatter = require "obsidian.frontmatter"
 local search = require "obsidian.search"
 local ignore = require "obsidian.ignore"
+local Section = require "obsidian.section"
+local Range = require "obsidian.range"
 
 local SKIP_UPDATING_FRONTMATTER = { "README.md", "CONTRIBUTING.md", "CHANGELOG.md" }
 
 local DEFAULT_MAX_LINES = 500
-
-local CODE_BLOCK_PATTERN = "^%s*```[%w_-]*$"
 
 --- A class that represents a note within a vault.
 ---
@@ -42,6 +42,7 @@ local CODE_BLOCK_PATTERN = "^%s*```[%w_-]*$"
 ---@field frontmatter_end_line integer|?
 ---@field anchor_links table<string, obsidian.note.HeaderAnchor>|?
 ---@field blocks table<string, obsidian.note.Block>?
+---@field sections obsidian.Section[]|? document-ordered sections, the first one is always the preamble.
 ---@field alt_alias string|?
 ---@field bufnr integer|?
 ---@field template string|? Template name carried by the note. Used as the default `template` for `note:write` when no explicit value is passed.
@@ -428,24 +429,23 @@ Note._location = function(self, opts)
     error "can not pass both range and an block/anhor link to Note:_location()"
   end
 
-  ---@type integer|?, obsidian.note.Block|?, obsidian.note.HeaderAnchor|?
-  local line = 0
+  -- The full section the link points at: jumps land at its start and the
+  -- whole range gets a blink highlight, like the Obsidian app.
+  ---@type obsidian.Section|?
+  local section
   if opts.block then
     local block_match = self:resolve_block(opts.block)
-    if block_match then
-      line = block_match.line - 1
-    end
+    section = block_match and block_match.section
   elseif opts.anchor then
     local anchor_match = self:resolve_anchor_link(opts.anchor)
-    if anchor_match then
-      line = anchor_match.line - 1
-    end
+    section = anchor_match and anchor_match.section
   end
 
   local range = opts.range
+    or (section and Range.to_lsp(section.range))
     or {
-      start = { line = line, character = 0 },
-      ["end"] = { line = line, character = 0 },
+      start = { line = 0, character = 0 },
+      ["end"] = { line = 0, character = 0 },
     }
 
   return {
@@ -666,61 +666,11 @@ Note.from_lines = function(lines, path, opts)
 
   local contents = {}
 
-  ---@type table<string, obsidian.note.HeaderAnchor>|?
-  local anchor_links
-  ---@type obsidian.note.HeaderAnchor[]|?
-  local anchor_stack
-  if opts.collect_anchor_links then
-    anchor_links = {}
-    anchor_stack = {}
-  end
-
-  ---@type table<string, obsidian.note.Block>|?
-  local blocks
-  if opts.collect_blocks then
-    blocks = {}
-  end
-
-  ---@param anchor_data obsidian.note.HeaderAnchor
-  ---@return obsidian.note.HeaderAnchor|?
-  local function get_parent_anchor(anchor_data)
-    assert(anchor_links and anchor_stack, "failed to collect anchor")
-    for i = #anchor_stack, 1, -1 do
-      local parent = anchor_stack[i]
-      if parent.level < anchor_data.level then
-        return parent
-      end
-    end
-  end
-
-  ---@param anchor string
-  ---@param data obsidian.note.HeaderAnchor|?
-  local function format_nested_anchor(anchor, data)
-    local out = anchor
-    if not data then
-      return out
-    end
-
-    local parent = data.parent
-    while parent ~= nil do
-      out = parent.anchor .. out
-      data = get_parent_anchor(parent)
-      if data ~= nil then
-        parent = data.parent
-      else
-        parent = nil
-      end
-    end
-
-    return out
-  end
-
-  -- Iterate over lines in the file, collecting frontmatter and parsing the title.
+  -- Iterate over lines in the file, collecting frontmatter and contents.
   local frontmatter_lines = {}
   local has_frontmatter, in_frontmatter = false, false
   local at_boundary
   local frontmatter_end_line = nil
-  local in_code_block = false
   for line_idx, line in iter(lines):enumerate() do
     line = util.rstrip_whitespace(line)
 
@@ -736,50 +686,8 @@ Note.from_lines = function(lines, path, opts)
       at_boundary = false
     end
 
-    if string.match(line, CODE_BLOCK_PATTERN) then
-      in_code_block = not in_code_block
-    end
-
     if in_frontmatter and not at_boundary then
       table.insert(frontmatter_lines, line)
-    elseif not in_frontmatter and not at_boundary and not in_code_block then
-      -- Check for title/header and collect anchor link.
-      local header_match = util.parse_header(line)
-      if header_match then
-        -- Collect anchor link.
-        if opts.collect_anchor_links then
-          assert(anchor_links and anchor_stack, "failed to collect anchor")
-          -- We collect up to two anchor for each header. One standalone, e.g. '#header1', and
-          -- one with the parents, e.g. '#header1#header2'.
-          -- This is our standalone one:
-          ---@type obsidian.note.HeaderAnchor
-          local data = {
-            anchor = header_match.anchor,
-            line = line_idx,
-            header = header_match.header,
-            level = header_match.level,
-          }
-          data.parent = get_parent_anchor(data)
-
-          anchor_links[header_match.anchor] = data
-          table.insert(anchor_stack, data)
-
-          -- Now if there's a parent we collect the nested version. All of the data will be the same
-          -- except the anchor key.
-          if data.parent ~= nil then
-            local nested_anchor = format_nested_anchor(header_match.anchor, data)
-            anchor_links[nested_anchor] = vim.tbl_extend("force", data, { anchor = nested_anchor })
-          end
-        end
-      end
-
-      -- Check for block.
-      if opts.collect_blocks then
-        local block = util.parse_block(line)
-        if block then
-          blocks[block] = { id = block, line = line_idx, block = line }
-        end
-      end
     end
 
     -- Collect contents.
@@ -788,6 +696,50 @@ Note.from_lines = function(lines, path, opts)
     -- Check if we can stop reading lines now.
     if line_idx > max_lines then
       break
+    end
+  end
+
+  ---@type obsidian.Section[]|?, table<string, obsidian.note.Block>|?
+  local sections, blocks
+  if opts.collect_sections or opts.collect_anchor_links or opts.collect_blocks then
+    sections, blocks = Section.parse(contents, {
+      start_row = frontmatter_end_line or 0,
+      collect_blocks = opts.collect_blocks,
+    })
+  end
+
+  ---@type table<string, obsidian.note.HeaderAnchor>|?
+  local anchor_links
+  if opts.collect_anchor_links then
+    anchor_links = {}
+    ---@type table<obsidian.Section, obsidian.note.HeaderAnchor>
+    local section_to_anchor = {}
+    for _, section in ipairs(assert(sections, "sections must be parsed when collecting anchor links")) do
+      if section.header then
+        -- We collect up to two anchors for each header. One standalone, e.g. '#header1', and
+        -- one with the parents, e.g. '#header1#header2'.
+        ---@type obsidian.note.HeaderAnchor
+        local data = {
+          anchor = section.anchor,
+          line = section.heading_range.start_row + 1,
+          header = section.header,
+          level = section.level,
+          parent = section.parent and section_to_anchor[section.parent],
+          section = section,
+        }
+        section_to_anchor[section] = data
+        anchor_links[section.anchor] = data
+
+        if data.parent ~= nil then
+          local nested_anchor = data.anchor
+          local parent = data.parent
+          while parent ~= nil do
+            nested_anchor = parent.anchor .. nested_anchor
+            parent = parent.parent
+          end
+          anchor_links[nested_anchor] = vim.tbl_extend("force", data, { anchor = nested_anchor })
+        end
+      end
     end
   end
 
@@ -814,6 +766,7 @@ Note.from_lines = function(lines, path, opts)
   n.contents = contents
   n.anchor_links = anchor_links
   n.blocks = blocks
+  n.sections = sections
   -- TODO: reflect the warnings in `:Obsidian check`
   return n, warnings
 end
@@ -1419,6 +1372,7 @@ end
 ---@field max_lines integer|?
 ---@field collect_anchor_links boolean|?
 ---@field collect_blocks boolean|?
+---@field collect_sections boolean|?
 
 ---@class (exact) obsidian.note.NoteCreationOpts
 ---@field notes_subdir string
@@ -1500,11 +1454,13 @@ end
 ---@field level integer
 ---@field line integer
 ---@field parent obsidian.note.HeaderAnchor|?
+---@field section obsidian.Section the full section this header begins.
 
 ---@class obsidian.note.Block
 ---
 ---@field id string
 ---@field line integer
 ---@field block string
+---@field section obsidian.Section the paragraph carrying the block identifier.
 
 return Note

--- a/lua/obsidian/range.lua
+++ b/lua/obsidian/range.lua
@@ -68,6 +68,32 @@ Range.lsp = function(range)
   return Range.new(range.start.line, range.start.character, range["end"].line, range["end"].character)
 end
 
+local blink_counter = 0
+
+--- Briefly highlight a range in a buffer.
+---
+---@param range obsidian.Range
+---@param bufnr integer|?
+---@param opts { timeout: integer|?, hl_group: string|? }|?
+Range.blink = function(range, bufnr, opts)
+  opts = opts or {}
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  blink_counter = blink_counter + 1
+
+  local ns = vim.api.nvim_create_namespace("obsidian_blink_" .. blink_counter)
+  local hl_group = opts.hl_group or "ObsidianBlink"
+  vim.api.nvim_set_hl(0, hl_group, { link = "Visual", default = true })
+
+  local hl = vim.hl or vim.highlight
+  hl.range(bufnr, ns, hl_group, { range.start_row, range.start_col }, { range.end_row, range.end_col }, {})
+
+  vim.defer_fn(function()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+    end
+  end, opts.timeout or 500)
+end
+
 setmetatable(Range, {
   __call = function(_, ...)
     return Range.new(...)

--- a/lua/obsidian/range.lua
+++ b/lua/obsidian/range.lua
@@ -1,0 +1,77 @@
+--- A minimal imitation of the experimental `vim.range` API (neovim/neovim#25509).
+---
+--- Only the useful subset is implemented here. Field names and semantics match
+--- `vim.Range` (0-based rows/cols, end-exclusive), so that once `vim.range`
+--- stabilizes, migrating is mechanical:
+--- `vim.range(buf, r.start_row, r.start_col, r.end_row, r.end_col)`.
+---
+--- Unlike `vim.Range`, no buffer handle is carried: ranges here typically
+--- describe locations in note *files* that may not be loaded in a buffer.
+---
+--- NOTE: prefer calling these as module functions (`Range.to_lsp(r)`) rather
+--- than methods (`r:to_lsp()`) inside the plugin, because ranges that
+--- round-trip through `vim.b` (see `Note.from_buffer`) lose their metatable.
+
+--- Represents a range in a file or buffer. 0-based, end-exclusive.
+---
+---@class obsidian.Range
+---@field start_row integer 0-based start row.
+---@field start_col integer 0-based start col, byte index.
+---@field end_row integer 0-based end row.
+---@field end_col integer 0-based end col, byte index, exclusive.
+local Range = {}
+Range.__index = Range
+
+---@param start_row integer
+---@param start_col integer
+---@param end_row integer
+---@param end_col integer
+---@return obsidian.Range
+Range.new = function(start_row, start_col, end_row, end_col)
+  return setmetatable({
+    start_row = start_row,
+    start_col = start_col,
+    end_row = end_row,
+    end_col = end_col,
+  }, Range)
+end
+
+--- Checks whether the given range is empty; i.e., start >= end.
+---
+---@param range obsidian.Range
+---@return boolean
+Range.is_empty = function(range)
+  return range.start_row > range.end_row or (range.start_row == range.end_row and range.start_col >= range.end_col)
+end
+
+--- Converts an |obsidian.Range| to an `lsp.Range`.
+---
+--- NOTE: `lsp.Position.character` is measured in code units of the position
+--- encoding while ours is a byte index. The ranges produced by this plugin are
+--- line-based (cols are always 0), where the two are identical, so no buffer
+--- access or re-encoding is needed.
+---
+---@param range obsidian.Range
+---@return lsp.Range
+Range.to_lsp = function(range)
+  return {
+    start = { line = range.start_row, character = range.start_col },
+    ["end"] = { line = range.end_row, character = range.end_col },
+  }
+end
+
+--- Creates a new |obsidian.Range| from an `lsp.Range`.
+---
+---@param range lsp.Range
+---@return obsidian.Range
+Range.lsp = function(range)
+  return Range.new(range.start.line, range.start.character, range["end"].line, range["end"].character)
+end
+
+setmetatable(Range, {
+  __call = function(_, ...)
+    return Range.new(...)
+  end,
+})
+
+return Range

--- a/lua/obsidian/section.lua
+++ b/lua/obsidian/section.lua
@@ -24,7 +24,7 @@ local CODE_BLOCK_PATTERN = "^```[%w_-]*$"
 ---@field anchor string|? standardized anchor, e.g. "#my-heading".
 ---@field range obsidian.Range full extent: heading through the content of the last descendant section. This is the range to highlight when navigating here.
 ---@field heading_range obsidian.Range the heading line(s). Empty for the preamble.
----@field content_range obsidian.Range own content (sub-sections excluded), trimmed of surrounding blank lines.
+---@field content_range obsidian.Range own content (sub-sections excluded), trimmed of leading and trailing blank lines.
 ---@field parent obsidian.Section|? the nearest section above with a lower heading level.
 
 local M = {}
@@ -103,7 +103,7 @@ M.parse = function(lines, opts)
 
   -- Working entries with 1-based [beg_incl, end_excl) line indices,
   -- mirroring the half-open ranges of the output.
-  ---@type { level: integer|?, label: string|?, h_beg: integer, h_end: integer, c_beg: integer, c_end: integer }
+  ---@type { level: integer|?, label: string|?, h_beg: integer, h_end: integer, c_beg: integer, c_end: integer, blocks: obsidian.note.Block[]|? }
   local current = { h_beg = first, h_end = first, c_beg = first, c_end = first }
   local entries = { current }
   local content_empty = true
@@ -114,10 +114,29 @@ M.parse = function(lines, opts)
   local para_beg
   ---@type obsidian.note.Block[]
   local para_blocks = {}
+  ---@type obsidian.Section|?
+  local last_para_section
+
+  ---@param entry table
+  ---@param idx integer
+  local function collect_section_block(entry, idx)
+    if not blocks then
+      return
+    end
+
+    local line = vim.trim(lines[idx])
+    local block_id = util.parse_block(line)
+    if block_id then
+      local block = { id = block_id, line = idx, block = line }
+      blocks[block_id] = block
+      entry.blocks = entry.blocks or {}
+      table.insert(entry.blocks, block)
+    end
+  end
 
   ---@param end_excl integer
   local function close_paragraph(end_excl)
-    if para_beg ~= nil and #para_blocks > 0 then
+    if para_beg ~= nil then
       local section = {
         range = Range.new(para_beg - 1, 0, end_excl - 1, 0),
         heading_range = Range.new(para_beg - 1, 0, para_beg - 1, 0),
@@ -126,6 +145,7 @@ M.parse = function(lines, opts)
       for _, block in ipairs(para_blocks) do
         block.section = section
       end
+      last_para_section = section
     end
     para_beg = nil
     para_blocks = {}
@@ -137,6 +157,7 @@ M.parse = function(lines, opts)
 
     if detail.type == "header" then
       close_paragraph(idx)
+      last_para_section = nil
       current = {
         level = detail.level,
         label = detail.label,
@@ -146,6 +167,7 @@ M.parse = function(lines, opts)
         c_end = idx_excl,
       }
       table.insert(entries, current)
+      collect_section_block(current, idx)
       content_empty = true
     elseif detail.type == "header-underline" then
       current.h_end = idx_excl
@@ -159,13 +181,17 @@ M.parse = function(lines, opts)
       current.c_end = idx_excl
 
       if blocks and detail.type == "text" then
-        para_beg = para_beg or idx
         local line = vim.trim(lines[idx])
         local block_id = util.parse_block(line)
-        if block_id then
-          local block = { id = block_id, line = idx, block = line }
-          blocks[block_id] = block
-          table.insert(para_blocks, block)
+        if block_id and line == block_id and para_beg == nil and last_para_section ~= nil then
+          blocks[block_id] = { id = block_id, line = idx, block = line, section = last_para_section }
+        else
+          para_beg = para_beg or idx
+          if block_id then
+            local block = { id = block_id, line = idx, block = line }
+            blocks[block_id] = block
+            table.insert(para_blocks, block)
+          end
         end
       else
         close_paragraph(idx)
@@ -209,6 +235,10 @@ M.parse = function(lines, opts)
           break
         end
       end
+    end
+
+    for _, block in ipairs(entry.blocks or {}) do
+      block.section = section
     end
 
     sections[i] = section

--- a/lua/obsidian/section.lua
+++ b/lua/obsidian/section.lua
@@ -1,0 +1,220 @@
+--- Shared markdown section parser.
+---
+--- This is the single source of truth for splitting a note into sections.
+--- It backs both anchor-link / block resolution (`Note.from_lines`) and
+--- `Note.insert_text` (via `obsidian.util.text_insertion`).
+
+local util = require "obsidian.util"
+local Range = require "obsidian.range"
+
+local H1_UNDERLINE_PATTERN = "^(=+)$"
+local H2_UNDERLINE_PATTERN = "^(-+)$"
+local CODE_BLOCK_PATTERN = "^```[%w_-]*$"
+
+--- A contiguous region of a markdown document.
+---
+--- All ranges are |obsidian.Range|s over *lines* of the parsed document:
+--- cols are always 0 and end rows are exclusive, i.e. a range covering lines
+--- 5-7 (1-based) is `{ start_row = 4, start_col = 0, end_row = 7, end_col = 0 }`.
+---
+---@class obsidian.Section
+---
+---@field header string|? raw heading label. `nil` for the preamble and for block paragraphs.
+---@field level integer|? heading level. `nil` for the preamble and for block paragraphs.
+---@field anchor string|? standardized anchor, e.g. "#my-heading".
+---@field range obsidian.Range full extent: heading through the content of the last descendant section. This is the range to highlight when navigating here.
+---@field heading_range obsidian.Range the heading line(s). Empty for the preamble.
+---@field content_range obsidian.Range own content (sub-sections excluded), trimmed of surrounding blank lines.
+---@field parent obsidian.Section|? the nearest section above with a lower heading level.
+
+local M = {}
+
+---@class obsidian.section.LineDetail
+---@field type "text"|"header"|"header-underline"|"code"|"empty"
+---@field level integer|?
+---@field label string|?
+
+--- Classify lines, resolving setext ("underline") headers retroactively.
+---
+---@param lines string[]
+---@param first integer 1-based index to start at.
+---@return table<integer, obsidian.section.LineDetail>
+local function get_line_details(lines, first)
+  local details = {}
+  local in_code_block = false
+
+  ---@param idx integer
+  ---@return obsidian.section.LineDetail
+  local function classify(idx)
+    local line = vim.trim(lines[idx] --[[@as string]])
+
+    if in_code_block then
+      in_code_block = not line:match(CODE_BLOCK_PATTERN)
+      return { type = "code" }
+    elseif line:match(CODE_BLOCK_PATTERN) then
+      in_code_block = true
+      return { type = "code" }
+    end
+
+    if line == "" then
+      return { type = "empty" }
+    end
+
+    local header = util.parse_header(line)
+    if header then
+      return { type = "header", level = header.level, label = header.header }
+    end
+
+    local prev = details[idx - 1] or { type = "empty" }
+    local level = (line:match(H1_UNDERLINE_PATTERN) and 1) or (line:match(H2_UNDERLINE_PATTERN) and 2)
+    if level and prev.type == "text" then
+      details[idx - 1] = { type = "header", level = level, label = prev.label }
+      return { type = "header-underline" }
+    end
+
+    return { type = "text", label = line }
+  end
+
+  for idx = first, #lines do
+    details[idx] = classify(idx)
+  end
+
+  return details
+end
+
+---@class obsidian.section.ParseOpts
+---@field start_row integer|? 0-based row where parsing begins, e.g. just past the frontmatter. Defaults to `0`.
+---@field collect_blocks boolean|? also collect block identifiers (`^block-id`).
+
+--- Parse markdown lines into a document-ordered list of sections.
+---
+--- The first section is always the "preamble" (`header == nil`): everything
+--- before the first heading. It is present even when empty.
+---
+---@param lines string[]
+---@param opts obsidian.section.ParseOpts|?
+---@return obsidian.Section[] sections
+---@return table<string, obsidian.note.Block>|? blocks `nil` unless `opts.collect_blocks` is set.
+M.parse = function(lines, opts)
+  opts = opts or {}
+  local first = (opts.start_row or 0) + 1
+
+  local details = get_line_details(lines, first)
+
+  -- Working entries with 1-based [beg_incl, end_excl) line indices,
+  -- mirroring the half-open ranges of the output.
+  ---@type { level: integer|?, label: string|?, h_beg: integer, h_end: integer, c_beg: integer, c_end: integer }
+  local current = { h_beg = first, h_end = first, c_beg = first, c_end = first }
+  local entries = { current }
+  local content_empty = true
+
+  ---@type table<string, obsidian.note.Block>|?
+  local blocks = opts.collect_blocks and {} or nil
+  ---@type integer|?
+  local para_beg
+  ---@type obsidian.note.Block[]
+  local para_blocks = {}
+
+  ---@param end_excl integer
+  local function close_paragraph(end_excl)
+    if para_beg ~= nil and #para_blocks > 0 then
+      local section = {
+        range = Range.new(para_beg - 1, 0, end_excl - 1, 0),
+        heading_range = Range.new(para_beg - 1, 0, para_beg - 1, 0),
+        content_range = Range.new(para_beg - 1, 0, end_excl - 1, 0),
+      }
+      for _, block in ipairs(para_blocks) do
+        block.section = section
+      end
+    end
+    para_beg = nil
+    para_blocks = {}
+  end
+
+  for idx = first, #lines do
+    local detail = details[idx]
+    local idx_excl = idx + 1
+
+    if detail.type == "header" then
+      close_paragraph(idx)
+      current = {
+        level = detail.level,
+        label = detail.label,
+        h_beg = idx,
+        h_end = idx_excl,
+        c_beg = idx_excl,
+        c_end = idx_excl,
+      }
+      table.insert(entries, current)
+      content_empty = true
+    elseif detail.type == "header-underline" then
+      current.h_end = idx_excl
+      current.c_beg = idx_excl
+      current.c_end = idx_excl
+    elseif detail.type ~= "empty" then
+      if content_empty then
+        current.c_beg = idx
+        content_empty = false
+      end
+      current.c_end = idx_excl
+
+      if blocks and detail.type == "text" then
+        para_beg = para_beg or idx
+        local line = vim.trim(lines[idx])
+        local block_id = util.parse_block(line)
+        if block_id then
+          local block = { id = block_id, line = idx, block = line }
+          blocks[block_id] = block
+          table.insert(para_blocks, block)
+        end
+      else
+        close_paragraph(idx)
+      end
+    else
+      close_paragraph(idx)
+    end
+  end
+  close_paragraph(#lines + 1)
+
+  -- Materialize sections. A section's full range extends through its
+  -- descendants: it ends where the next section of the same or lower level
+  -- begins (or at the end of the document).
+  ---@type obsidian.Section[]
+  local sections = {}
+  for i, entry in ipairs(entries) do
+    local full_end = entry.c_end
+    if entry.level then
+      for j = i + 1, #entries do
+        if entries[j].level <= entry.level then
+          break
+        end
+        full_end = math.max(full_end, entries[j].c_end)
+      end
+    end
+
+    ---@type obsidian.Section
+    local section = {
+      header = entry.label,
+      level = entry.level,
+      anchor = entry.label and util.header_to_anchor(entry.label) or nil,
+      range = Range.new((entry.level and entry.h_beg or entry.c_beg) - 1, 0, full_end - 1, 0),
+      heading_range = Range.new(entry.h_beg - 1, 0, entry.h_end - 1, 0),
+      content_range = Range.new(entry.c_beg - 1, 0, entry.c_end - 1, 0),
+    }
+
+    if entry.level then
+      for j = #sections, 2, -1 do
+        if sections[j].level < entry.level then
+          section.parent = sections[j]
+          break
+        end
+      end
+    end
+
+    sections[i] = section
+  end
+
+  return sections, blocks
+end
+
+return M

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -1,7 +1,4 @@
-local HEADER_PREFIX_PATTERN = "^(#+)%s*(%S.*)$"
-local H1_UNDERLINE_PATTERN = "^(=+)$"
-local H2_UNDERLINE_PATTERN = "^(-+)$"
-local CODE_BLOCK_PATTERN = "^```[%w_-]*$"
+local Section = require "obsidian.section"
 
 local M = {}
 local H = {}
@@ -26,9 +23,9 @@ function M.resolve(lines, opts)
   end
 end
 
---- Collapses lines into a list of "sections". Each section is itself composed of two sub-sections: heading and content.
---- The heading and content sub-sections are defined using a half-open `[beg_incl, end_excl)` range. When empty, they
---- will use values such that `beg_incl == end_excl`.
+--- Collapses lines into a list of "sections" via the shared parser in `obsidian.section`. Each section is itself
+--- composed of two sub-sections: heading and content. The heading and content sub-sections are defined using a
+--- half-open `[beg_incl, end_excl)` range. When empty, they will use values such that `beg_incl == end_excl`.
 ---
 --- IMPORTANT: There will always be AT LEAST TWO sections.
 ---
@@ -42,31 +39,25 @@ end
 ---@param lines string[] The list of lines in the markdown document.
 ---@return obsidian.note.SectionDetail[] sections defining the document. There will always be at least two items.
 function H.collapse_into_sections(lines)
-  local sections = { H.new_section_detail(1, 1) }
-  local current = sections[1]
-  local current_content_empty = true
+  ---@type obsidian.note.SectionDetail[]
+  local sections = {}
 
-  for idx_incl, line_detail in ipairs(H.get_line_details(lines)) do
-    local idx_excl = idx_incl + 1
-
-    if line_detail.type == "header" then
-      table.insert(sections, H.new_section_detail(idx_incl, idx_excl, line_detail.level, line_detail.label))
-      current = sections[#sections]
-      current_content_empty = true
-    elseif line_detail.type == "header-underline" then
-      current.heading.end_excl = idx_excl
-      current.content.beg_incl = idx_excl
-      current.content.end_excl = idx_excl
-    elseif line_detail.type ~= "empty" then
-      if current_content_empty then
-        current.content.beg_incl = idx_incl
-        current_content_empty = false
-      end
-      current.content.end_excl = idx_excl
-    end
+  for _, section in ipairs(Section.parse(lines)) do
+    table.insert(sections, {
+      heading = {
+        beg_incl = section.heading_range.start_row + 1,
+        end_excl = section.heading_range.end_row + 1,
+        level = section.level or 0,
+        label = section.header or "",
+      },
+      content = {
+        beg_incl = section.content_range.start_row + 1,
+        end_excl = section.content_range.end_row + 1,
+      },
+    })
   end
 
-  local eof_excl = current.content.end_excl
+  local eof_excl = sections[#sections].content.end_excl
   table.insert(sections, H.new_section_detail(eof_excl, eof_excl))
 
   return sections
@@ -201,80 +192,10 @@ function H.is_content_empty(section)
   return not section or section.content.beg_incl == section.content.end_excl
 end
 
----@param lines string[]
----@return obsidian.note.LineDetail[]
-function H.get_line_details(lines)
-  local line_details = {}
-  local within_code_block = false
-
-  ---@param idx integer
-  ---@return obsidian.note.LineDetail
-  local function get_detail_for_idx_by_using_early_return_statements(idx)
-    local line_str = vim.trim(lines[idx])
-
-    if within_code_block then
-      within_code_block = not line_str:match(CODE_BLOCK_PATTERN)
-      return { type = "code" }
-    elseif line_str:match(CODE_BLOCK_PATTERN) then
-      within_code_block = true
-      return { type = "code" }
-    end
-
-    if line_str == "" then
-      return { type = "empty" }
-    end
-
-    local level_str, label_str = line_str:match(HEADER_PREFIX_PATTERN)
-    if level_str and label_str and level_str ~= "" and label_str ~= "" then
-      return { type = "header", level = level_str:len(), label = label_str }
-    end
-
-    local prev_line = idx > 1 and line_details[idx - 1] or { type = "empty" }
-    local level = (line_str:match(H1_UNDERLINE_PATTERN) and 1) or (line_str:match(H2_UNDERLINE_PATTERN) and 2)
-    if level and prev_line.type == "text" then
-      line_details[idx - 1] = { type = "header", level = level, label = prev_line.text }
-      return { type = "header-underline" }
-    end
-
-    return { type = "text", text = line_str }
-  end
-
-  for idx = 1, #lines do
-    line_details[idx] = get_detail_for_idx_by_using_early_return_statements(idx)
-  end
-
-  return line_details
-end
-
 ---@alias obsidian.note.OnSectionMissingHandler fun(sections: obsidian.note.SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_top: string[], insert_bot: string[]
 
 ---@class obsidian.note.SectionDetail
 ---@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }
 ---@field content? { beg_incl: integer, end_excl: integer }
-
----@alias obsidian.note.LineDetail
----|obsidian.note.LineTextDetail
----|obsidian.note.LineHeaderDetail
----|obsidian.note.LineHeaderUnderlineDetail
----|obsidian.note.LineCodeDetail
----|obsidian.note.LineEmptyDetail
-
----@class obsidian.note.LineTextDetail
----@field type 'text'
----@field text string
-
----@class obsidian.note.LineHeaderDetail
----@field type 'header'
----@field level integer
----@field label string
-
----@class obsidian.note.LineHeaderUnderlineDetail
----@field type 'header-underline'
-
----@class obsidian.note.LineCodeDetail
----@field type 'code'
-
----@class obsidian.note.LineEmptyDetail
----@field type 'empty'
 
 return M

--- a/lua/obsidian/util/text_insertion.lua
+++ b/lua/obsidian/util/text_insertion.lua
@@ -1,4 +1,5 @@
 local Section = require "obsidian.section"
+local Range = require "obsidian.range"
 
 local M = {}
 local H = {}
@@ -11,7 +12,7 @@ local H = {}
 ---@return string[] insert_top holds the lines needed _before_ the text in order to preserve the constraints.
 ---@return string[] insert_bot holds the lines needed _after_ the text in order to preserve the constraints.
 function M.resolve(lines, opts)
-  local sections = H.collapse_into_sections(lines)
+  local sections = H.parse_sections(lines)
   local chosen_idx = H.choose_section(sections, opts)
 
   if chosen_idx > 0 then
@@ -23,49 +24,43 @@ function M.resolve(lines, opts)
   end
 end
 
---- Collapses lines into a list of "sections" via the shared parser in `obsidian.section`. Each section is itself
---- composed of two sub-sections: heading and content. The heading and content sub-sections are defined using a
---- half-open `[beg_incl, end_excl)` range. When empty, they will use values such that `beg_incl == end_excl`.
+--- Parse markdown sections and append an empty EOF marker.
 ---
---- IMPORTANT: There will always be AT LEAST TWO sections.
----
---- The FIRST section is the PREAMBLE. It contains the non-empty lines _before_ the first heading. If there aren't any
---- headings, then it will contain ALL non-empty lines in the file. Otherwise, when the document is empty or when the
---- first line in the document is a heading, then the content section of the preamble will be empty.
----
---- The FINAL section is the EOF-MARKER. Both its heading and content is always empty. This section can be used to find
---- the final lines in the document.
+--- IMPORTANT: There will always be AT LEAST TWO sections:
+--- - the first is the preamble from `obsidian.section`;
+--- - the final one is an empty EOF marker used as an insertion target.
 ---
 ---@param lines string[] The list of lines in the markdown document.
----@return obsidian.note.SectionDetail[] sections defining the document. There will always be at least two items.
-function H.collapse_into_sections(lines)
-  ---@type obsidian.note.SectionDetail[]
-  local sections = {}
+---@return obsidian.Section[] sections
+function H.parse_sections(lines)
+  local sections = Section.parse(lines)
+  local eof_row = sections[#sections].content_range.end_row
+  local eof_range = Range.new(eof_row, 0, eof_row, 0)
 
-  for _, section in ipairs(Section.parse(lines)) do
-    table.insert(sections, {
-      heading = {
-        beg_incl = section.heading_range.start_row + 1,
-        end_excl = section.heading_range.end_row + 1,
-        level = section.level or 0,
-        label = section.header or "",
-      },
-      content = {
-        beg_incl = section.content_range.start_row + 1,
-        end_excl = section.content_range.end_row + 1,
-      },
-    })
-  end
-
-  local eof_excl = sections[#sections].content.end_excl
-  table.insert(sections, H.new_section_detail(eof_excl, eof_excl))
+  sections[#sections + 1] = {
+    range = eof_range,
+    heading_range = eof_range,
+    content_range = eof_range,
+  }
 
   return sections
 end
 
+---@param range obsidian.Range
+---@return integer
+local function beg_incl(range)
+  return range.start_row + 1
+end
+
+---@param range obsidian.Range
+---@return integer
+local function end_excl(range)
+  return range.end_row + 1
+end
+
 --- Chooses a section to insert new text into.
 ---
----@param sections obsidian.note.SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param sections obsidian.Section[] List of sections in the document. Must contain the preamble and EOF-marker.
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer chosen_idx where the new text can be inserted while maintaining the layout, or `0` if none are valid.
 function H.choose_section(sections, opts)
@@ -77,10 +72,9 @@ function H.choose_section(sections, opts)
   end
 
   for idx = 2, #sections - 1 do
-    local ith_heading = sections[idx].heading or {}
+    local section = sections[idx]
     if
-      (not header_wanted or ith_heading.label == header_wanted)
-      and (not level_wanted or ith_heading.level == level_wanted)
+      (not header_wanted or section.header == header_wanted) and (not level_wanted or section.level == level_wanted)
     then
       return idx
     end
@@ -91,7 +85,7 @@ end
 
 --- Expands the section positioned at the specified index so that it can have more text inserted into it.
 ---
----@param sections obsidian.note.SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param sections obsidian.Section[] List of sections in the document. Must contain the preamble and EOF-marker.
 ---@param chosen_idx integer The index where the old section is located. Must NOT be the EOF-marker (`idx = #sections`).
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints.
@@ -103,7 +97,8 @@ function H.expand_old_section(sections, chosen_idx, opts)
   local section_chosen = sections[chosen_idx]
   local section_after = sections[chosen_idx + 1]
 
-  local insert_idx = opts.placement == "top" and section_chosen.content.beg_incl or section_chosen.content.end_excl
+  local insert_idx = opts.placement == "top" and beg_incl(section_chosen.content_range)
+    or end_excl(section_chosen.content_range)
   local insert_top = {}
   local insert_bot = {}
 
@@ -111,7 +106,7 @@ function H.expand_old_section(sections, chosen_idx, opts)
     table.insert(insert_top, "")
   end
 
-  if not H.is_section_empty(section_after) and section_after.heading.beg_incl == insert_idx then
+  if not H.is_section_empty(section_after) and beg_incl(section_after.heading_range) == insert_idx then
     table.insert(insert_bot, "")
   end
 
@@ -120,7 +115,7 @@ end
 
 --- Inserts a new heading and section at the specified index and "pushes down" the section that is currently there.
 ---
----@param sections obsidian.note.SectionDetail[] List of sections in the document. Must contain the preamble and EOF-marker.
+---@param sections obsidian.Section[] List of sections in the document. Must contain the preamble and EOF-marker.
 ---@param chosen_idx integer The index where the new section will be inserted. Must NOT be the preamble (`idx = 1`).
 ---@param opts obsidian.note.InsertTextOpts Constrains where text can be inserted.
 ---@return integer insert_idx where new text should be inserted to satisfy the constraints.
@@ -132,11 +127,14 @@ function H.insert_new_section(sections, chosen_idx, opts)
   local section_chosen = sections[chosen_idx]
   local section_before = sections[chosen_idx - 1]
 
-  local insert_idx = section_chosen.heading.beg_incl
+  local insert_idx = beg_incl(section_chosen.heading_range)
   local insert_top = {}
   local insert_bot = {}
 
-  if (not H.is_section_empty(section_before) or opts.padding_top) and section_before.content.end_excl == insert_idx then
+  if
+    (not H.is_section_empty(section_before) or opts.padding_top)
+    and end_excl(section_before.content_range) == insert_idx
+  then
     table.insert(insert_top, "")
   end
 
@@ -168,34 +166,18 @@ H.on_section_missing_handlers = {
   end,
 }
 
----@param beg_incl integer
----@param end_excl integer
----@param level? integer
----@param label? string
----@return obsidian.note.SectionDetail
-function H.new_section_detail(beg_incl, end_excl, level, label)
-  return {
-    heading = { beg_incl = beg_incl, end_excl = end_excl, level = level or 0, label = label or "" },
-    content = { beg_incl = end_excl, end_excl = end_excl },
-  }
-end
-
----@param section? obsidian.note.SectionDetail
+---@param section? obsidian.Section
 ---@return boolean
 function H.is_section_empty(section)
-  return not section or section.heading.beg_incl == section.content.end_excl
+  return not section or beg_incl(section.heading_range) == end_excl(section.content_range)
 end
 
----@param section? obsidian.note.SectionDetail
+---@param section? obsidian.Section
 ---@return boolean
 function H.is_content_empty(section)
-  return not section or section.content.beg_incl == section.content.end_excl
+  return not section or Range.is_empty(section.content_range)
 end
 
----@alias obsidian.note.OnSectionMissingHandler fun(sections: obsidian.note.SectionDetail[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_top: string[], insert_bot: string[]
-
----@class obsidian.note.SectionDetail
----@field heading? { beg_incl: integer, end_excl: integer, level: integer, label: string }
----@field content? { beg_incl: integer, end_excl: integer }
+---@alias obsidian.note.OnSectionMissingHandler fun(sections: obsidian.Section[], opts: obsidian.note.InsertTextOpts): insert_idx: integer, insert_top: string[], insert_bot: string[]
 
 return M

--- a/tests/test_api.lua
+++ b/tests/test_api.lua
@@ -205,4 +205,25 @@ T["cursor_heading"] = function()
   eq(vim.NIL, child.lua [[return M.cursor_heading()]])
 end
 
+T["open_note"] = new_set()
+
+T["open_note"]["should blink quickfix-style ranges"] = function()
+  local result = child.lua [[
+    local path = tostring(Obsidian.dir / "blink.md")
+    vim.fn.writefile({ "# Heading", "body" }, path)
+    local bufnr = M.open_note({ filename = path, lnum = 1, col = 0, end_lnum = 2, end_col = 5 })
+    local blinked = false
+    for name, ns in pairs(vim.api.nvim_get_namespaces()) do
+      if name:match("^obsidian_blink_") and #vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, {}) > 0 then
+        blinked = true
+      end
+    end
+    return { vim.api.nvim_buf_get_name(bufnr), vim.api.nvim_win_get_cursor(0), blinked }
+  ]]
+
+  eq(tostring(child.Obsidian.dir / "blink.md"), result[1])
+  eq({ 1, 0 }, result[2])
+  eq(true, result[3])
+end
+
 return T

--- a/tests/test_bookmarks.lua
+++ b/tests/test_bookmarks.lua
@@ -107,4 +107,37 @@ _G.res = M.parse(src)
   eq(result[8].url, "https://chatgpt.com/")
 end
 
+T["parse"]["blinks anchor target range"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "# Heading\nbody\n\n# Next\n",
+  })
+
+  local blinked = child.lua [[
+vim.ui.select = function(items, _, callback)
+  callback(items[1])
+end
+
+M.pick {
+  {
+    type = "file",
+    path = "note.md",
+    subpath = "#Heading",
+    title = "Heading",
+  },
+}
+
+local bufnr = vim.api.nvim_get_current_buf()
+for name, ns in pairs(vim.api.nvim_get_namespaces()) do
+  if name:match("^obsidian_blink_") and #vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, {}) > 0 then
+    return true
+  end
+end
+return false
+]]
+
+  eq(true, blinked)
+end
+
 return T

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -167,6 +167,21 @@ id: note_with_a_bunch_of_headers
 
 ## Sub header 3 A]]
 
+--- Strip the `section` references so anchors can be compared with `eq`.
+---@param anchor obsidian.note.HeaderAnchor|?
+local function anchor_fields(anchor)
+  if anchor == nil then
+    return nil
+  end
+  return {
+    anchor = anchor.anchor,
+    line = anchor.line,
+    header = anchor.header,
+    level = anchor.level,
+    parent = anchor_fields(anchor.parent),
+  }
+end
+
 T["from_lines"]["should be able to collect anchor links"] = function()
   local note = from_str(note_with_headers, "anchors.md", {
     collect_anchor_links = true,
@@ -178,53 +193,84 @@ T["from_lines"]["should be able to collect anchor links"] = function()
     line = 5,
     header = "Header 1",
     level = 1,
-  }, note.anchor_links["#header-1"])
+  }, anchor_fields(note.anchor_links["#header-1"]))
   eq({
     anchor = "#sub-header-1-a",
     line = 7,
     header = "Sub header 1 A",
     level = 2,
-    parent = note.anchor_links["#header-1"],
-  }, note.anchor_links["#sub-header-1-a"])
+    parent = anchor_fields(note.anchor_links["#header-1"]),
+  }, anchor_fields(note.anchor_links["#sub-header-1-a"]))
   eq({
     anchor = "#header-2",
     line = 9,
     header = "Header 2",
     level = 1,
-  }, note.anchor_links["#header-2"])
+  }, anchor_fields(note.anchor_links["#header-2"]))
   eq({
     anchor = "#sub-header-2-a",
     line = 11,
     header = "Sub header 2 A",
     level = 2,
-    parent = note.anchor_links["#header-2"],
-  }, note.anchor_links["#sub-header-2-a"])
+    parent = anchor_fields(note.anchor_links["#header-2"]),
+  }, anchor_fields(note.anchor_links["#sub-header-2-a"]))
   eq({
     anchor = "#sub-header-3-a",
     line = 13,
     header = "Sub header 3 A",
     level = 2,
-    parent = note.anchor_links["#header-2"],
-  }, note.anchor_links["#sub-header-3-a"])
+    parent = anchor_fields(note.anchor_links["#header-2"]),
+  }, anchor_fields(note.anchor_links["#sub-header-3-a"]))
   eq({
     anchor = "#header-2#sub-header-3-a",
     line = 13,
     header = "Sub header 3 A",
     level = 2,
-    parent = note.anchor_links["#header-2"],
-  }, note.anchor_links["#header-2#sub-header-3-a"])
+    parent = anchor_fields(note.anchor_links["#header-2"]),
+  }, anchor_fields(note.anchor_links["#header-2#sub-header-3-a"]))
   eq({
     anchor = "#header-1",
     line = 5,
     header = "Header 1",
     level = 1,
-  }, note:resolve_anchor_link "#header-1")
+  }, anchor_fields(note:resolve_anchor_link "#header-1"))
   eq({
     anchor = "#header-1",
     line = 5,
     header = "Header 1",
     level = 1,
-  }, note:resolve_anchor_link "#Header 1")
+  }, anchor_fields(note:resolve_anchor_link "#Header 1"))
+end
+
+T["from_lines"]["should collect sections with full ranges for anchors"] = function()
+  local note = from_str(note_with_headers, "anchors.md", {
+    collect_anchor_links = true,
+  })
+  not_eq(nil, note.sections)
+  -- preamble + 5 headers
+  eq(6, #note.sections)
+  eq(nil, note.sections[1].header)
+
+  local h1 = note.anchor_links["#header-1"].section
+  -- "# Header 1" (line 5) through "## Sub header 1 A" content (line 7), i.e. until "# Header 2".
+  eq({ start_row = 4, start_col = 0, end_row = 7, end_col = 0 }, h1.range)
+  eq({ start_row = 4, start_col = 0, end_row = 5, end_col = 0 }, h1.heading_range)
+
+  local h2 = note.anchor_links["#header-2"].section
+  -- "# Header 2" (line 9) through the last sub header (line 13).
+  eq({ start_row = 8, start_col = 0, end_row = 13, end_col = 0 }, h2.range)
+  eq(h2, note.anchor_links["#sub-header-2-a"].section.parent)
+end
+
+T["from_lines"]["should resolve anchor locations to full section ranges"] = function()
+  local note = from_str(note_with_headers, "anchors.md", {
+    collect_anchor_links = true,
+  })
+  local location = note:_location { anchor = "#header-2" }
+  eq({
+    start = { line = 8, character = 0 },
+    ["end"] = { line = 13, character = 0 },
+  }, location.range)
 end
 
 local note_with_blocks = [[---
@@ -242,12 +288,23 @@ T["from_lines"]["should be able to collect blocks"] = function()
     id = "^1234",
     line = 5,
     block = "This is a block ^1234",
-  }, note.blocks["^1234"])
+  }, {
+    id = note.blocks["^1234"].id,
+    line = note.blocks["^1234"].line,
+    block = note.blocks["^1234"].block,
+  })
   eq({
     id = "^hello-world",
     line = 7,
     block = "And another block ^hello-world",
-  }, note.blocks["^hello-world"])
+  }, {
+    id = note.blocks["^hello-world"].id,
+    line = note.blocks["^hello-world"].line,
+    block = note.blocks["^hello-world"].block,
+  })
+  -- Each block carries the paragraph it lives in as a section.
+  eq({ start_row = 4, start_col = 0, end_row = 5, end_col = 0 }, note.blocks["^1234"].section.range)
+  eq({ start_row = 6, start_col = 0, end_row = 7, end_col = 0 }, note.blocks["^hello-world"].section.range)
 end
 
 T["from_lines"]["should work from a file w/o frontmatter"] = function()

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -273,6 +273,23 @@ T["from_lines"]["should resolve anchor locations to full section ranges"] = func
   }, location.range)
 end
 
+T["from_lines"]["should collect setext header anchors"] = function()
+  local note = from_str("Title\n=====\n\nBody", "setext.md", {
+    collect_anchor_links = true,
+  })
+
+  eq({
+    anchor = "#title",
+    line = 1,
+    header = "Title",
+    level = 1,
+  }, anchor_fields(note.anchor_links["#title"]))
+  eq({
+    start = { line = 0, character = 0 },
+    ["end"] = { line = 4, character = 0 },
+  }, note:_location({ anchor = "#title" }).range)
+end
+
 local note_with_blocks = [[---
 id: note_with_a_bunch_of_blocks
 ---
@@ -305,6 +322,17 @@ T["from_lines"]["should be able to collect blocks"] = function()
   -- Each block carries the paragraph it lives in as a section.
   eq({ start_row = 4, start_col = 0, end_row = 5, end_col = 0 }, note.blocks["^1234"].section.range)
   eq({ start_row = 6, start_col = 0, end_row = 7, end_col = 0 }, note.blocks["^hello-world"].section.range)
+end
+
+T["from_lines"]["should map block ids to the referenced paragraph"] = function()
+  local note = from_str("text ^123", "block-inline.md", { collect_blocks = true })
+  eq({ start_row = 0, start_col = 0, end_row = 1, end_col = 0 }, note.blocks["^123"].section.range)
+
+  note = from_str("text\ntext2\n^123", "block-multiline.md", { collect_blocks = true })
+  eq({ start_row = 0, start_col = 0, end_row = 3, end_col = 0 }, note.blocks["^123"].section.range)
+
+  note = from_str("text\ntext2\n\n^123", "block-standalone.md", { collect_blocks = true })
+  eq({ start_row = 0, start_col = 0, end_row = 2, end_col = 0 }, note.blocks["^123"].section.range)
 end
 
 T["from_lines"]["should work from a file w/o frontmatter"] = function()

--- a/tests/test_section.lua
+++ b/tests/test_section.lua
@@ -1,0 +1,82 @@
+local Section = require "obsidian.section"
+
+local new_set, eq = MiniTest.new_set, MiniTest.expect.equality
+
+local T = new_set()
+
+T["setext headings get anchors and ranges"] = function()
+  local sections = Section.parse {
+    "Title",
+    "====",
+    "",
+    "Body",
+    "",
+    "Subtitle",
+    "---",
+    "More",
+  }
+
+  eq(3, #sections)
+  eq("Title", sections[2].header)
+  eq(1, sections[2].level)
+  eq("#title", sections[2].anchor)
+  eq({ start_row = 0, start_col = 0, end_row = 2, end_col = 0 }, sections[2].heading_range)
+  eq({ start_row = 3, start_col = 0, end_row = 4, end_col = 0 }, sections[2].content_range)
+
+  eq("Subtitle", sections[3].header)
+  eq(2, sections[3].level)
+  eq("#subtitle", sections[3].anchor)
+  eq(sections[2], sections[3].parent)
+  eq({ start_row = 0, start_col = 0, end_row = 8, end_col = 0 }, sections[2].range)
+end
+
+T["blocks attach to heading and paragraph sections"] = function()
+  local _, blocks = Section.parse({
+    "# Heading ^head",
+    "",
+    "Text ^para",
+    "continued",
+    "^standalone",
+  }, { collect_blocks = true })
+
+  eq("Heading ^head", blocks["^head"].section.header)
+  eq({ start_row = 0, start_col = 0, end_row = 1, end_col = 0 }, blocks["^head"].section.heading_range)
+  eq({ start_row = 2, start_col = 0, end_row = 5, end_col = 0 }, blocks["^para"].section.range)
+  eq(blocks["^para"].section, blocks["^standalone"].section)
+end
+
+T["full ranges include nested descendants only"] = function()
+  local sections = Section.parse {
+    "# H1",
+    "h1 text",
+    "## H2",
+    "h2 text",
+    "### H3",
+    "h3 text",
+    "## H2b",
+    "h2b text",
+    "# H1b",
+    "h1b text",
+  }
+
+  eq({ start_row = 0, start_col = 0, end_row = 8, end_col = 0 }, sections[2].range)
+  eq({ start_row = 2, start_col = 0, end_row = 6, end_col = 0 }, sections[3].range)
+  eq({ start_row = 4, start_col = 0, end_row = 6, end_col = 0 }, sections[4].range)
+  eq({ start_row = 6, start_col = 0, end_row = 8, end_col = 0 }, sections[5].range)
+  eq({ start_row = 8, start_col = 0, end_row = 10, end_col = 0 }, sections[6].range)
+end
+
+T["content ranges trim trailing blanks"] = function()
+  local sections = Section.parse {
+    "# H",
+    "",
+    "body",
+    "",
+    "",
+    "## Next",
+  }
+
+  eq({ start_row = 2, start_col = 0, end_row = 3, end_col = 0 }, sections[2].content_range)
+end
+
+return T


### PR DESCRIPTION
  Use a shared Section parser and Range type for headings, blocks,
   text insertion, LSP symbols, bookmarks, and navigation highlights.
   This removes duplicate section-splitting logic and gives anchor/block
   targets consistent full-section ranges.