### PR TITLE
Fix tag search text contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML will not force quoted number strings into number.
 - Warns if workspace folder does not exist.
 - Picker will properly require available picker in runtime path, and fallback to native.
+- The `tags` command telescope picker searches through line contents instead of file name
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML will not force quoted number strings into number.
 - Warns if workspace folder does not exist.
 - Picker will properly require available picker in runtime path, and fallback to native.
-- The `tags` command telescope picker searches through line contents instead of file name
+- Bring back the ordinal fallback to the display and filename in the telescope picker.
 
 ### Changed
 

--- a/lua/obsidian/commands/tags.lua
+++ b/lua/obsidian/commands/tags.lua
@@ -32,6 +32,7 @@ local function gather_tag_picker_list(tag_locations, tags)
           filename = tostring(tag_loc.path),
           lnum = tag_loc.line,
           col = tag_loc.tag_start,
+          text = tag_loc.text,
         }
         break
       end

--- a/lua/obsidian/commands/tags.lua
+++ b/lua/obsidian/commands/tags.lua
@@ -32,7 +32,6 @@ local function gather_tag_picker_list(tag_locations, tags)
           filename = tostring(tag_loc.path),
           lnum = tag_loc.line,
           col = tag_loc.tag_start,
-          text = tag_loc.text,
         }
         break
       end

--- a/lua/obsidian/picker/_telescope.lua
+++ b/lua/obsidian/picker/_telescope.lua
@@ -248,10 +248,20 @@ M.pick = function(values, opts)
           if type(v) == "string" then
             return make_entry_from_string(v)
           else
+            local ordinal = v.ordinal
+            if ordinal == nil then
+              ordinal = ""
+              if type(v.display) == "string" then
+                ordinal = ordinal .. v.display
+              end
+              if v.filename ~= nil then
+                ordinal = ordinal .. " " .. v.filename
+              end
+            end
             return {
               value = v.user_data,
               display = displayer,
-              ordinal = v.text or v.filename,
+              ordinal = ordinal,
               filename = v.filename,
               lnum = v.lnum,
               col = v.col,


### PR DESCRIPTION
# Fall back to display and filename in the telescope picker

Fixes https://github.com/obsidian-nvim/obsidian.nvim/issues/877

Bring back the ordinal fallback in the telescope picker. This falls back to v.display and v.filename as it used to prior to https://github.com/obsidian-nvim/obsidian.nvim/commit/828b74d

I've verified in my obsidian notes that the tag search now checks both the file name and the line contents, resolving what we observe in https://github.com/obsidian-nvim/obsidian.nvim/issues/877

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] ~The changes are documented in the `README.md` file~
- [x] The code complies with `make chores` (for style, lint, types, and tests)
