### PR TITLE
fix(note): honor disabled frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `frontmatter.enabled = false` now prevents `:Obsidian new` from writing the default frontmatter template. Closes #862.
 - Proper trigger characters for neovim native LSP completion to work.
 - After `actions.move_note`, buffers can be properly saved without warning.
 - Sync will properly log cli errors.

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -25,6 +25,13 @@ local SKIP_UPDATING_FRONTMATTER = { "README.md", "CONTRIBUTING.md", "CHANGELOG.m
 
 local DEFAULT_MAX_LINES = 500
 
+local function is_default_note_template(template)
+  local default_template = require("obsidian.config.default").note.template
+  return template ~= nil
+    and default_template ~= nil
+    and Path.new(template):resolve() == Path.new(default_template):resolve()
+end
+
 ---@param section obsidian.Section
 ---@param parent obsidian.note.HeaderAnchor|?
 ---@param anchor string|?
@@ -904,6 +911,11 @@ Note.write = function(self, opts)
 
   -- Fall back to the template carried by the note (set at Note.create).
   local template = opts.template ~= nil and opts.template or self.template
+  local should_save_frontmatter = self:should_save_frontmatter()
+
+  if not should_save_frontmatter and is_default_note_template(template) then
+    template = nil
+  end
 
   ---@type string
   local verb
@@ -923,13 +935,13 @@ Note.write = function(self, opts)
   end
 
   local frontmatter = nil
-  if Obsidian.opts.frontmatter.func ~= nil then
+  if should_save_frontmatter and Obsidian.opts.frontmatter.func ~= nil then
     frontmatter = Obsidian.opts.frontmatter.func(self)
   end
 
   self:save {
     path = path,
-    insert_frontmatter = self:should_save_frontmatter(),
+    insert_frontmatter = should_save_frontmatter,
     frontmatter = frontmatter,
     update_content = opts.update_content,
     check_buffers = opts.check_buffers,

--- a/tests/test_note.lua
+++ b/tests/test_note.lua
@@ -1,5 +1,6 @@
 local M = require "obsidian.note"
-local T = dofile("tests/helpers.lua").temp_vault
+local h = dofile "tests/helpers.lua"
+local T = h.temp_vault
 local api = require "obsidian.api"
 local Path = require "obsidian.path"
 local util = require "obsidian.util"
@@ -130,6 +131,48 @@ T["save"]["should not error on :checktime when save path contains regex-special 
 
   vim.cmd "bwipeout!"
   vim.fn.delete(path)
+end
+
+T["write"] = new_set()
+
+T["write"]["should not add default frontmatter template when frontmatter is disabled"] = function()
+  Obsidian.opts.frontmatter.enabled = false
+
+  local note = M.create { id = "Foo", template = Obsidian.opts.note.template }
+  note:write()
+
+  local saved_note = M.from_file(note.path)
+  eq(false, saved_note.has_frontmatter)
+end
+
+T["write"]["should not call frontmatter function when frontmatter is disabled"] = function()
+  local calls = 0
+  Obsidian.opts.frontmatter.enabled = false
+  Obsidian.opts.frontmatter.func = function()
+    calls = calls + 1
+    return { id = "SHOULD_NOT_BE_WRITTEN" }
+  end
+
+  local note = M.create { id = "Foo" }
+  note:write()
+
+  eq(0, calls)
+  local saved_note = M.from_file(note.path)
+  eq(false, saved_note.has_frontmatter)
+end
+
+T["write"]["should preserve explicit template frontmatter when frontmatter is disabled"] = function()
+  Obsidian.opts.frontmatter.enabled = false
+  h.write("---\ncustom: true\n---\nBody", Obsidian.dir / "templates" / "custom.md")
+
+  local note = M.create { id = "Foo", template = "custom.md" }
+  note:write()
+
+  local lines = h.read(note.path)
+  eq("---", lines[1])
+  eq("custom: true", lines[2])
+  eq("---", lines[3])
+  eq("Body", lines[4])
 end
 
 T["add_alias"] = new_set()


### PR DESCRIPTION
Closes #862
- `frontmatter.enabled = false` will prevent default note template with frontmatter.
