### PR TITLE
fix(picker): align snacks insert link position with other pickers

### DIFF
--- a/lua/obsidian/picker/_snacks.lua
+++ b/lua/obsidian/picker/_snacks.lua
@@ -32,7 +32,13 @@ local function query_mappings(mapping, live)
     opts.actions[name] = function(picker)
       local query = live and picker.input.filter.search or picker.input.filter.pattern
       picker:close()
+      local saved_win = Picker.state.calling_win
+      local saved_cursor = Picker.state.calling_cursor
       vim.schedule(function()
+        if saved_win and vim.api.nvim_win_is_valid(saved_win) then
+          vim.api.nvim_set_current_win(saved_win)
+          vim.api.nvim_win_set_cursor(saved_win, saved_cursor)
+        end
         v.callback(query)
       end)
     end
@@ -70,6 +76,8 @@ local function notes_mappings(mapping)
       opts.win.input.keys[k] = { name, mode = { "n", "i" }, desc = v.desc }
       opts.actions[name] = function(picker, item)
         picker:close()
+        local saved_win = Picker.state.calling_win
+        local saved_cursor = Picker.state.calling_cursor
         if v.allow_multiple then
           local selected = picker:selected { fallback = true }
           ---@type obsidian.PickerEntry[]
@@ -81,6 +89,10 @@ local function notes_mappings(mapping)
             })
           end
           vim.schedule(function()
+            if saved_win and vim.api.nvim_win_is_valid(saved_win) then
+              vim.api.nvim_set_current_win(saved_win)
+              vim.api.nvim_win_set_cursor(saved_win, saved_cursor)
+            end
             ---@diagnostic disable-next-line: param-type-mismatch
             v.callback(unpack(entries))
           end)
@@ -91,6 +103,10 @@ local function notes_mappings(mapping)
             user_data = item.user_data or item.value or item.text,
           }
           vim.schedule(function()
+            if saved_win and vim.api.nvim_win_is_valid(saved_win) then
+              vim.api.nvim_set_current_win(saved_win)
+              vim.api.nvim_win_set_cursor(saved_win, saved_cursor)
+            end
             v.callback(entry)
           end)
         end
@@ -106,6 +122,8 @@ local M = {}
 ---@param opts obsidian.PickerFindOpts|? Options.
 M.find_files = function(opts)
   opts = opts or {}
+  Picker.state.calling_win = vim.api.nvim_get_current_win()
+  Picker.state.calling_cursor = vim.api.nvim_win_get_cursor(0)
   local callback = opts.callback or api.open_note
 
   ---@type obsidian.Path
@@ -141,6 +159,8 @@ end
 ---@param opts obsidian.PickerGrepOpts|? Options.
 M.grep = function(opts)
   opts = opts or {}
+  Picker.state.calling_win = vim.api.nvim_get_current_win()
+  Picker.state.calling_cursor = vim.api.nvim_win_get_cursor(0)
 
   ---@type obsidian.Path
   local dir = opts.dir and Path.new(opts.dir) or Obsidian.dir
@@ -177,6 +197,8 @@ end
 ---@param opts obsidian.PickerPickOpts|? Options.
 M.pick = function(values, opts)
   Picker.state.calling_bufnr = vim.api.nvim_get_current_buf()
+  Picker.state.calling_win = vim.api.nvim_get_current_win()
+  Picker.state.calling_cursor = vim.api.nvim_win_get_cursor(0)
 
   opts = opts or {}
   local callback = opts.callback or api.open_note

--- a/lua/obsidian/picker/mappings.lua
+++ b/lua/obsidian/picker/mappings.lua
@@ -8,7 +8,7 @@ local api = require "obsidian.api"
 M.insert_link = function(entry)
   local note = Note.from_file(entry.filename)
   local link = note:format_link()
-  vim.api.nvim_put({ link }, "", false, true)
+  vim.api.nvim_put({ link }, "", true, true)
   require("obsidian.ui").update(0)
 end
 
@@ -56,7 +56,7 @@ M.insert_tag = function(entry)
     log.err "Tag does not exist"
     return
   end
-  vim.api.nvim_put({ "#" .. tag }, "", false, true)
+  vim.api.nvim_put({ "#" .. tag }, "", true, true)
 end
 
 M.new_note = function(query)


### PR DESCRIPTION
## Problem

When using `snacks.picker`, pressing `<C-l>` (insert link) or the tag
insert mapping pastes the link/tag **2 characters to the left** of where
telescope, fzf-lua and mini.pick would put it.

Given cursor on the `s` of `some` in `This is some text`:

| Picker | Result |
|---|---|
| telescope / fzf-lua / mini.pick | `This is s[[Note]]ome text` ✅ |
| snacks (before fix) | `This is[[Note]] some text` ❌ |

## Root cause

Two issues compound to produce the 2-character offset:

**1. Wrong `nvim_put` direction (`mappings.lua`)**
`insert_link` and `insert_tag` called `nvim_put` with `after=false`
(P-style: insert *before* cursor). The correct value is `after=true`
(p-style: insert *after* the character at cursor).

**2. snacks does not preserve cursor position across `vim.schedule`
(`_snacks.lua`)**
Unlike telescope and fzf-lua, which fire callbacks **synchronously**
inside their action handlers (so the picker framework controls window
focus during the call), snacks defers all callbacks via `vim.schedule`.
By the time the callback runs, snacks has already restored the calling
window — but shifts the cursor one position to the left in the process.

Neither `calling_win` nor `calling_cursor` were being saved before the
picker opened, so there was nothing to restore from.

## Fix

- Save `calling_win` and `calling_cursor` at the top of `M.find_files`,
  `M.grep`, and `M.pick` (all three snacks entry points).
- In every `vim.schedule` callback inside `notes_mappings` and
  `query_mappings`, explicitly restore the window and cursor before
  invoking the user callback.
- Change `after=false` → `after=true` in `nvim_put` for both
  `insert_link` and `insert_tag`.