### PR TITLE
feat: add markdown checkbox auto-continuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Checkbox auto-continuation: pressing `<CR>` in Insert mode at the end of a checkbox line or `o` in Normal mode now automatically creates a new unchecked checkbox `- [ ]` on the next line. Empty checkbox lines are cleared instead (standard markdown list behavior). Mappings are registered automatically when `opts.checkbox.enabled` is true.
+
 - LSP folding support, see `:Obsidian help Folding`.
 - Sync supports creating remote with end to end encryption password.
 - Navigating to an anchor or block link now briefly highlights the full referenced section, like the Obsidian app. The highlight group is `ObsidianBlink` (defaults to `Visual`) and the duration is controlled by `vim.g.obsidian_blink_duration` (ms, defaults to 500).

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ The original project has not been actively maintained for quite a while and with
   - If cursor is on a checkbox, toggle the checkbox, see [Checkbox.create_new](https://github.com/obsidian-nvim/obsidian.nvim/wiki/Checkbox#create-new).
   - If cursor is on a heading, cycle the fold of that heading, see [Folding](https://github.com/obsidian-nvim/obsidian.nvim/wiki/Folding) to set this up.
 - `nav_link`, bind to `[o` and `]o` will navigate cursor to next valid link in the buffer.
+- Checkbox auto-continuation:
+  - `<CR>` in Insert mode at the end of a checkbox line (e.g., `- [x]`) creates a new unchecked checkbox `- [ ]` on the next line.
+  - `o` in Normal mode on a checkbox line creates a new unchecked checkbox below.
+  - Empty checkbox lines (no text after the checkbox) are cleared to a plain list item instead, mirroring standard markdown list behavior.
+  - Disabled when `opts.checkbox.enabled` is `false`.
 
 For other available actions and remapping default ones, see [Keymaps](https://github.com/obsidian-nvim/obsidian.nvim/wiki/Keymaps)
 

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -300,6 +300,104 @@ M.set_checkbox = function(state)
   vim.api.nvim_buf_set_lines(0, line_num - 1, line_num, true, { cur_line })
 end
 
+--- Get checkbox continuation info for the current line.
+---
+---@param line string The current line content.
+---@param col number|nil Optional column (1-indexed) for end-of-line check. If nil, skips the check.
+---@return { clear: boolean, continuation: string|nil }|nil
+M._get_checkbox_continuation = function(line, col)
+  local prefix, rest = parse_list_prefix(line)
+  if not prefix or not rest then
+    return nil
+  end
+
+  local state, _, body = parse_checkbox_rest(rest)
+  if not state then
+    return nil
+  end
+
+  if col then
+    if col <= #line then
+      return nil
+    end
+  end
+
+  local indent = line:match "^(%s*)" or ""
+
+  if body == "" then
+    return { clear = true, continuation = nil }
+  end
+
+  return { clear = false, continuation = indent .. "- [ ] " }
+end
+
+--- Handle checkbox auto-continuation when creating a new line.
+---
+--- Triggered by pressing <CR> in Insert mode at end of line, or `o` in Normal mode.
+--- When the current line has a markdown checkbox (like `- [ ]`, `- [x]`, etc.),
+--- the new line will automatically prepend an unchecked checkbox `- [ ]`.
+--- If the current line contains only a checkbox with no text after it, the checkbox
+--- is cleared instead (standard markdown list behavior).
+---
+---@param mode "i"|"n" The mode in which the continuation was triggered.
+M.checkbox_continue = function(mode)
+  if not Obsidian.opts.checkbox.enabled then
+    if mode == "i" then
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, true, true), "n", true)
+    else
+      vim.cmd "normal! o"
+    end
+    return
+  end
+
+  if no_checkbox() then
+    if mode == "i" then
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, true, true), "n", true)
+    else
+      vim.cmd "normal! o"
+    end
+    return
+  end
+
+  local line = vim.api.nvim_get_current_line()
+
+  local col = nil
+  if mode == "i" then
+    col = vim.api.nvim_win_get_cursor(0)[2] + 1
+  end
+
+  local info = M._get_checkbox_continuation(line, col)
+  if not info then
+    if mode == "i" then
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, true, true), "n", true)
+    else
+      vim.cmd "normal! o"
+    end
+    return
+  end
+
+  if info.clear then
+    -- Empty checkbox: clear it, then normal line break.
+    local prefix, rest = parse_list_prefix(line)
+    vim.api.nvim_set_current_line(prefix .. rest:gsub("^%[.%]%s*", ""))
+  end
+
+  if mode == "i" then
+    if info.clear then
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, true, true), "n", true)
+    else
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>" .. info.continuation, true, true, true), "n", true)
+    end
+  else
+    -- Normal mode: use 'o' to open a new line.
+    vim.cmd "normal! o"
+    if not info.clear then
+      vim.api.nvim_set_current_line(info.continuation)
+      vim.api.nvim_win_set_cursor(0, { vim.api.nvim_win_get_cursor(0)[1], #info.continuation })
+    end
+  end
+end
+
 --- Calculate the byte position after a UTF-8 character at the given byte position.
 --- This is needed because visual selection cecol points to the start byte of the last
 --- selected character, but we need the position after the full character.

--- a/lua/obsidian/autocmds.lua
+++ b/lua/obsidian/autocmds.lua
@@ -63,6 +63,18 @@ local function bufenter_callback(ev)
     vim.keymap.set("n", "[o", function()
       api.nav_link "prev"
     end, { buffer = true, desc = "Obsidian Previous Link" })
+
+    -- Checkbox auto-continuation mappings.
+    if Obsidian.opts.checkbox.enabled then
+      local actions = require "obsidian.actions"
+      vim.keymap.set("i", "<CR>", function()
+        actions.checkbox_continue "i"
+      end, { buffer = true, desc = "Obsidian Checkbox Continue" })
+
+      vim.keymap.set("n", "o", function()
+        actions.checkbox_continue "n"
+      end, { buffer = true, desc = "Obsidian Checkbox Continue" })
+    end
   end
 
   require("obsidian.lsp").start(ev.buf)

--- a/tests/test_api.lua
+++ b/tests/test_api.lua
@@ -226,4 +226,71 @@ T["open_note"]["should blink quickfix-style ranges"] = function()
   eq(true, result[3])
 end
 
+T["checkbox_continue"] = new_set()
+
+T["checkbox_continue"]["should create continuation for checkbox with body (normal mode)"] = function()
+  child.api.nvim_buf_set_lines(0, 0, -1, false, { "- [x] foo" })
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+  child.lua [[require("obsidian.actions").checkbox_continue("n")]]
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  eq(2, #lines)
+  eq("- [ ] ", lines[2])
+end
+
+T["checkbox_continue"]["should preserve indentation in continuation (normal mode)"] = function()
+  child.api.nvim_buf_set_lines(0, 0, -1, false, { "    - [x] nested" })
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+  child.lua [[require("obsidian.actions").checkbox_continue("n")]]
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  eq(2, #lines)
+  eq("    - [ ] ", lines[2])
+end
+
+T["checkbox_continue"]["should clear empty checkbox (normal mode)"] = function()
+  child.api.nvim_buf_set_lines(0, 0, -1, false, { "- [ ]" })
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+  child.lua [[require("obsidian.actions").checkbox_continue("n")]]
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  eq(2, #lines)
+  eq("- ", lines[1])
+  eq("", lines[2])
+end
+
+T["checkbox_continue"]["should clear empty checkbox with trailing spaces (normal mode)"] = function()
+  child.api.nvim_buf_set_lines(0, 0, -1, false, { "- [x] " })
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+  child.lua [[require("obsidian.actions").checkbox_continue("n")]]
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  eq(2, #lines)
+  eq("- ", lines[1])
+  eq("", lines[2])
+end
+
+T["checkbox_continue"]["should not continue for non-checkbox list items (normal mode)"] = function()
+  child.api.nvim_buf_set_lines(0, 0, -1, false, { "- plain item" })
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+  child.lua [[require("obsidian.actions").checkbox_continue("n")]]
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  eq(2, #lines)
+  eq("", lines[2])
+end
+
+T["checkbox_continue"]["should continue for star checkbox (normal mode)"] = function()
+  child.api.nvim_buf_set_lines(0, 0, -1, false, { "* [!] task" })
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+  child.lua [[require("obsidian.actions").checkbox_continue("n")]]
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  eq(2, #lines)
+  eq("- [ ] ", lines[2])
+end
+
+T["checkbox_continue"]["should continue for numbered list checkbox (normal mode)"] = function()
+  child.api.nvim_buf_set_lines(0, 0, -1, false, { "1. [~] task" })
+  child.api.nvim_win_set_cursor(0, { 1, 0 })
+  child.lua [[require("obsidian.actions").checkbox_continue("n")]]
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  eq(2, #lines)
+  eq("- [ ] ", lines[2])
+end
+
 return T


### PR DESCRIPTION
Adds automatic checkbox continuation when creating new lines in Markdown buffers. When the cursor is on a line with a checkbox (e.g., `- [x]`, `- [>]`, `- [ ]`, etc.), pressing `<CR>` in Insert mode (at end of line) or `o` in Normal mode automatically prepends a new unchecked checkbox `- [ ]` on the next line, matching the original line's indentation. Empty checkbox lines (no text after the checkbox) are cleared to a plain list item instead, following standard Markdown list behavior.

### Changes

| File | Change |
|---|---|
| `lua/obsidian/actions.lua` | Added `_get_checkbox_continuation(line, col)` pure logic function and `checkbox_continue(mode)` interactive handler |
| `lua/obsidian/autocmds.lua` | Registered buffer-local `<CR>` (Insert mode) and `o` (Normal mode) mappings, gated behind `opts.checkbox.enabled` and `vim.g.obsidian_default_keymap` |
| `tests/test_api.lua` | Added 7 integration tests for normal-mode continuation, indentation preservation, empty checkbox clearing, non-checkbox fallthrough, and varied bullet types |
| `CHANGELOG.md` | Added entry under "Unreleased → Added" |
| `README.md` | Documented the new keybindings in the Keymaps section |

### Behavior details

- **Continuation:** On `- [x] foo`, creates `- [ ] ` on new line with matching indent
- **Empty checkbox:** On `- [ ]` (no body text), clears to `- ` instead of creating continuation
- **Non-checkbox:** On `- plain item`, falls through to normal `<CR>` / `o` behavior
- **Disabled:** No mapping registered when `opts.checkbox.enabled = false`
- **Gate:** Respects `vim.g.obsidian_default_keymap = false`

### Checklist

- [x] Code changes
- [x] Tests (7 new tests, 0 failures in full suite)
- [x] Inline documentation (LuaDoc annotations)
- [x] CHANGELOG.md entry
- [x] README.md updated
- [x] `make style` passes
- [x] `make test` passes (674 tests, 0 failures)
