### PR TITLE
fix(lsp): sort existing note matches before create-new-note items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Warns if workspace folder does not exist.
 - Picker will properly require available picker in runtime path, and fallback to native.
 - Bring back the ordinal fallback to the display and filename in the telescope picker.
+- `[[` completion no longer lists the "(create)" item above an existing note match; existing-note results now always sort before create-new-note items, regardless of which completion source resolves first.
 
 ### Changed
 

--- a/lua/obsidian/lsp/handlers/completion.lua
+++ b/lua/obsidian/lsp/handlers/completion.lua
@@ -54,6 +54,26 @@ local function merge_results(a, b)
   }
 end
 
+--- Stable-partition items so "create new note" items (produced by the new-note source,
+--- identified by their obsidian.write_note command) always sort after every other item,
+--- regardless of which source resolved first. Relative order within each group is preserved.
+---@param items lsp.CompletionItem[]
+---@return lsp.CompletionItem[]
+local function partition_create_last(items)
+  local rest, create = {}, {}
+  for _, item in ipairs(items) do
+    if item.command and item.command.command == "obsidian.write_note" then
+      create[#create + 1] = item
+    else
+      rest[#rest + 1] = item
+    end
+  end
+  for _, item in ipairs(create) do
+    rest[#rest + 1] = item
+  end
+  return rest
+end
+
 ---@param params lsp.CompletionParams
 ---@param callback fun(err: any, result: lsp.CompletionList)
 return function(params, callback, _)
@@ -76,6 +96,7 @@ return function(params, callback, _)
     end
     pending = pending - 1
     if pending == 0 then
+      merged.items = partition_create_last(merged.items)
       callback(nil, merged)
     end
   end

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -444,6 +444,39 @@ tags:
   eq(true, found)
 end
 
+T["completion"]["existing note match sorts before create item for the same title"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[Title",
+    ["Title.md"] = [==[
+---
+id: Title
+aliases: []
+tags: []
+---
+Existing note content
+]==],
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 7 })
+
+  local result = run_completion(0, 7)
+  eq("table", type(result))
+
+  local existing_idx, create_idx
+  for i, item in ipairs(result.items or {}) do
+    if item.command and item.command.command == "obsidian.write_note" then
+      create_idx = i
+    elseif item.label == "[[Title]]" then
+      existing_idx = i
+    end
+  end
+
+  assert(existing_idx, "no existing-note item found")
+  assert(create_idx, "no create item found")
+  assert(existing_idx < create_idx, "existing note item should sort before create item")
+end
+
 T["completion"]["create_new emits write_note command that writes file"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["test.md"] = "[[brandnewnote",


### PR DESCRIPTION
## Bug

Typing `[[Title` when a note titled "Title" already exists produced:

```
[[Title]] (create)
[[Title]]
```

instead of:

```
[[Title]]
[[Title]] (create)
```

Users often accidentally select "(create)" and create a duplicate note instead of linking to the existing one.

## Root cause

`lua/obsidian/lsp/handlers/completion.lua`'s `merge_results` appended items from each completion source (refs, tags, footnotes, new-note) in whatever order each source's async callback happened to fire, with no sorting. The "create new note" source is synchronous, while the "existing note match" source shells out to ripgrep and resolves at least one tick later — so the create item consistently landed first. Both sources also produce identical `filterText`/`sortText` for the same label, so completion clients had no signal to reorder them.

## Fix

Stable-partition the fully merged item list once, right before the final callback fires, so any item produced by the new-note source (identified by its `obsidian.write_note` command) always sorts after every other item — regardless of which source resolved first. This is a server-side, client-agnostic fix; no `sortText`/`filterText` changes were needed, and no new config option was added (this is a straightforward correctness fix, not a new opt-in behavior).

`footnotes.lua`'s own `(create)` item is untouched, since it never sets the `obsidian.write_note` command and has its own already-correct ordering.

## Testing

- Added a regression test asserting the existing-note item's index precedes the create item's index for the same title.
- Full `MiniTest` suite passes (0 fails).