### PR TITLE
fix: switch workspace on note enter

### DIFF
--- a/lua/obsidian/autocmds.lua
+++ b/lua/obsidian/autocmds.lua
@@ -34,6 +34,10 @@ local function bufenter_callback(ev)
     return
   end
 
+  if workspace ~= Obsidian.workspace then
+    require("obsidian.workspace").set(workspace)
+  end
+
   -- Check if this file should be ignored based on file.ignore_filters.
   if ignore.is_ignored(ev.file) then
     return

--- a/tests/test_workspace.lua
+++ b/tests/test_workspace.lua
@@ -87,4 +87,43 @@ T["find"]["find and resolve workspace based on dirs"] = function()
   eq(wss[1], workspace.find(subdir, wss))
 end
 
+T["autocmds"] = new_set()
+
+T["autocmds"]["should switch current workspace when entering a note from another workspace"] = function()
+  local vault_a = Path.temp { suffix = "-obsidian-a" }
+  local vault_b = Path.temp { suffix = "-obsidian-b" }
+  vault_a:mkdir()
+  vault_b:mkdir()
+  local vault_a_config = vault_a / ".obsidian"
+  local vault_b_config = vault_b / ".obsidian"
+  vault_a_config:mkdir()
+  vault_b_config:mkdir()
+
+  local note = vault_b / "note.md"
+  vim.fn.writefile({ "[[target]]" }, tostring(note))
+
+  require("obsidian").setup {
+    legacy_commands = false,
+    workspaces = {
+      {
+        name = "vault-a",
+        path = tostring(vault_a),
+      },
+      {
+        name = "vault-b",
+        path = tostring(vault_b),
+      },
+    },
+    footer = {
+      enabled = false,
+    },
+  }
+
+  eq("vault-a", Obsidian.workspace.name)
+  vim.cmd.edit(tostring(note))
+  vim.bo.filetype = "markdown"
+  vim.cmd.doautocmd "BufEnter"
+  eq("vault-b", Obsidian.workspace.name)
+end
+
 return T


### PR DESCRIPTION
What does the PR do?

When entering a Markdown note that belongs to a different configured workspace, update the active Obsidian workspace to match the buffer.

This fixes a multi-vault case where `api.find_workspace(bufname)` correctly identifies the buffer's workspace, but `Obsidian.workspace` / `Obsidian.dir` remain set to the startup/default workspace. In that state, wiki links like `[[Biography]]` can resolve against the wrong vault.

This PR also adds a regression test covering entering a note from a second workspace.

## Screenshots

Not applicable.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)

Notes:
- `make test` passes locally: 723 cases, 0 failures.
- `make style` could not be run locally because `stylua` is not installed.
- I did not update `CHANGELOG.md` or `README.md` because this is a bug fix with no user-facing configuration change.
