### PR TITLE
fix(commands/toc): error attempt to index local 'pos' (a nil value)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fzf-lua picker selections now honor multi-select consistently across files, grep, and list pickers.
 - Picker will apply `format_item` consistently.
 - Cache will be triggered by buffer writes.
+- Fixed `attempt to index local 'pos' (a nil value)` error in `:Obsidian toc` by dropping redundant `pos` passing to `vim.lsp.buf.document_symbol`.
 
 ### Changed
 

--- a/lua/obsidian/commands/toc.lua
+++ b/lua/obsidian/commands/toc.lua
@@ -3,8 +3,6 @@ local picker = require "obsidian.picker"
 local util = require "obsidian.util"
 
 return function()
-  local pos = vim.pos and vim.pos.cursor and vim.pos.cursor(0)
-  ---@cast pos -nil
   vim.lsp.buf.document_symbol {
     on_list = picker and function(t)
       picker.select(t.items, {
@@ -24,6 +22,5 @@ return function()
         end
       end)
     end,
-    pos = pos,
   }
 end


### PR DESCRIPTION
Relying on the experimental `vim.pos` API caused runtime nil indexing errors **probably** due to shifting function signature expectations around the second argument of `vim.pos.cursor` in recent Neovim updates.

Rather than patching the `vim.pos.cursor(0)` call, investigation into the Neovim [LSP documentation](https://neovim.io/doc/user/lsp/#vim.lsp.ListOpts#:~:text={pos}?) revealed that the  `pos` parameter is optional. Omitting `pos` altogether allows Neovim to  automatically fall back to the current buffer and cursor position natively.

Removing explicit position fetching eliminates reliance on unstable APIs and  keeps the command lightweight.

Fixes #918 