### PR TITLE
feat(completion): add Obsidian-style block reference search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Obsidian-style `[[^query` and `[[^^query` block completion, including previews and automatic IDs for unlabeled blocks (#505, #749).
+- Obsidian-style block completion with previews and automatic IDs for unlabeled blocks, using `[[^query`, `[[note^query`, `[[note#^query`, or `[[^^query` (#505, #749).
 - Added separate icons module to support obsidian related filetypes and usecases.
 - Fallback libuv-based fs walker that makes `ripgrep` optional in file finding.
 - Fallback interactive UI for `picker.select`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Obsidian-style `[[^query` and `[[^^query` block completion, including previews and automatic IDs for unlabeled blocks (#505, #749).
 - Added separate icons module to support obsidian related filetypes and usecases.
 - Fallback libuv-based fs walker that makes `ripgrep` optional in file finding.
 - Fallback interactive UI for `picker.select`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The original project has not been actively maintained for quite a while and with
 
 ## ⭐ Features
 
-▶️ **Completion:** Ultra-fast, asynchronous autocompletion for note references and tags via in-process LSP (triggered by typing `[[` for wiki and markdown links, `#` for tags, `[^` for footnotes). Use `[[^query` to select a block in the current note or `[[^^query` to search blocks across the vault; unlabeled blocks receive an ID when selected.
+▶️ **Completion:** Ultra-fast, asynchronous autocompletion for note references and tags via in-process LSP (triggered by typing `[[` for wiki and markdown links, `#` for tags, `[^` for footnotes). Use `[[^query` for the current note, `[[note^query` or `[[note#^query` for a named note, and `[[^^query` across the vault; unlabeled blocks receive an ID when selected.
 
 🏃 **Navigation:** Navigate throughout your vault via links, backlinks, tags and etc.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The original project has not been actively maintained for quite a while and with
 
 ## ⭐ Features
 
-▶️ **Completion:** Ultra-fast, asynchronous autocompletion for note references and tags via in-process LSP (triggered by typing `[[` for wiki and markdown links, `#` for tags, `[^` for footnotes)
+▶️ **Completion:** Ultra-fast, asynchronous autocompletion for note references and tags via in-process LSP (triggered by typing `[[` for wiki and markdown links, `#` for tags, `[^` for footnotes). Use `[[^query` to select a block in the current note or `[[^^query` to search blocks across the vault; unlabeled blocks receive an ID when selected.
 
 🏃 **Navigation:** Navigate throughout your vault via links, backlinks, tags and etc.
 

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -895,11 +895,23 @@ M.footnote_new = function(id, bufnr, restore_cursor)
   require("obsidian.footnotes").create(id, bufnr, restore_cursor)
 end
 
+---@param lines string[]
+---@param block_id string
+---@return boolean
+local function contains_block_id(lines, block_id)
+  for _, line in ipairs(lines) do
+    if util.parse_block(vim.trim(line)) == block_id then
+      return true
+    end
+  end
+  return false
+end
+
 ---@class obsidian.actions.BlockReferenceOpts
 ---@field target_path string
 ---@field target_bufnr integer|?
 ---@field target_range lsp.Range
----@field expected_lines string[]
+---@field target_checksum string
 ---@field block_id string
 ---@field placement "inline"|"standalone"
 ---@field source_bufnr integer
@@ -908,7 +920,7 @@ end
 ---@field placeholder string
 
 --- Add an ID to an unlabeled block and replace the accepted completion with its link.
----@param opts obsidian.actions.BlockReferenceOpts
+---@param opts obsidian.actions.BlockReferenceOpts|?
 M.block_reference_new = function(opts)
   if not opts or not vim.api.nvim_buf_is_valid(opts.source_bufnr) then
     return
@@ -935,58 +947,88 @@ M.block_reference_new = function(opts)
     target_bufnr = vim.fn.bufadd(opts.target_path)
   end
   vim.fn.bufload(target_bufnr)
+  if not vim.bo[target_bufnr].modifiable or vim.bo[target_bufnr].readonly then
+    return log.warn "Target block is not writable"
+  end
 
-  local target =
-    vim.api.nvim_buf_get_lines(target_bufnr, opts.target_range.start.line, opts.target_range["end"].line, false)
-  if not vim.deep_equal(target, opts.expected_lines) then
+  local target_lines = vim.api.nvim_buf_get_lines(target_bufnr, 0, -1, false)
+  local normalized_target = vim.tbl_map(util.rstrip_whitespace, target_lines)
+  if vim.fn.sha256(table.concat(normalized_target, "\n")) ~= opts.target_checksum then
     return log.warn "Block changed before its reference could be created"
   end
 
-  for _, line in ipairs(vim.api.nvim_buf_get_lines(target_bufnr, 0, -1, false)) do
-    if util.parse_block(vim.trim(line)) == opts.block_id then
-      return log.warn "Generated block ID already exists"
-    end
+  if contains_block_id(target_lines, opts.block_id) then
+    return log.warn "Generated block ID already exists"
+  end
+
+  local target =
+    vim.api.nvim_buf_get_lines(target_bufnr, opts.target_range.start.line, opts.target_range["end"].line, false)
+  if #target == 0 then
+    return log.warn "Target block no longer exists"
   end
 
   local target_line = opts.target_range["end"].line - 1
-  local target_character = #opts.expected_lines[#opts.expected_lines]
-  local target_uri = vim.uri_from_bufnr(target_bufnr)
-  local source_uri = vim.uri_from_bufnr(opts.source_bufnr)
-  local changes = {
-    [target_uri] = {
-      {
-        range = {
-          start = { line = target_line, character = target_character },
-          ["end"] = { line = target_line, character = target_character },
-        },
-        newText = opts.placement == "standalone" and "\n" .. opts.block_id or " " .. opts.block_id,
-      },
+  local target_character = #target[#target]
+  local target_edit = {
+    range = {
+      start = { line = target_line, character = target_character },
+      ["end"] = { line = target_line, character = target_character },
     },
+    newText = opts.placement == "standalone" and "\n" .. opts.block_id or " " .. opts.block_id,
   }
   local source_edit = { range = opts.source_range, newText = opts.source_text }
-  if source_uri == target_uri then
-    changes[target_uri][#changes[target_uri] + 1] = source_edit
-  else
-    changes[source_uri] = { source_edit }
+
+  ---@param edits lsp.TextEdit[]
+  ---@param bufnr integer
+  ---@return boolean
+  local function apply_text_edits(edits, bufnr)
+    local ok, err = pcall(vim.lsp.util.apply_text_edits, edits, bufnr, "utf-8")
+    if not ok then
+      log.err("Failed to apply block reference edit: %s", err)
+      return false
+    end
+    return true
   end
 
-  vim.lsp.util.apply_workspace_edit({ changes = changes }, "utf-8")
-
-  if not target_was_loaded then
-    local ok, err = pcall(vim.api.nvim_buf_call, target_bufnr, function()
-      vim.cmd "silent noautocmd write"
-    end)
-    if not ok then
-      log.err("Failed to save block ID in '%s': %s", opts.target_path, err)
+  if target_bufnr == opts.source_bufnr then
+    if not apply_text_edits({ target_edit, source_edit }, target_bufnr) then
+      return
+    end
+  else
+    if not apply_text_edits({ target_edit }, target_bufnr) then
+      return
+    end
+    if not target_was_loaded then
+      local ok, err = pcall(vim.api.nvim_buf_call, target_bufnr, function()
+        vim.cmd "silent write"
+      end)
+      if not ok then
+        log.err("Failed to save block ID in '%s': %s", opts.target_path, err)
+        return
+      end
+    end
+    if not contains_block_id(vim.api.nvim_buf_get_lines(target_bufnr, 0, -1, false), opts.block_id) then
+      log.err("Block ID was removed while saving '%s'", opts.target_path)
+      return
+    end
+    if not apply_text_edits({ source_edit }, opts.source_bufnr) then
+      return
     end
   end
 
   if vim.api.nvim_get_current_buf() == opts.source_bufnr then
     local source_line = opts.source_range.start.line
-    if source_uri == target_uri and opts.placement == "standalone" and target_line < opts.source_range.start.line then
+    ---@cast source_line integer
+    if
+      target_bufnr == opts.source_bufnr
+      and opts.placement == "standalone"
+      and target_line < opts.source_range.start.line
+    then
       source_line = source_line + 1
     end
-    vim.api.nvim_win_set_cursor(0, { source_line + 1, opts.source_range.start.character + #opts.source_text })
+    local source_col = opts.source_range.start.character + #opts.source_text
+    ---@cast source_col integer
+    vim.api.nvim_win_set_cursor(0, { source_line + 1, source_col })
   end
   require("obsidian.ui").update(opts.source_bufnr)
 end

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -895,6 +895,102 @@ M.footnote_new = function(id, bufnr, restore_cursor)
   require("obsidian.footnotes").create(id, bufnr, restore_cursor)
 end
 
+---@class obsidian.actions.BlockReferenceOpts
+---@field target_path string
+---@field target_bufnr integer|?
+---@field target_range lsp.Range
+---@field expected_lines string[]
+---@field block_id string
+---@field placement "inline"|"standalone"
+---@field source_bufnr integer
+---@field source_range lsp.Range
+---@field source_text string
+---@field placeholder string
+
+--- Add an ID to an unlabeled block and replace the accepted completion with its link.
+---@param opts obsidian.actions.BlockReferenceOpts
+M.block_reference_new = function(opts)
+  if not opts or not vim.api.nvim_buf_is_valid(opts.source_bufnr) then
+    return
+  end
+
+  local source = vim.api.nvim_buf_get_text(
+    opts.source_bufnr,
+    opts.source_range.start.line,
+    opts.source_range.start.character,
+    opts.source_range["end"].line,
+    opts.source_range["end"].character,
+    {}
+  )
+  if #source ~= 1 or source[1] ~= opts.placeholder then
+    return log.warn "Block reference completion is no longer current"
+  end
+
+  local target_bufnr = opts.target_bufnr
+  if not target_bufnr or not vim.api.nvim_buf_is_valid(target_bufnr) then
+    target_bufnr = vim.fn.bufnr(opts.target_path)
+  end
+  local target_was_loaded = target_bufnr > 0 and vim.api.nvim_buf_is_loaded(target_bufnr)
+  if target_bufnr < 1 then
+    target_bufnr = vim.fn.bufadd(opts.target_path)
+  end
+  vim.fn.bufload(target_bufnr)
+
+  local target =
+    vim.api.nvim_buf_get_lines(target_bufnr, opts.target_range.start.line, opts.target_range["end"].line, false)
+  if not vim.deep_equal(target, opts.expected_lines) then
+    return log.warn "Block changed before its reference could be created"
+  end
+
+  for _, line in ipairs(vim.api.nvim_buf_get_lines(target_bufnr, 0, -1, false)) do
+    if util.parse_block(vim.trim(line)) == opts.block_id then
+      return log.warn "Generated block ID already exists"
+    end
+  end
+
+  local target_line = opts.target_range["end"].line - 1
+  local target_character = #opts.expected_lines[#opts.expected_lines]
+  local target_uri = vim.uri_from_bufnr(target_bufnr)
+  local source_uri = vim.uri_from_bufnr(opts.source_bufnr)
+  local changes = {
+    [target_uri] = {
+      {
+        range = {
+          start = { line = target_line, character = target_character },
+          ["end"] = { line = target_line, character = target_character },
+        },
+        newText = opts.placement == "standalone" and "\n" .. opts.block_id or " " .. opts.block_id,
+      },
+    },
+  }
+  local source_edit = { range = opts.source_range, newText = opts.source_text }
+  if source_uri == target_uri then
+    changes[target_uri][#changes[target_uri] + 1] = source_edit
+  else
+    changes[source_uri] = { source_edit }
+  end
+
+  vim.lsp.util.apply_workspace_edit({ changes = changes }, "utf-8")
+
+  if not target_was_loaded then
+    local ok, err = pcall(vim.api.nvim_buf_call, target_bufnr, function()
+      vim.cmd "silent noautocmd write"
+    end)
+    if not ok then
+      log.err("Failed to save block ID in '%s': %s", opts.target_path, err)
+    end
+  end
+
+  if vim.api.nvim_get_current_buf() == opts.source_bufnr then
+    local source_line = opts.source_range.start.line
+    if source_uri == target_uri and opts.placement == "standalone" and target_line < opts.source_range.start.line then
+      source_line = source_line + 1
+    end
+    vim.api.nvim_win_set_cursor(0, { source_line + 1, opts.source_range.start.character + #opts.source_text })
+  end
+  require("obsidian.ui").update(opts.source_bufnr)
+end
+
 ---@param bufnr      integer
 ---@param suggestion obsidian.LinkSuggestion
 ---@param candidate  obsidian.LinkSuggestionCandidate

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -913,7 +913,8 @@ end
 ---@field target_range lsp.Range
 ---@field target_checksum string
 ---@field block_id string
----@field placement "inline"|"standalone"
+---@field placement "inline"|"list-item"|"standalone"
+---@field indent string|?
 ---@field source_bufnr integer
 ---@field source_range lsp.Range
 ---@field source_text string
@@ -969,12 +970,20 @@ M.block_reference_new = function(opts)
 
   local target_line = opts.target_range["end"].line - 1
   local target_character = #target[#target]
+  local has_blank_after = target_lines[opts.target_range["end"].line + 1] ~= nil
+    and vim.trim(target_lines[opts.target_range["end"].line + 1]) == ""
+  local target_text = " " .. opts.block_id
+  if opts.placement == "standalone" then
+    target_text = "\n\n" .. opts.block_id .. (has_blank_after and "" or "\n")
+  elseif opts.placement == "list-item" then
+    target_text = "\n" .. (opts.indent or "    ") .. opts.block_id
+  end
   local target_edit = {
     range = {
       start = { line = target_line, character = target_character },
       ["end"] = { line = target_line, character = target_character },
     },
-    newText = opts.placement == "standalone" and "\n" .. opts.block_id or " " .. opts.block_id,
+    newText = target_text,
   }
   local source_edit = { range = opts.source_range, newText = opts.source_text }
 
@@ -1021,10 +1030,10 @@ M.block_reference_new = function(opts)
     ---@cast source_line integer
     if
       target_bufnr == opts.source_bufnr
-      and opts.placement == "standalone"
+      and target_text:find("\n", 1, true)
       and target_line < opts.source_range.start.line
     then
-      source_line = source_line + 1
+      source_line = source_line + select(2, target_text:gsub("\n", ""))
     end
     local source_col = opts.source_range.start.character + #opts.source_text
     ---@cast source_col integer

--- a/lua/obsidian/completion/refs.lua
+++ b/lua/obsidian/completion/refs.lua
@@ -46,6 +46,17 @@ M.can_complete = function(request)
   end
 end
 
+---@param search_string string
+---@return "current"|"vault"|? scope
+---@return string|? query
+function M.block_search(search_string)
+  if vim.startswith(search_string, "^^") then
+    return "vault", search_string:sub(3)
+  elseif vim.startswith(search_string, "^") then
+    return "current", search_string:sub(2)
+  end
+end
+
 ---@param label string
 ---@return string
 M.get_filter_text = function(label)

--- a/lua/obsidian/completion/refs.lua
+++ b/lua/obsidian/completion/refs.lua
@@ -47,13 +47,23 @@ M.can_complete = function(request)
 end
 
 ---@param search_string string
----@return "current"|"vault"|? scope
+---@return "current"|"note"|"vault"|? scope
 ---@return string|? query
+---@return string|? target
 function M.block_search(search_string)
   if vim.startswith(search_string, "^^") then
     return "vault", search_string:sub(3)
   elseif vim.startswith(search_string, "^") then
     return "current", search_string:sub(2)
+  end
+
+  local target, query = search_string:match "^(.-)#%^(.*)$"
+  if target ~= nil then
+    return target == "" and "current" or "note", query, target
+  end
+  target, query = search_string:match "^(.-)%^(.*)$"
+  if target and target ~= "" then
+    return "note", query, target
   end
 end
 

--- a/lua/obsidian/completion/sources/new.lua
+++ b/lua/obsidian/completion/sources/new.lua
@@ -16,7 +16,12 @@ local EMPTY_RESPONSE = {
 function M.process_completion(callback, request)
   local can_complete, term, insert_start, insert_end = completion.can_complete(request)
 
-  if (not can_complete) or (#term < Obsidian.opts.completion.min_chars) then
+  if not can_complete or term == nil then
+    callback(EMPTY_RESPONSE)
+    return
+  end
+
+  if vim.startswith(term, "^") or #term < Obsidian.opts.completion.min_chars then
     callback(EMPTY_RESPONSE)
     return
   end

--- a/lua/obsidian/completion/sources/new.lua
+++ b/lua/obsidian/completion/sources/new.lua
@@ -21,7 +21,7 @@ function M.process_completion(callback, request)
     return
   end
 
-  if vim.startswith(term, "^") or #term < Obsidian.opts.completion.min_chars then
+  if completion.block_search(term) ~= nil or #term < Obsidian.opts.completion.min_chars then
     callback(EMPTY_RESPONSE)
     return
   end

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -190,6 +190,7 @@ end
 local function process_block_search_results(cc, scope, query, results)
   ---@cast cc.insert_start -nil
   ---@cast cc.insert_end -nil
+  ---@cast cc.search -nil
   ---@type lsp.Range
   local range = {
     start = { line = cc.request.line, character = cc.insert_start },
@@ -235,7 +236,7 @@ local function process_block_search_results(cc, scope, query, results)
           local item = {
             label = label,
             sortText = ("%08d:%08d"):format(note_idx, section.range.start_row),
-            filterText = (scope == "vault" and "[[^^" or "[[^") .. query .. " " .. label,
+            filterText = "[[" .. cc.search .. " " .. label,
             documentation = {
               kind = "markdown",
               value = note:display_info { label = link, block = block },

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -42,11 +42,244 @@ local function can_complete_request(cc)
   local can_complete
   can_complete, cc.search, cc.insert_start, cc.insert_end = completion.can_complete(cc.request)
 
-  if not (can_complete and cc.search ~= nil and #cc.search >= Obsidian.opts.completion.min_chars) then
+  if
+    not (
+      can_complete
+      and cc.search ~= nil
+      and (vim.startswith(cc.search, "^") or #cc.search >= Obsidian.opts.completion.min_chars)
+    )
+  then
     return false
   end
 
   return true
+end
+
+---@param search_string string
+---@return "current"|"vault"|?
+---@return string|?
+local function block_search(search_string)
+  if vim.startswith(search_string, "^^") then
+    return "vault", search_string:sub(3)
+  elseif vim.startswith(search_string, "^") then
+    return "current", search_string:sub(2)
+  end
+  return nil
+end
+
+---@param note obsidian.Note
+---@param section obsidian.Section
+---@return obsidian.note.Block|?
+local function existing_block(note, section)
+  for _, block in pairs(note.blocks or {}) do
+    if block.section == section then
+      return block
+    end
+  end
+end
+
+---@param lines string[]
+---@param block_id string|?
+---@return string
+local function block_text(lines, block_id)
+  local visible = {}
+  for _, line in ipairs(lines) do
+    if not (block_id and vim.trim(line) == block_id) then
+      if block_id and util.parse_block(line) == block_id then
+        line = line:gsub("%s*" .. vim.pesc(block_id) .. "%s*$", "")
+      end
+      visible[#visible + 1] = line
+    end
+  end
+  return vim.trim(table.concat(visible, "\n"))
+end
+
+---@param note obsidian.Note
+---@param section obsidian.Section
+---@param text string
+---@param reserved table<string, boolean>
+---@return string
+local function generated_block_id(note, section, text, reserved)
+  local salt = 0
+  while true do
+    local digest =
+      vim.fn.sha256(("%s:%d:%d:%s:%d"):format(note.path, section.range.start_row, section.range.end_row, text, salt))
+    local id = "^" .. digest:sub(1, 6)
+    if not (note.blocks or {})[id] and not reserved[id] then
+      reserved[id] = true
+      return id
+    end
+    salt = salt + 1
+  end
+end
+
+---@param text string
+---@return string
+local function block_label(text)
+  local label = text:gsub("%s+", " ")
+  if vim.fn.strchars(label) > 80 then
+    label = vim.fn.strcharpart(label, 0, 79) .. "…"
+  end
+  return label
+end
+
+---@param lines string[]
+---@return "inline"|"standalone"
+local function block_id_placement(lines)
+  for _, line in ipairs(lines) do
+    local table_separator = line:find("|", 1, true) and line:gsub("[|:%-%s]", "") == ""
+    if line:match "^%s*>" or line:match "^%s*|" or table_separator then
+      return "standalone"
+    end
+  end
+  return "inline"
+end
+
+---@param block obsidian.note.Block
+---@return string
+local function format_current_block_link(block)
+  if Obsidian.opts.link.style == "wiki" then
+    return "[[#" .. block.id .. "]]"
+  elseif Obsidian.opts.link.style == "markdown" then
+    return "[#" .. block.id .. "](#" .. block.id .. ")"
+  elseif type(Obsidian.opts.link.style) == "function" then
+    return Obsidian.opts.link.style { label = "", path = "", block = block }
+  end
+  error "not implemented"
+end
+
+---@param request obsidian.completion.Request
+---@param range lsp.Range
+---@return string
+local function current_completion_text(request, range)
+  local suffix_len = range["end"].character - request.character
+  return request.cursor_before_line:sub(range.start.character + 1) .. request.cursor_after_line:sub(1, suffix_len)
+end
+
+---@param note obsidian.Note
+---@return obsidian.Note
+local function prefer_loaded_note(note)
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      local path = vim.uv.fs_realpath(vim.fn.resolve(vim.api.nvim_buf_get_name(bufnr)))
+      if path == tostring(note.path) then
+        return require("obsidian.note").from_buffer(bufnr, {
+          collect_blocks = true,
+          collect_block_candidates = true,
+        })
+      end
+    end
+  end
+  return note
+end
+
+---@param cc obsidian.completion.sources.refs.context
+---@param scope "current"|"vault"
+---@param query string
+---@param results obsidian.Note[]
+local function process_block_search_results(cc, scope, query, results)
+  local range = {
+    start = { line = cc.request.line, character = cc.insert_start },
+    ["end"] = { line = cc.request.line, character = cc.insert_end },
+  }
+  local placeholder = current_completion_text(cc.request, range)
+  local source_name = vim.api.nvim_buf_get_name(cc.request.bufnr)
+  local source_path = vim.uv.fs_realpath(vim.fn.resolve(source_name)) or vim.fs.normalize(source_name)
+  local lowered_query = vim.fn.tolower(query)
+  local items = {}
+
+  for note_idx, searched_note in ipairs(results) do
+    local note = prefer_loaded_note(searched_note)
+    local same_note = vim.fs.normalize(tostring(note.path)) == source_path
+    local reserved_ids = {}
+    for _, section in ipairs(note.block_candidates or {}) do
+      if not (same_note and section.range.start_row <= cc.request.line and cc.request.line < section.range.end_row) then
+        local lines = vim.list_slice(note.contents, section.range.start_row + 1, section.range.end_row)
+        local existing = existing_block(note, section)
+        local text = block_text(lines, existing and existing.id)
+        if text ~= "" and vim.fn.tolower(text):find(lowered_query, 1, true) then
+          local block = existing
+            or {
+              id = generated_block_id(note, section, text, reserved_ids),
+              line = section.range.end_row,
+              block = text,
+              section = section,
+            }
+          if existing then
+            block = vim.tbl_extend("force", block, { block = text })
+          end
+
+          local link = scope == "current" and format_current_block_link(block)
+            or note:format_link { label = note:display_name(), block = block }
+          local label = block_label(text)
+          if scope == "vault" then
+            label = label .. " — " .. note:display_name()
+          end
+
+          local item = {
+            label = label,
+            sortText = ("%08d:%08d"):format(note_idx, section.range.start_row),
+            filterText = (scope == "vault" and "[[^^" or "[[^") .. query .. " " .. label,
+            documentation = {
+              kind = "markdown",
+              value = note:display_info { label = link, block = block },
+            },
+            kind = vim.lsp.protocol.CompletionItemKind.Reference,
+            textEdit = {
+              newText = existing and link or placeholder,
+              range = range,
+            },
+          }
+
+          if not existing then
+            item.command = {
+              command = "obsidian.block_reference_new",
+              title = "Obsidian create block reference",
+              arguments = {
+                {
+                  target_path = tostring(note.path),
+                  target_bufnr = note.bufnr,
+                  target_range = {
+                    start = { line = section.range.start_row, character = 0 },
+                    ["end"] = { line = section.range.end_row, character = 0 },
+                  },
+                  expected_lines = lines,
+                  block_id = block.id,
+                  placement = block_id_placement(lines),
+                  source_bufnr = cc.request.bufnr,
+                  source_range = range,
+                  source_text = link,
+                  placeholder = placeholder,
+                },
+              },
+            }
+          end
+          items[#items + 1] = item
+        end
+      end
+    end
+  end
+
+  cc.completion_resolve_callback { isIncomplete = true, items = items }
+end
+
+---@param cc obsidian.completion.sources.refs.context
+---@param scope "current"|"vault"
+---@param query string
+local function process_block_search(cc, scope, query)
+  if scope == "current" then
+    local note = api.current_note(cc.request.bufnr, { collect_blocks = true, collect_block_candidates = true })
+    process_block_search_results(cc, scope, query, note and { note } or {})
+    return
+  end
+
+  search.find_notes_async(query, function(results)
+    process_block_search_results(cc, scope, query, results)
+  end, {
+    dir = api.resolve_workspace_dir(),
+    search = { sort = false, include_templates = false, ignore_case = true },
+    notes = { collect_blocks = true, collect_block_candidates = true },
+  })
 end
 
 --- Determines whatever the in_buffer_only should be enabled
@@ -327,6 +560,12 @@ function M.process_completion(completion_resolve_callback, request)
 
   if not can_complete_request(cc) or not cc.search then
     cc.completion_resolve_callback(EMPTY_RESPONSE)
+    return
+  end
+
+  local block_scope, block_query = block_search(cc.search)
+  if block_scope and block_query then
+    process_block_search(cc, block_scope, block_query)
     return
   end
 

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -152,8 +152,9 @@ end
 
 ---@param results obsidian.Note[]
 ---@param dir obsidian.Path
+---@param include_unmatched boolean|?
 ---@return obsidian.Note[]
-local function include_loaded_notes(results, dir)
+local function include_loaded_notes(results, dir, include_unmatched)
   local path_to_idx = {}
   for idx, note in ipairs(results) do
     path_to_idx[tostring(note.path)] = idx
@@ -172,7 +173,7 @@ local function include_loaded_notes(results, dir)
         local idx = path_to_idx[tostring(note.path)]
         if idx then
           results[idx] = note
-        else
+        elseif include_unmatched ~= false then
           results[#results + 1] = note
           path_to_idx[tostring(note.path)] = #results
         end
@@ -183,7 +184,7 @@ local function include_loaded_notes(results, dir)
 end
 
 ---@param cc obsidian.completion.sources.refs.context
----@param scope "current"|"vault"
+---@param scope "current"|"note"|"vault"
 ---@param query string
 ---@param results obsidian.Note[]
 local function process_block_search_results(cc, scope, query, results)
@@ -208,7 +209,8 @@ local function process_block_search_results(cc, scope, query, results)
         local lines = vim.list_slice(note.contents, section.range.start_row + 1, section.range.end_row)
         local existing = existing_block(note, section)
         local text = block_text(lines, existing and existing.id)
-        if text ~= "" and vim.fn.tolower(text):find(lowered_query, 1, true) then
+        local searchable = text .. (existing and " " .. existing.id or "")
+        if text ~= "" and vim.fn.tolower(searchable):find(lowered_query, 1, true) then
           local block = existing
             or {
               id = generated_block_id(note, section, text, reserved_ids),
@@ -223,6 +225,9 @@ local function process_block_search_results(cc, scope, query, results)
           local link = scope == "current" and format_current_block_link(block)
             or note:format_link { label = note:display_name(), block = block }
           local label = block_label(text)
+          if existing then
+            label = label .. " " .. existing.id
+          end
           if scope == "vault" then
             label = label .. " — " .. note:display_name()
           end
@@ -277,9 +282,10 @@ local function process_block_search_results(cc, scope, query, results)
 end
 
 ---@param cc obsidian.completion.sources.refs.context
----@param scope "current"|"vault"
+---@param scope "current"|"note"|"vault"
 ---@param query string
-local function process_block_search(cc, scope, query)
+---@param target string|?
+local function process_block_search(cc, scope, query, target)
   if scope == "current" then
     local note = api.current_note(cc.request.bufnr, {
       max_lines = vim.api.nvim_buf_line_count(cc.request.bufnr),
@@ -291,12 +297,22 @@ local function process_block_search(cc, scope, query)
   end
 
   local dir = api.resolve_workspace_dir()
-  search.find_notes_async(query, function(results)
-    process_block_search_results(cc, scope, query, include_loaded_notes(results, dir))
-  end, {
+  local note_opts = { max_lines = ALL_LINES, collect_blocks = true, collect_block_candidates = true }
+  local function on_results(results)
+    process_block_search_results(cc, scope, query, include_loaded_notes(results, dir, scope == "vault"))
+  end
+  if scope == "note" then
+    search.resolve_note_async(
+      assert(target, "named-note block search requires a target"),
+      on_results,
+      { notes = note_opts }
+    )
+    return
+  end
+  search.find_notes_async(query, on_results, {
     dir = dir,
     search = { sort = false, include_templates = false, ignore_case = true },
-    notes = { max_lines = ALL_LINES, collect_blocks = true, collect_block_candidates = true },
+    notes = note_opts,
   })
 end
 
@@ -573,9 +589,9 @@ function M.process_completion(completion_resolve_callback, request)
     return
   end
 
-  local block_scope, block_query = completion.block_search(cc.search)
+  local block_scope, block_query, block_target = completion.block_search(cc.search)
   if block_scope and block_query then
-    process_block_search(cc, block_scope, block_query)
+    process_block_search(cc, block_scope, block_query, block_target)
     return
   end
 

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -115,13 +115,14 @@ local function block_label(text)
 end
 
 ---@param lines string[]
----@return "inline"|"standalone"
-local function block_id_placement(lines)
-  for _, line in ipairs(lines) do
-    local table_separator = line:find("|", 1, true) and line:gsub("[|:%-%s]", "") == ""
-    if line:match "^%s*>" or line:match "^%s*|" or table_separator then
-      return "standalone"
-    end
+---@param section obsidian.Section
+---@return "inline"|"list-item"|"standalone"
+---@return string|? indent
+local function block_id_placement(lines, section)
+  if section.block_type == "quote" or section.block_type == "table" then
+    return "standalone"
+  elseif section.block_type == "list" and #lines > 1 then
+    return "list-item", lines[#lines]:match "^(%s+)" or (lines[1]:match "^(%s*)" or "") .. "    "
   end
   return "inline"
 end
@@ -240,6 +241,7 @@ local function process_block_search_results(cc, scope, query, results)
           }
 
           if not existing then
+            local placement, indent = block_id_placement(lines, section)
             item.command = {
               command = "obsidian.block_reference_new",
               title = "Obsidian create block reference",
@@ -253,7 +255,8 @@ local function process_block_search_results(cc, scope, query, results)
                   },
                   target_checksum = vim.fn.sha256(table.concat(note.contents, "\n")),
                   block_id = block.id,
-                  placement = block_id_placement(lines),
+                  placement = placement,
+                  indent = indent,
                   source_bufnr = cc.request.bufnr,
                   source_range = range,
                   source_text = link,

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -49,25 +49,13 @@ local function can_complete_request(cc)
     not (
       can_complete
       and cc.search ~= nil
-      and (vim.startswith(cc.search, "^") or #cc.search >= Obsidian.opts.completion.min_chars)
+      and (completion.block_search(cc.search) ~= nil or #cc.search >= Obsidian.opts.completion.min_chars)
     )
   then
     return false
   end
 
   return true
-end
-
----@param search_string string
----@return "current"|"vault"|?
----@return string|?
-local function block_search(search_string)
-  if vim.startswith(search_string, "^^") then
-    return "vault", search_string:sub(3)
-  elseif vim.startswith(search_string, "^") then
-    return "current", search_string:sub(2)
-  end
-  return nil
 end
 
 ---@param note obsidian.Note
@@ -580,7 +568,7 @@ function M.process_completion(completion_resolve_callback, request)
     return
   end
 
-  local block_scope, block_query = block_search(cc.search)
+  local block_scope, block_query = completion.block_search(cc.search)
   if block_scope and block_query then
     process_block_search(cc, block_scope, block_query)
     return

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -121,7 +121,9 @@ end
 local function block_id_placement(lines, section)
   if section.block_type == "quote" or section.block_type == "table" then
     return "standalone"
-  elseif section.block_type == "list" and #lines > 1 then
+  elseif section.block_type == "list" then
+    return "standalone"
+  elseif section.block_type == "list-item" and #lines > 1 then
     return "list-item", lines[#lines]:match "^(%s+)" or (lines[1]:match "^(%s*)" or "") .. "    "
   end
   return "inline"

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -35,6 +35,9 @@ local EMPTY_RESPONSE = {
   items = {},
 }
 
+---@type integer
+local ALL_LINES = 2147483647
+
 --- Returns whether it's possible to complete the search and sets up the search related variables in cc
 ---@param cc obsidian.completion.sources.refs.context
 ---@return boolean success provides a chance to return early if the request didn't meet the requirements
@@ -156,21 +159,36 @@ local function current_completion_text(request, range)
   return request.cursor_before_line:sub(range.start.character + 1) .. request.cursor_after_line:sub(1, suffix_len)
 end
 
----@param note obsidian.Note
----@return obsidian.Note
-local function prefer_loaded_note(note)
+---@param results obsidian.Note[]
+---@param dir obsidian.Path
+---@return obsidian.Note[]
+local function include_loaded_notes(results, dir)
+  local path_to_idx = {}
+  for idx, note in ipairs(results) do
+    path_to_idx[tostring(note.path)] = idx
+  end
+
+  local Note = require "obsidian.note"
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_loaded(bufnr) then
       local path = vim.uv.fs_realpath(vim.fn.resolve(vim.api.nvim_buf_get_name(bufnr)))
-      if path == tostring(note.path) then
-        return require("obsidian.note").from_buffer(bufnr, {
+      if path and util.is_subpath(path, tostring(dir)) and api.path_is_note(path) then
+        local note = Note.from_buffer(bufnr, {
+          max_lines = vim.api.nvim_buf_line_count(bufnr),
           collect_blocks = true,
           collect_block_candidates = true,
         })
+        local idx = path_to_idx[tostring(note.path)]
+        if idx then
+          results[idx] = note
+        else
+          results[#results + 1] = note
+          path_to_idx[tostring(note.path)] = #results
+        end
       end
     end
   end
-  return note
+  return results
 end
 
 ---@param cc obsidian.completion.sources.refs.context
@@ -178,6 +196,9 @@ end
 ---@param query string
 ---@param results obsidian.Note[]
 local function process_block_search_results(cc, scope, query, results)
+  ---@cast cc.insert_start -nil
+  ---@cast cc.insert_end -nil
+  ---@type lsp.Range
   local range = {
     start = { line = cc.request.line, character = cc.insert_start },
     ["end"] = { line = cc.request.line, character = cc.insert_end },
@@ -188,8 +209,7 @@ local function process_block_search_results(cc, scope, query, results)
   local lowered_query = vim.fn.tolower(query)
   local items = {}
 
-  for note_idx, searched_note in ipairs(results) do
-    local note = prefer_loaded_note(searched_note)
+  for note_idx, note in ipairs(results) do
     local same_note = vim.fs.normalize(tostring(note.path)) == source_path
     local reserved_ids = {}
     for _, section in ipairs(note.block_candidates or {}) do
@@ -243,7 +263,7 @@ local function process_block_search_results(cc, scope, query, results)
                     start = { line = section.range.start_row, character = 0 },
                     ["end"] = { line = section.range.end_row, character = 0 },
                   },
-                  expected_lines = lines,
+                  target_checksum = vim.fn.sha256(table.concat(note.contents, "\n")),
                   block_id = block.id,
                   placement = block_id_placement(lines),
                   source_bufnr = cc.request.bufnr,
@@ -268,17 +288,22 @@ end
 ---@param query string
 local function process_block_search(cc, scope, query)
   if scope == "current" then
-    local note = api.current_note(cc.request.bufnr, { collect_blocks = true, collect_block_candidates = true })
+    local note = api.current_note(cc.request.bufnr, {
+      max_lines = vim.api.nvim_buf_line_count(cc.request.bufnr),
+      collect_blocks = true,
+      collect_block_candidates = true,
+    })
     process_block_search_results(cc, scope, query, note and { note } or {})
     return
   end
 
+  local dir = api.resolve_workspace_dir()
   search.find_notes_async(query, function(results)
-    process_block_search_results(cc, scope, query, results)
+    process_block_search_results(cc, scope, query, include_loaded_notes(results, dir))
   end, {
-    dir = api.resolve_workspace_dir(),
+    dir = dir,
     search = { sort = false, include_templates = false, ignore_case = true },
-    notes = { collect_blocks = true, collect_block_candidates = true },
+    notes = { max_lines = ALL_LINES, collect_blocks = true, collect_block_candidates = true },
   })
 end
 
@@ -388,15 +413,7 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
       }
     elseif option.block then
       -- In buffer block link.
-      if Obsidian.opts.link.style == "wiki" then
-        new_text = "[[#" .. option.block.id .. "]]"
-      elseif Obsidian.opts.link.style == "markdown" then
-        new_text = "[#" .. option.block.id .. "](#" .. option.block.id .. ")"
-      elseif type(Obsidian.opts.link.style) == "function" then
-        new_text = Obsidian.opts.link.style { label = option.label or "", path = "", block = option.block }
-      else
-        error "not implemented"
-      end
+      new_text = format_current_block_link(option.block)
 
       final_label = "#" .. option.block.id
       sort_text = final_label

--- a/lua/obsidian/lsp/handlers/initialize.lua
+++ b/lua/obsidian/lsp/handlers/initialize.lua
@@ -25,6 +25,7 @@ local initializeResult = {
       commands = {
         "obsidian.write_note",
         "obsidian.footnote_new",
+        "obsidian.block_reference_new",
         "obsidian.link_suggestion",
       },
     },

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -67,6 +67,7 @@ end
 ---@field frontmatter_end_line integer|?
 ---@field anchor_links table<string, obsidian.note.HeaderAnchor>|?
 ---@field blocks table<string, obsidian.note.Block>?
+---@field block_candidates obsidian.Section[]|? paragraphs that can receive block identifiers.
 ---@field sections obsidian.Section[]|? document-ordered sections, the first one is always the preamble.
 ---@field alt_alias string|?
 ---@field bufnr integer|?
@@ -764,12 +765,13 @@ Note.from_lines = function(lines, path, opts)
     end
   end
 
-  ---@type obsidian.Section[]|?, table<string, obsidian.note.Block>|?
-  local sections, blocks
-  if opts.collect_sections or opts.collect_anchor_links or opts.collect_blocks then
-    sections, blocks = Section.parse(contents, {
+  ---@type obsidian.Section[]|?, table<string, obsidian.note.Block>|?, obsidian.Section[]|?
+  local sections, blocks, block_candidates
+  if opts.collect_sections or opts.collect_anchor_links or opts.collect_blocks or opts.collect_block_candidates then
+    sections, blocks, block_candidates = Section.parse(contents, {
       start_row = frontmatter_end_line or 0,
       collect_blocks = opts.collect_blocks,
+      collect_block_candidates = opts.collect_block_candidates,
     })
   end
 
@@ -825,6 +827,7 @@ Note.from_lines = function(lines, path, opts)
   n.contents = contents
   n.anchor_links = anchor_links
   n.blocks = blocks
+  n.block_candidates = block_candidates
   n.sections = sections
   -- TODO: reflect the warnings in `:Obsidian check`
   return n, warnings
@@ -1463,6 +1466,7 @@ end
 ---@field max_lines integer|?
 ---@field collect_anchor_links boolean|?
 ---@field collect_blocks boolean|?
+---@field collect_block_candidates boolean|?
 ---@field collect_sections boolean|?
 
 ---@class (exact) obsidian.note.NoteCreationOpts

--- a/lua/obsidian/section.lua
+++ b/lua/obsidian/section.lua
@@ -11,6 +11,10 @@ local H1_UNDERLINE_PATTERN = "^(=+)$"
 local H2_UNDERLINE_PATTERN = "^(-+)$"
 local CODE_BLOCK_PATTERN = "^```[%w_-]*$"
 
+local function is_list_item(line)
+  return line:match "^%s*[-+*]%s+" ~= nil or line:match "^%s*%d+[.)]%s+" ~= nil
+end
+
 --- A contiguous region of a markdown document.
 ---
 --- All ranges are |obsidian.Range|s over *lines* of the parsed document:
@@ -85,6 +89,7 @@ end
 ---@class obsidian.section.ParseOpts
 ---@field start_row integer|? 0-based row where parsing begins, e.g. just past the frontmatter. Defaults to `0`.
 ---@field collect_blocks boolean|? also collect block identifiers (`^block-id`).
+---@field collect_block_candidates boolean|? also collect paragraphs that can receive block identifiers.
 
 --- Parse markdown lines into a document-ordered list of sections.
 ---
@@ -95,6 +100,7 @@ end
 ---@param opts obsidian.section.ParseOpts|?
 ---@return obsidian.Section[] sections
 ---@return table<string, obsidian.note.Block>|? blocks `nil` unless `opts.collect_blocks` is set.
+---@return obsidian.Section[]|? block_candidates `nil` unless `opts.collect_block_candidates` is set.
 M.parse = function(lines, opts)
   opts = opts or {}
   local first = (opts.start_row or 0) + 1
@@ -110,6 +116,8 @@ M.parse = function(lines, opts)
 
   ---@type table<string, obsidian.note.Block>|?
   local blocks = opts.collect_blocks and {} or nil
+  ---@type obsidian.Section[]|?
+  local block_candidates = opts.collect_block_candidates and {} or nil
   ---@type integer|?
   local para_beg
   ---@type obsidian.note.Block[]
@@ -144,6 +152,9 @@ M.parse = function(lines, opts)
       }
       for _, block in ipairs(para_blocks) do
         block.section = section
+      end
+      if block_candidates then
+        table.insert(block_candidates, section)
       end
       last_para_section = section
     end
@@ -180,14 +191,19 @@ M.parse = function(lines, opts)
       end
       current.c_end = idx_excl
 
-      if blocks and detail.type == "text" then
+      if (blocks or block_candidates) and detail.type == "text" then
         local line = vim.trim(lines[idx])
+        if block_candidates and para_beg ~= nil and is_list_item(lines[idx]) then
+          close_paragraph(idx)
+        end
         local block_id = util.parse_block(line)
         if block_id and line == block_id and para_beg == nil and last_para_section ~= nil then
-          blocks[block_id] = { id = block_id, line = idx, block = line, section = last_para_section }
+          if blocks then
+            blocks[block_id] = { id = block_id, line = idx, block = line, section = last_para_section }
+          end
         else
           para_beg = para_beg or idx
-          if block_id then
+          if block_id and blocks then
             local block = { id = block_id, line = idx, block = line }
             blocks[block_id] = block
             table.insert(para_blocks, block)
@@ -244,7 +260,7 @@ M.parse = function(lines, opts)
     sections[i] = section
   end
 
-  return sections, blocks
+  return sections, blocks, block_candidates
 end
 
 return M

--- a/lua/obsidian/section.lua
+++ b/lua/obsidian/section.lua
@@ -12,21 +12,30 @@ local H2_UNDERLINE_PATTERN = "^(-+)$"
 local CODE_BLOCK_PATTERN = "^```[%w_-]*$"
 
 ---@param line string
----@return boolean
-local function is_list_item(line)
-  return line:match "^%s*[-+*]%s+" ~= nil or line:match "^%s*%d+[.)]%s+" ~= nil
+---@return integer|? indent
+---@return "bullet"|"ordered"|? kind
+local function list_item_info(line)
+  local indent = line:match "^(%s*)[-+*]%s+"
+  if indent then
+    return #indent, "bullet"
+  end
+  indent = line:match "^(%s*)%d+[.)]%s+"
+  if indent then
+    return #indent, "ordered"
+  end
+  return nil
 end
 
 ---@param line string
 ---@param detail obsidian.section.LineDetail
----@return "list"|"quote"|"table"|"text"
+---@return "list-item"|"quote"|"table"|"text"
 local function block_candidate_type(line, detail)
-  if is_list_item(line) then
-    return "list"
+  if detail.type == "table" then
+    return "table"
+  elseif list_item_info(line) then
+    return "list-item"
   elseif line:match "^%s*>" then
     return "quote"
-  elseif detail.type == "table" then
-    return "table"
   end
   return "text"
 end
@@ -46,7 +55,7 @@ end
 ---@field heading_range obsidian.Range the heading line(s). Empty for the preamble.
 ---@field content_range obsidian.Range own content (sub-sections excluded), trimmed of leading and trailing blank lines.
 ---@field parent obsidian.Section|? the nearest section above with a lower heading level.
----@field block_type "paragraph"|"list"|"quote"|"table"|? present on block-completion candidates.
+---@field block_type "paragraph"|"list"|"list-item"|"quote"|"table"|? present on block-completion candidates.
 
 local M = {}
 
@@ -102,7 +111,8 @@ local function get_line_details(lines, first)
 
   for idx = first + 1, #lines do
     local line = vim.trim(lines[idx])
-    local previous = assert(lines[idx - 1])
+    local previous = lines[idx - 1]
+    ---@cast previous -nil
     if
       details[idx].type == "text"
       and details[idx - 1].type == "text"
@@ -115,7 +125,8 @@ local function get_line_details(lines, first)
       details[idx].type = "table"
       local row = idx + 1
       while details[row] and details[row].type == "text" do
-        local row_line = assert(lines[row])
+        local row_line = lines[row]
+        ---@cast row_line -nil
         if not row_line:find("|", 1, true) then
           break
         end
@@ -162,7 +173,7 @@ M.parse = function(lines, opts)
   local block_candidates = opts.collect_block_candidates and {} or nil
   ---@type integer|?
   local para_beg
-  ---@type "list"|"quote"|"table"|"text"|?
+  ---@type "list-item"|"quote"|"table"|"text"|?
   local para_type
   ---@type obsidian.note.Block[]
   local para_blocks = {}
@@ -189,7 +200,7 @@ M.parse = function(lines, opts)
   ---@param end_excl integer
   local function close_paragraph(end_excl)
     if para_beg ~= nil then
-      ---@type "paragraph"|"list"|"quote"|"table"|?
+      ---@type "paragraph"|"list-item"|"quote"|"table"|?
       local block_type
       if para_type == "text" then
         block_type = "paragraph"
@@ -249,9 +260,14 @@ M.parse = function(lines, opts)
         local line = vim.trim(lines[idx])
         local next_type = block_candidate_type(lines[idx], detail)
         if block_candidates and para_beg ~= nil then
-          local split = next_type == "list" or (para_type ~= "list" and next_type ~= para_type)
-          if para_type == "list" and (next_type == "quote" or next_type == "table") then
-            local item_indent = #(assert(lines[para_beg]):match "^%s*" or "")
+          local split = next_type == "list-item" or (para_type ~= "list-item" and next_type ~= para_type)
+          if para_type == "quote" and next_type == "text" then
+            split = false
+          end
+          if para_type == "list-item" and (next_type == "quote" or next_type == "table") then
+            local item_line = lines[para_beg]
+            ---@cast item_line -nil
+            local item_indent = #(item_line:match "^%s*" or "")
             local next_indent = #(lines[idx]:match "^%s*" or "")
             split = next_indent <= item_indent
           end
@@ -281,6 +297,74 @@ M.parse = function(lines, opts)
     end
   end
   close_paragraph(#lines + 1)
+
+  if block_candidates then
+    local candidates = {}
+    local idx = 1
+    while idx <= #block_candidates do
+      local first_candidate = block_candidates[idx]
+      ---@cast first_candidate -nil
+      if first_candidate.block_type ~= "list-item" then
+        candidates[#candidates + 1] = first_candidate
+        idx = idx + 1
+      else
+        local base_line = lines[first_candidate.range.start_row + 1]
+        ---@cast base_line -nil
+        local base_indent, base_kind = list_item_info(base_line)
+        ---@cast base_indent -nil
+        ---@cast base_kind -nil
+        local last_idx = idx
+        while last_idx < #block_candidates do
+          local current_candidate = block_candidates[last_idx]
+          local next_candidate = block_candidates[last_idx + 1]
+          ---@cast current_candidate -nil
+          ---@cast next_candidate -nil
+          if
+            next_candidate.block_type ~= "list-item"
+            or current_candidate.range.end_row ~= next_candidate.range.start_row
+          then
+            break
+          end
+          local next_line = lines[next_candidate.range.start_row + 1]
+          ---@cast next_line -nil
+          local indent, kind = list_item_info(next_line)
+          ---@cast indent -nil
+          ---@cast kind -nil
+          if indent < base_indent or (indent == base_indent and kind ~= base_kind) then
+            break
+          end
+          last_idx = last_idx + 1
+        end
+
+        if last_idx > idx then
+          local last_candidate = block_candidates[last_idx]
+          ---@cast last_candidate -nil
+          ---@type obsidian.Section
+          local list_candidate = {
+            range = Range.new(first_candidate.range.start_row, 0, last_candidate.range.end_row, 0),
+            heading_range = Range.new(first_candidate.range.start_row, 0, first_candidate.range.start_row, 0),
+            content_range = Range.new(first_candidate.range.start_row, 0, last_candidate.range.end_row, 0),
+            block_type = "list",
+          }
+          for _, block in pairs(blocks or {}) do
+            if
+              block.section == last_candidate
+              and block.block == block.id
+              and block.line - 1 > last_candidate.range.end_row
+            then
+              block.section = list_candidate
+            end
+          end
+          candidates[#candidates + 1] = list_candidate
+        end
+        for item_idx = idx, last_idx do
+          candidates[#candidates + 1] = block_candidates[item_idx]
+        end
+        idx = last_idx + 1
+      end
+    end
+    block_candidates = candidates
+  end
 
   -- Materialize sections. A section's full range extends through its
   -- descendants: it ends where the next section of the same or lower level

--- a/lua/obsidian/section.lua
+++ b/lua/obsidian/section.lua
@@ -17,6 +17,20 @@ local function is_list_item(line)
   return line:match "^%s*[-+*]%s+" ~= nil or line:match "^%s*%d+[.)]%s+" ~= nil
 end
 
+---@param line string
+---@param detail obsidian.section.LineDetail
+---@return "list"|"quote"|"table"|"text"
+local function block_candidate_type(line, detail)
+  if is_list_item(line) then
+    return "list"
+  elseif line:match "^%s*>" then
+    return "quote"
+  elseif detail.type == "table" then
+    return "table"
+  end
+  return "text"
+end
+
 --- A contiguous region of a markdown document.
 ---
 --- All ranges are |obsidian.Range|s over *lines* of the parsed document:
@@ -32,11 +46,12 @@ end
 ---@field heading_range obsidian.Range the heading line(s). Empty for the preamble.
 ---@field content_range obsidian.Range own content (sub-sections excluded), trimmed of leading and trailing blank lines.
 ---@field parent obsidian.Section|? the nearest section above with a lower heading level.
+---@field block_type "paragraph"|"list"|"quote"|"table"|? present on block-completion candidates.
 
 local M = {}
 
 ---@class obsidian.section.LineDetail
----@field type "text"|"header"|"header-underline"|"code"|"empty"
+---@field type "text"|"header"|"header-underline"|"code"|"empty"|"table"
 ---@field level integer|?
 ---@field label string|?
 
@@ -85,6 +100,31 @@ local function get_line_details(lines, first)
     details[idx] = classify(idx)
   end
 
+  for idx = first + 1, #lines do
+    local line = vim.trim(lines[idx])
+    local previous = assert(lines[idx - 1])
+    if
+      details[idx].type == "text"
+      and details[idx - 1].type == "text"
+      and line:find("|", 1, true)
+      and line:find("-", 1, true)
+      and line:gsub("[|:%-%s]", "") == ""
+      and previous:find("|", 1, true)
+    then
+      details[idx - 1].type = "table"
+      details[idx].type = "table"
+      local row = idx + 1
+      while details[row] and details[row].type == "text" do
+        local row_line = assert(lines[row])
+        if not row_line:find("|", 1, true) then
+          break
+        end
+        details[row].type = "table"
+        row = row + 1
+      end
+    end
+  end
+
   return details
 end
 
@@ -122,6 +162,8 @@ M.parse = function(lines, opts)
   local block_candidates = opts.collect_block_candidates and {} or nil
   ---@type integer|?
   local para_beg
+  ---@type "list"|"quote"|"table"|"text"|?
+  local para_type
   ---@type obsidian.note.Block[]
   local para_blocks = {}
   ---@type obsidian.Section|?
@@ -147,10 +189,19 @@ M.parse = function(lines, opts)
   ---@param end_excl integer
   local function close_paragraph(end_excl)
     if para_beg ~= nil then
+      ---@type "paragraph"|"list"|"quote"|"table"|?
+      local block_type
+      if para_type == "text" then
+        block_type = "paragraph"
+      elseif para_type ~= nil then
+        block_type = para_type
+      end
+      ---@type obsidian.Section
       local section = {
         range = Range.new(para_beg - 1, 0, end_excl - 1, 0),
         heading_range = Range.new(para_beg - 1, 0, para_beg - 1, 0),
         content_range = Range.new(para_beg - 1, 0, end_excl - 1, 0),
+        block_type = block_type,
       }
       for _, block in ipairs(para_blocks) do
         block.section = section
@@ -161,6 +212,7 @@ M.parse = function(lines, opts)
       last_para_section = section
     end
     para_beg = nil
+    para_type = nil
     para_blocks = {}
   end
 
@@ -193,10 +245,19 @@ M.parse = function(lines, opts)
       end
       current.c_end = idx_excl
 
-      if (blocks or block_candidates) and detail.type == "text" then
+      if (blocks or block_candidates) and (detail.type == "text" or detail.type == "table") then
         local line = vim.trim(lines[idx])
-        if block_candidates and para_beg ~= nil and is_list_item(lines[idx]) then
-          close_paragraph(idx)
+        local next_type = block_candidate_type(lines[idx], detail)
+        if block_candidates and para_beg ~= nil then
+          local split = next_type == "list" or (para_type ~= "list" and next_type ~= para_type)
+          if para_type == "list" and (next_type == "quote" or next_type == "table") then
+            local item_indent = #(assert(lines[para_beg]):match "^%s*" or "")
+            local next_indent = #(lines[idx]:match "^%s*" or "")
+            split = next_indent <= item_indent
+          end
+          if split then
+            close_paragraph(idx)
+          end
         end
         local block_id = util.parse_block(line)
         if block_id and line == block_id and para_beg == nil and last_para_section ~= nil then
@@ -205,6 +266,7 @@ M.parse = function(lines, opts)
           end
         else
           para_beg = para_beg or idx
+          para_type = para_type or next_type
           if block_id and blocks then
             local block = { id = block_id, line = idx, block = line }
             blocks[block_id] = block

--- a/lua/obsidian/section.lua
+++ b/lua/obsidian/section.lua
@@ -11,6 +11,8 @@ local H1_UNDERLINE_PATTERN = "^(=+)$"
 local H2_UNDERLINE_PATTERN = "^(-+)$"
 local CODE_BLOCK_PATTERN = "^```[%w_-]*$"
 
+---@param line string
+---@return boolean
 local function is_list_item(line)
   return line:match "^%s*[-+*]%s+" ~= nil or line:match "^%s*%d+[.)]%s+" ~= nil
 end

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -291,6 +291,9 @@ T["completion"]["creates a vault-wide block reference from unlabeled content"] =
     return candidate.command and candidate.command.command == "obsidian.block_reference_new"
   end)
   assert(item, "no unlabeled block completion found")
+  assert(not vim.iter(result.items or {}):any(function(candidate)
+    return candidate.command and candidate.command.command == "obsidian.write_note"
+  end), "block search offered to create a note")
 
   accept_completion(item)
 
@@ -396,10 +399,34 @@ T["completion"]["places a blockquote ID on its own line"] = function()
   assert(lines[second + 1]:match "^%^[0-9a-f]+$", "blockquote ID is not standalone")
 end
 
+T["completion"]["places a table ID on its own line"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^value",
+    ["target.md"] = "Key | Value\n--- | ---\nOne | Two",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+
+  local result = run_completion(0, 9)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label:find("Key | Value", 1, true)
+  end)
+  assert(item, "no table completion found")
+  accept_completion(item)
+
+  local lines = vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))
+  local last_row = vim.iter(lines):enumerate():find(function(_, line)
+    return line == "One | Two"
+  end)
+  assert(last_row, "table disappeared")
+  assert(lines[last_row + 1]:match "^%^[0-9a-f]+$", "table ID is not standalone")
+end
+
 T["completion"]["updates a loaded unsaved target without overwriting it"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "[[^^needle",
-    ["target.md"] = "Old needle paragraph",
+    ["target.md"] = "Old on-disk paragraph",
   })
 
   child.cmd "set hidden"
@@ -419,14 +446,48 @@ T["completion"]["updates a loaded unsaved target without overwriting it"] = func
   local target_line = child.api.nvim_buf_get_lines(target_bufnr, 0, 1, false)[1]
   assert(target_line:match "^Unsaved needle paragraph %^[0-9a-f]+$", "unsaved target was not updated")
   eq(true, child.api.nvim_get_option_value("modified", { buf = target_bufnr }))
-  eq("Old needle paragraph", vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))[1])
+  eq("Old on-disk paragraph", vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))[1])
 end
 
 T["completion"]["does not create a dangling link when the target changes"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "[[^^needle",
+    ["target.md"] = "A needle paragraph\n\nA needle paragraph",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 10 })
+
+  local result = run_completion(0, 10)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.command.arguments[1].target_range.start.line == 2
+  end)
+  assert(item, "no second duplicate-block completion found")
+
+  vim.fn.writefile(
+    { "A needle paragraph", "", "A needle paragraph", "", "A needle paragraph" },
+    tostring(child.Obsidian.dir / "target.md")
+  )
+  accept_completion(item)
+
+  eq("[[^^needle", child.api.nvim_get_current_line())
+  eq(5, #vim.fn.readfile(tostring(child.Obsidian.dir / "target.md")))
+end
+
+T["completion"]["does not link when the target save fails"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^needle",
     ["target.md"] = "A needle paragraph",
   })
+  child.lua [[
+    require("obsidian.log").err = function() end
+    vim.api.nvim_create_autocmd("BufWritePre", {
+      pattern = "target.md",
+      callback = function()
+        error("expected write failure")
+      end,
+    })
+  ]]
 
   child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
   child.api.nvim_win_set_cursor(0, { 1, 10 })
@@ -436,12 +497,82 @@ T["completion"]["does not create a dangling link when the target changes"] = fun
     return candidate.command and candidate.command.command == "obsidian.block_reference_new"
   end)
   assert(item, "no unlabeled block completion found")
-
-  vim.fn.writefile({ "Changed needle paragraph" }, tostring(child.Obsidian.dir / "target.md"))
   accept_completion(item)
 
   eq("[[^^needle", child.api.nvim_get_current_line())
-  eq("Changed needle paragraph", vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))[1])
+  eq("A needle paragraph", vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))[1])
+end
+
+T["completion"]["searches beyond the configured note line cap"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^deep needle",
+    ["target.md"] = "First line\n\nDeep needle paragraph",
+  })
+  child.lua [[Obsidian.opts.search.max_lines = 1]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 15 })
+
+  local result = run_completion(0, 15)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "Deep needle paragraph — target"
+  end)
+  assert(item, "block completion stopped at search.max_lines")
+end
+
+T["completion"]["avoids generated block ID collisions"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^",
+    ["target.md"] = "First paragraph\n\nSecond paragraph",
+  })
+  child.lua [[
+    _G.obsidian_test_sha256 = vim.fn.sha256
+    vim.fn.sha256 = function(value)
+      return string.rep(vim.endswith(value, ":1") and "b" or "a", 64)
+    end
+  ]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 4 })
+  local result = run_completion(0, 4)
+  child.lua [[
+    vim.fn.sha256 = _G.obsidian_test_sha256
+    _G.obsidian_test_sha256 = nil
+  ]]
+
+  local ids = vim
+    .iter(result.items or {})
+    :filter(function(item)
+      return item.command and vim.endswith(item.label, "— target")
+    end)
+    :map(function(item)
+      return item.command.arguments[1].block_id
+    end)
+    :totable()
+  table.sort(ids)
+  eq({ "^aaaaaa", "^bbbbbb" }, ids)
+end
+
+T["completion"]["preserves trailing whitespace in the target block"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^trailing",
+    ["target.md"] = "Trailing paragraph  ",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 12 })
+  local result = run_completion(0, 12)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "Trailing paragraph — target"
+  end)
+  assert(item, "no trailing-whitespace block completion found")
+  accept_completion(item)
+
+  local target_line = vim.iter(vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))):find(function(line)
+    return vim.startswith(line, "Trailing paragraph")
+  end)
+  assert(target_line, "target paragraph disappeared")
+  assert(target_line:match "^Trailing paragraph   %^[0-9a-f]+$", "target whitespace was not preserved")
 end
 
 T["completion"]["returns items for tag trigger"] = function()

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -307,6 +307,100 @@ T["completion"]["creates a vault-wide block reference from unlabeled content"] =
   eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
 end
 
+T["completion"]["creates a block embed while preserving the leading bang"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "![[^^embed needle",
+    ["target.md"] = "An embed needle paragraph",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 17 })
+
+  local result = run_completion(0, 17)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "An embed needle paragraph — target"
+  end)
+  assert(item, "no generated block embed completion found")
+  accept_completion(item)
+
+  local target_line = vim.iter(vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))):find(function(line)
+    return vim.startswith(line, "An embed needle paragraph")
+  end)
+  assert(target_line, "embedded target paragraph disappeared")
+  local block_id = target_line:match "(%^[0-9a-f]+)$"
+  assert(block_id, "embedded target has no generated block ID")
+  eq("![[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["creates a named-note block reference from unlabeled content after hash caret"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[target#^needle",
+    ["target.md"] = "A named needle paragraph",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 16 })
+
+  local result = run_completion(0, 16)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "A named needle paragraph"
+  end)
+  assert(item, "no named-note unlabeled block completion found")
+  accept_completion(item)
+
+  local target_line = vim.iter(vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))):find(function(line)
+    return vim.startswith(line, "A named needle paragraph")
+  end)
+  assert(target_line, "named-note target paragraph disappeared")
+  local block_id = target_line:match "(%^[0-9a-f]+)$"
+  assert(block_id, "named-note target has no generated block ID")
+  eq("A named needle paragraph " .. block_id, target_line)
+  eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["creates a named-note block reference from unlabeled content after bare caret"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[target^named needle",
+    ["target.md"] = "A second named needle paragraph",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 21 })
+
+  local result = run_completion(0, 21)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "A second named needle paragraph"
+  end)
+  assert(item, "no bare-caret named-note block completion found")
+  accept_completion(item)
+
+  local target_line = vim.iter(vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))):find(function(line)
+    return vim.startswith(line, "A second named needle paragraph")
+  end)
+  assert(target_line, "bare-caret named-note target paragraph disappeared")
+  local block_id = target_line:match "(%^[0-9a-f]+)$"
+  assert(block_id, "bare-caret named-note target has no generated block ID")
+  eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["searches and displays existing block IDs"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^quote-of-the-day",
+    ["target.md"] = "Unrelated content ^quote-of-the-day",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 20 })
+
+  local result = run_completion(0, 20)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.label == "Unrelated content ^quote-of-the-day — target"
+  end)
+  assert(item, "existing block ID was not searchable and visible")
+  eq(nil, item.command)
+  eq("[[target#^quote-of-the-day]]", item.textEdit.newText)
+end
+
 T["completion"]["creates a current-note block reference from a bare caret trigger"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "A local paragraph\n\n[[^",
@@ -418,7 +512,7 @@ T["completion"]["reuses a whole-list block ID"] = function()
 
   local result = run_completion(0, 16)
   local item = vim.iter(result.items or {}):find(function(candidate)
-    return candidate.label == "- Alpha manual - Beta manual — target"
+    return candidate.label == "- Alpha manual - Beta manual ^whole-list — target"
   end)
   assert(item, "no existing whole-list completion found")
   eq(nil, item.command)
@@ -492,7 +586,7 @@ T["completion"]["reuses an existing block ID"] = function()
 
   local result = run_completion(0, 17)
   local item = vim.iter(result.items or {}):find(function(candidate)
-    return candidate.label == "A manual needle — target"
+    return candidate.label == "A manual needle ^manual — target"
   end)
   assert(item, "no existing block completion found")
   eq(nil, item.command)

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -364,7 +364,7 @@ T["completion"]["adds a multiline list-item ID on an indented line"] = function(
 
   local result = run_completion(0, 13)
   local item = vim.iter(result.items or {}):find(function(candidate)
-    return candidate.command and candidate.label:find("Paperclip", 1, true)
+    return candidate.command and candidate.label == "- Gemmy $$Paperclip / Pen$$ — target"
   end)
   assert(item, "no multiline list-item completion found")
   eq("- Gemmy $$Paperclip / Pen$$ — target", item.label)
@@ -379,6 +379,50 @@ T["completion"]["adds a multiline list-item ID on an indented line"] = function(
   assert(block_id, "multiline list-item ID is not on an indented line")
   eq("- Unhelpful assistant", lines[content_line + 2])
   eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["creates a reference to a whole list"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^Alpha whole",
+    ["target.md"] = "- Alpha whole\n- Beta whole",
+  })
+
+  child.cmd "set hidden"
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "target.md"))
+  local target_bufnr = child.api.nvim_get_current_buf()
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 15 })
+
+  local result = run_completion(0, 15)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "- Alpha whole - Beta whole — target"
+  end)
+  assert(item, "no whole-list completion found")
+  accept_completion(item)
+
+  local lines = child.api.nvim_buf_get_lines(target_bufnr, 0, -1, false)
+  local block_id = lines[4] and lines[4]:match "^%^[0-9a-f]+$"
+  assert(block_id, "whole-list ID is not surrounded by blank lines")
+  eq({ "- Alpha whole", "- Beta whole", "", block_id, "" }, lines)
+  eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["reuses a whole-list block ID"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^Alpha manual",
+    ["target.md"] = "- Alpha manual\n- Beta manual\n\n^whole-list",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 16 })
+
+  local result = run_completion(0, 16)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.label == "- Alpha manual - Beta manual — target"
+  end)
+  assert(item, "no existing whole-list completion found")
+  eq(nil, item.command)
+  eq("[[target#^whole-list]]", item.textEdit.newText)
 end
 
 T["completion"]["keeps the cursor on a same-note link after multiline list-item ID insertion"] = function()
@@ -418,6 +462,23 @@ T["completion"]["separates quotations from preceding list items"] = function()
   end)
   assert(item, "no quotation completion found after list")
   eq("> quoted target > continuation — target", item.label)
+end
+
+T["completion"]["keeps lazy continuation lines inside quotations"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^lazy continuation",
+    ["target.md"] = "> quoted start\nlazy continuation",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 21 })
+
+  local result = run_completion(0, 21)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.label:find("lazy continuation", 1, true)
+  end)
+  assert(item, "no lazy quotation completion found")
+  eq("> quoted start lazy continuation — target", item.label)
 end
 
 T["completion"]["reuses an existing block ID"] = function()
@@ -471,7 +532,7 @@ end
 T["completion"]["separates callouts from paragraphs and surrounds their IDs with blank lines"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "[[^^Callout body",
-    ["target.md"] = "A plain paragraph\n> [!note] Quoted target\n> Callout body\nA trailing paragraph",
+    ["target.md"] = "A plain paragraph\n> [!note] Quoted target\n> Callout body\n\nA trailing paragraph",
   })
 
   child.cmd "set hidden"
@@ -550,6 +611,27 @@ T["completion"]["separates tables from adjacent paragraphs"] = function()
   assert(block_id, "paragraph after table did not receive an inline ID")
   eq("A plain target " .. block_id, target_line)
   eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["keeps list-like rows inside tables"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^foo",
+    ["target.md"] = "Name | Value\n--- | ---\n- foo | bar",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 7 })
+
+  local result = run_completion(0, 7)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Name | Value --- | --- - foo | bar — target"
+    end),
+    "no complete table candidate found"
+  )
+  assert(not vim.iter(result.items or {}):any(function(candidate)
+    return candidate.label == "- foo | bar — target"
+  end), "table row was exposed as a list-item candidate")
 end
 
 T["completion"]["updates a loaded unsaved target without overwriting it"] = function()

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -22,6 +22,16 @@ local function run_completion(line, character)
   )
 end
 
+local function accept_completion(item)
+  child.lua(([[
+    local item = %s
+    vim.lsp.util.apply_text_edits({ item.textEdit }, vim.api.nvim_get_current_buf(), "utf-8")
+    if item.command then
+      require("obsidian.actions").block_reference_new(unpack(item.command.arguments))
+    end
+  ]]):format(vim.inspect(item)))
+end
+
 T["refs"] = MiniTest.new_set()
 
 T["refs"]["can_complete should handle wiki links with text"] = function()
@@ -265,6 +275,173 @@ Target note content
     end
   end
   eq(true, found)
+end
+
+T["completion"]["creates a vault-wide block reference from unlabeled content"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^needle",
+    ["target.md"] = "A needle paragraph",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 10 })
+
+  local result = run_completion(0, 10)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.command.command == "obsidian.block_reference_new"
+  end)
+  assert(item, "no unlabeled block completion found")
+
+  accept_completion(item)
+
+  local target_line = vim.iter(vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))):find(function(line)
+    return vim.startswith(line, "A needle paragraph")
+  end)
+  assert(target_line, "target paragraph disappeared")
+  local block_id = target_line:match "(%^[0-9a-f]+)$"
+  assert(block_id, "target paragraph has no generated block ID")
+  eq("A needle paragraph " .. block_id, target_line)
+  eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["creates a current-note block reference from a bare caret trigger"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "A local paragraph\n\n[[^",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 3, 3 })
+
+  local result = run_completion(2, 3)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.command.command == "obsidian.block_reference_new"
+  end)
+  assert(item, "no current-note block completion found")
+  accept_completion(item)
+
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  local block_id = lines[1]:match "(%^[0-9a-f]+)$"
+  assert(block_id, "local paragraph has no generated block ID")
+  eq("A local paragraph " .. block_id, lines[1])
+  eq("[[#" .. block_id .. "]]", lines[3])
+end
+
+T["completion"]["adds a block ID to the selected list item"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^first item",
+    ["target.md"] = "- first item\n- second item",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 14 })
+
+  local result = run_completion(0, 14)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "- first item — target"
+  end)
+  assert(item, "no first-list-item completion found")
+  accept_completion(item)
+
+  local lines = vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))
+  local first_item = vim.iter(lines):find(function(line)
+    return vim.startswith(line, "- first item")
+  end)
+  assert(first_item and first_item:match " %^[0-9a-f]+$", "selected list item has no block ID")
+  eq("- second item", lines[#lines])
+end
+
+T["completion"]["reuses an existing block ID"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^manual needle",
+    ["target.md"] = "A manual needle ^manual",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 17 })
+
+  local result = run_completion(0, 17)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.label == "A manual needle — target"
+  end)
+  assert(item, "no existing block completion found")
+  eq(nil, item.command)
+  eq("[[target#^manual]]", item.textEdit.newText)
+  accept_completion(item)
+
+  eq("[[target#^manual]]", child.api.nvim_get_current_line())
+  eq("A manual needle ^manual", vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))[1])
+end
+
+T["completion"]["places a blockquote ID on its own line"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^quoted",
+    ["target.md"] = "> quoted first\n> quoted second",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 10 })
+
+  local result = run_completion(0, 10)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label:find("quoted first", 1, true)
+  end)
+  assert(item, "no blockquote completion found")
+  accept_completion(item)
+
+  local lines = vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))
+  local second = vim.iter(lines):enumerate():find(function(_, line)
+    return line == "> quoted second"
+  end)
+  assert(second, "quoted block disappeared")
+  assert(lines[second + 1]:match "^%^[0-9a-f]+$", "blockquote ID is not standalone")
+end
+
+T["completion"]["updates a loaded unsaved target without overwriting it"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^needle",
+    ["target.md"] = "Old needle paragraph",
+  })
+
+  child.cmd "set hidden"
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "target.md"))
+  local target_bufnr = child.api.nvim_get_current_buf()
+  child.api.nvim_buf_set_lines(target_bufnr, 0, 1, false, { "Unsaved needle paragraph" })
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 10 })
+
+  local result = run_completion(0, 10)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "Unsaved needle paragraph — target"
+  end)
+  assert(item, "completion ignored the loaded target buffer")
+  accept_completion(item)
+
+  local target_line = child.api.nvim_buf_get_lines(target_bufnr, 0, 1, false)[1]
+  assert(target_line:match "^Unsaved needle paragraph %^[0-9a-f]+$", "unsaved target was not updated")
+  eq(true, child.api.nvim_get_option_value("modified", { buf = target_bufnr }))
+  eq("Old needle paragraph", vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))[1])
+end
+
+T["completion"]["does not create a dangling link when the target changes"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^needle",
+    ["target.md"] = "A needle paragraph",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 10 })
+
+  local result = run_completion(0, 10)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.command.command == "obsidian.block_reference_new"
+  end)
+  assert(item, "no unlabeled block completion found")
+
+  vim.fn.writefile({ "Changed needle paragraph" }, tostring(child.Obsidian.dir / "target.md"))
+  accept_completion(item)
+
+  eq("[[^^needle", child.api.nvim_get_current_line())
+  eq("Changed needle paragraph", vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))[1])
 end
 
 T["completion"]["returns items for tag trigger"] = function()

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -353,6 +353,73 @@ T["completion"]["adds a block ID to the selected list item"] = function()
   eq("- second item", lines[#lines])
 end
 
+T["completion"]["adds a multiline list-item ID on an indented line"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^Paperclip",
+    ["target.md"] = "- Gemmy\n    $$Paperclip / Pen$$\n- Unhelpful assistant",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 13 })
+
+  local result = run_completion(0, 13)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label:find("Paperclip", 1, true)
+  end)
+  assert(item, "no multiline list-item completion found")
+  eq("- Gemmy $$Paperclip / Pen$$ — target", item.label)
+  accept_completion(item)
+
+  local lines = vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))
+  local content_line = vim.iter(lines):enumerate():find(function(_, line)
+    return line == "    $$Paperclip / Pen$$"
+  end)
+  assert(content_line, "list-item continuation disappeared")
+  local block_id = lines[content_line + 1]:match "^    (%^[0-9a-f]+)$"
+  assert(block_id, "multiline list-item ID is not on an indented line")
+  eq("- Unhelpful assistant", lines[content_line + 2])
+  eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["keeps the cursor on a same-note link after multiline list-item ID insertion"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "- Gemmy\n    $$Paperclip / Pen$$\n\n[[^Paperclip",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 4, 12 })
+
+  local result = run_completion(3, 12)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label:find("Paperclip", 1, true)
+  end)
+  assert(item, "no current-note multiline list-item completion found")
+  accept_completion(item)
+
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  local block_id = lines[3]:match "^    (%^[0-9a-f]+)$"
+  assert(block_id, "same-note list item has no indented block ID")
+  eq("[[#" .. block_id .. "]]", lines[5])
+  eq({ 5, #lines[5] - 1 }, child.api.nvim_win_get_cursor(0))
+end
+
+T["completion"]["separates quotations from preceding list items"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^quoted target",
+    ["target.md"] = "- list item\n> quoted target\n> continuation",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 17 })
+
+  local result = run_completion(0, 17)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label:find("quoted target", 1, true)
+  end)
+  assert(item, "no quotation completion found after list")
+  eq("> quoted target > continuation — target", item.label)
+end
+
 T["completion"]["reuses an existing block ID"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "[[^^manual needle",
@@ -389,6 +456,7 @@ T["completion"]["places a blockquote ID on its own line"] = function()
     return candidate.command and candidate.label:find("quoted first", 1, true)
   end)
   assert(item, "no blockquote completion found")
+  eq("> quoted first > quoted second — target", item.label)
   accept_completion(item)
 
   local lines = vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))
@@ -396,7 +464,38 @@ T["completion"]["places a blockquote ID on its own line"] = function()
     return line == "> quoted second"
   end)
   assert(second, "quoted block disappeared")
-  assert(lines[second + 1]:match "^%^[0-9a-f]+$", "blockquote ID is not standalone")
+  eq("", lines[second + 1])
+  assert(lines[second + 2]:match "^%^[0-9a-f]+$", "blockquote ID is not standalone")
+end
+
+T["completion"]["separates callouts from paragraphs and surrounds their IDs with blank lines"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^Callout body",
+    ["target.md"] = "A plain paragraph\n> [!note] Quoted target\n> Callout body\nA trailing paragraph",
+  })
+
+  child.cmd "set hidden"
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "target.md"))
+  local target_bufnr = child.api.nvim_get_current_buf()
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 16 })
+
+  local result = run_completion(0, 16)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label:find("Callout body", 1, true)
+  end)
+  assert(item, "no callout completion found")
+  eq("> [!note] Quoted target > Callout body — target", item.label)
+  accept_completion(item)
+
+  local lines = child.api.nvim_buf_get_lines(target_bufnr, 0, -1, false)
+  local block_id = lines[5] and lines[5]:match "^%^[0-9a-f]+$"
+  assert(block_id, "callout ID is not surrounded by blank lines")
+  eq(
+    { "A plain paragraph", "> [!note] Quoted target", "> Callout body", "", block_id, "", "A trailing paragraph" },
+    lines
+  )
+  eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
 end
 
 T["completion"]["places a table ID on its own line"] = function()
@@ -413,6 +512,7 @@ T["completion"]["places a table ID on its own line"] = function()
     return candidate.command and candidate.label:find("Key | Value", 1, true)
   end)
   assert(item, "no table completion found")
+  eq("Key | Value --- | --- One | Two — target", item.label)
   accept_completion(item)
 
   local lines = vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))
@@ -420,7 +520,36 @@ T["completion"]["places a table ID on its own line"] = function()
     return line == "One | Two"
   end)
   assert(last_row, "table disappeared")
-  assert(lines[last_row + 1]:match "^%^[0-9a-f]+$", "table ID is not standalone")
+  eq("", lines[last_row + 1])
+  assert(lines[last_row + 2]:match "^%^[0-9a-f]+$", "table ID is not standalone")
+end
+
+T["completion"]["separates tables from adjacent paragraphs"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^plain target",
+    ["target.md"] = "Key | Value\n--- | ---\nOne | Two\nA plain target",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 16 })
+
+  local result = run_completion(0, 16)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label:find("plain target", 1, true)
+  end)
+  assert(item, "no paragraph completion found after table")
+  eq("A plain target — target", item.label)
+  accept_completion(item)
+
+  local lines = vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))
+  local target_line = vim.iter(lines):find(function(line)
+    return vim.startswith(line, "A plain target")
+  end)
+  assert(target_line, "paragraph after table disappeared")
+  local block_id = target_line:match "(%^[0-9a-f]+)$"
+  assert(block_id, "paragraph after table did not receive an inline ID")
+  eq("A plain target " .. block_id, target_line)
+  eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
 end
 
 T["completion"]["updates a loaded unsaved target without overwriting it"] = function()

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -346,6 +346,12 @@ T["completion"]["creates a named-note block reference from unlabeled content aft
     return candidate.command and candidate.label == "A named needle paragraph"
   end)
   assert(item, "no named-note unlabeled block completion found")
+  assert(
+    vim.iter(vim.lsp.completion._lsp_to_complete_items(result, "[[target#^needle")):any(function(candidate)
+      return candidate.abbr == item.label
+    end),
+    "Neovim filtered out the named-note block completion"
+  )
   accept_completion(item)
 
   local target_line = vim.iter(vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))):find(function(line)
@@ -372,6 +378,12 @@ T["completion"]["creates a named-note block reference from unlabeled content aft
     return candidate.command and candidate.label == "A second named needle paragraph"
   end)
   assert(item, "no bare-caret named-note block completion found")
+  assert(
+    vim.iter(vim.lsp.completion._lsp_to_complete_items(result, "[[target^named needle")):any(function(candidate)
+      return candidate.abbr == item.label
+    end),
+    "Neovim filtered out the bare-caret named-note block completion"
+  )
   accept_completion(item)
 
   local target_line = vim.iter(vim.fn.readfile(tostring(child.Obsidian.dir / "target.md"))):find(function(line)

--- a/tests/test_section.lua
+++ b/tests/test_section.lua
@@ -45,6 +45,20 @@ T["blocks attach to heading and paragraph sections"] = function()
   eq(blocks["^para"].section, blocks["^standalone"].section)
 end
 
+T["block candidates split adjacent list items"] = function()
+  local _, _, candidates = Section.parse({
+    "A paragraph ^existing",
+    "",
+    "- first item",
+    "- second item",
+  }, { collect_block_candidates = true })
+
+  eq(3, #candidates)
+  eq({ start_row = 0, start_col = 0, end_row = 1, end_col = 0 }, candidates[1].range)
+  eq({ start_row = 2, start_col = 0, end_row = 3, end_col = 0 }, candidates[2].range)
+  eq({ start_row = 3, start_col = 0, end_row = 4, end_col = 0 }, candidates[3].range)
+end
+
 T["full ranges include nested descendants only"] = function()
   local sections = Section.parse {
     "# H1",

--- a/tests/test_section.lua
+++ b/tests/test_section.lua
@@ -45,7 +45,7 @@ T["blocks attach to heading and paragraph sections"] = function()
   eq(blocks["^para"].section, blocks["^standalone"].section)
 end
 
-T["block candidates split adjacent list items"] = function()
+T["block candidates include whole lists and split adjacent list items"] = function()
   local _, _, candidates = Section.parse({
     "A paragraph ^existing",
     "",
@@ -53,10 +53,14 @@ T["block candidates split adjacent list items"] = function()
     "- second item",
   }, { collect_block_candidates = true })
 
-  eq(3, #candidates)
+  eq(4, #candidates)
   eq({ start_row = 0, start_col = 0, end_row = 1, end_col = 0 }, candidates[1].range)
-  eq({ start_row = 2, start_col = 0, end_row = 3, end_col = 0 }, candidates[2].range)
-  eq({ start_row = 3, start_col = 0, end_row = 4, end_col = 0 }, candidates[3].range)
+  eq("list", candidates[2].block_type)
+  eq({ start_row = 2, start_col = 0, end_row = 4, end_col = 0 }, candidates[2].range)
+  eq("list-item", candidates[3].block_type)
+  eq({ start_row = 2, start_col = 0, end_row = 3, end_col = 0 }, candidates[3].range)
+  eq("list-item", candidates[4].block_type)
+  eq({ start_row = 3, start_col = 0, end_row = 4, end_col = 0 }, candidates[4].range)
 end
 
 T["full ranges include nested descendants only"] = function()


### PR DESCRIPTION
# Obsidian-style block reference completion

Related to #505 and #749.

This implements the block-completion portions of those broader trackers, including vault-wide `[[^^block]]`. It does not fully resolve or close either issue.

## What does the PR do?

Adds Obsidian-compatible block search to LSP completion:

- `[[^query` searches the current note.
- `[[^^query` searches the vault.
- `[[note^query` and `[[note#^query` search a named note.
- Existing block IDs are searchable, displayed, and reused.
- Unlabeled blocks are shown with content previews and receive a collision-safe ID when selected.
- Block embeds preserve the leading `!`.

Generated IDs follow Obsidian's documented placement rules:

- Paragraphs and single-line list items receive an inline ID.
- Multiline list items receive an indented ID line.
- Whole lists, block quotes, callouts, and tables receive a separate ID line surrounded by blank lines.

Acceptance verifies that both the completion placeholder and target note are still current. Loaded target buffers are updated in memory without overwriting unsaved edits. Unloaded targets are saved before the source link is finalized, preventing dangling links when an update fails.

The implementation extends the existing `Section` parser for candidate boundaries and uses the existing link-formatting, preview, LSP-command, and action-dispatch paths.

Vault-wide heading completion (`[[##query`) remains separate and is tracked by #320.

## Screenshots

N/A — the completion menu is rendered by the user's selected completion client. Native Neovim completion visibility and acceptance are covered by regression tests and manual testing.

## Testing

- Full MiniTest suite: `TZ=UTC make test` — 768 cases, 61 groups, 0 failures.
- Focused completion suite: 45/45 passed.
- StyLua and Selene checks passed.
- EmmyLua reported no diagnostics in touched files; eight existing diagnostics remain elsewhere.
- `git diff --check` passed.
- Manually tested native Neovim LSP completion and acceptance for current-note, named-note, vault-wide, embed, structured-block, and unsaved-buffer workflows.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md](https://github.com/obsidian-nvim/obsidian.nvim/blob/main/CONTRIBUTING.md) file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (for style, lint, types, and tests)
