### PR TITLE
fix(completion): preserve anchor case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Named-note heading completion now preserves the heading's original case and spelling in wiki links.
 - Fzf-lua picker selections now honor multi-select consistently across files, grep, and list pickers.
 - Picker will apply `format_item` consistently.
 - Cache will be triggered by buffer writes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Named-note heading completion now preserves the heading's original case and spelling in wiki links.
 - No `Note.create` interrupt calls in completion.
 - `:Obsidian sync log` opens real obsidian-headless cli logs.
 - YAML frontmatter dumping now quotes ambiguous string values and safely handles backslashes and single quotes.

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -6,6 +6,7 @@ local search = require "obsidian.search"
 
 ---@class obsidian.completion.sources.refs.options
 ---@field label string|?
+---@field display_label string|?
 ---@field new_text string
 ---@field sort_text string|?
 ---@field documentation table|?
@@ -140,6 +141,29 @@ local function format_current_block_link(block)
     return Obsidian.opts.link.style { label = "", path = "", block = block }
   end
   error "not implemented"
+end
+
+---Use the headings' original spelling in wiki-link completion while retaining
+---nested anchor paths when the selected anchor includes them.
+---@param anchor obsidian.note.HeaderAnchor|?
+---@return obsidian.note.HeaderAnchor|?
+local function wiki_completion_anchor(anchor)
+  if not anchor or Obsidian.opts.link.style ~= "wiki" then
+    return anchor
+  end
+
+  local headers = { anchor.header }
+  if anchor.anchor:find("#", 2, true) then
+    local parent = anchor.parent
+    while parent do
+      table.insert(headers, 1, parent.header)
+      parent = parent.parent
+    end
+  end
+
+  local formatted = vim.tbl_extend("force", anchor, { anchor = "#" .. table.concat(headers, "#") })
+  ---@cast formatted obsidian.note.HeaderAnchor
+  return formatted
 end
 
 ---@param request obsidian.completion.Request
@@ -382,15 +406,21 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
 
   -- De-duplicate options relative to their `new_text`.
   for _, option in ipairs(new_options) do
-    local final_label, sort_text, new_text, documentation
+    local final_label, display_label, sort_text, new_text, documentation
+    local formatted_anchor = wiki_completion_anchor(option.anchor)
     if option.label then
-      new_text = note:format_link { label = option.label, anchor = option.anchor, block = option.block }
+      new_text = note:format_link { label = option.label, anchor = formatted_anchor, block = option.block }
 
       final_label = option.alt_label or option.label
+      display_label = final_label
       if option.anchor then
         final_label = final_label .. option.anchor.anchor
+        local display_anchor = assert(formatted_anchor, "formatted heading anchor is required")
+        display_label = display_label
+          .. (Obsidian.opts.link.style == "wiki" and display_anchor.anchor or "#" .. option.anchor.header)
       elseif option.block then
         final_label = final_label .. "#" .. option.block.id
+        display_label = final_label
       end
       sort_text = final_label
 
@@ -415,6 +445,7 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
       end
 
       final_label = option.anchor.anchor
+      display_label = "#" .. option.anchor.header
       sort_text = final_label
 
       documentation = {
@@ -426,6 +457,7 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
       new_text = format_current_block_link(option.block)
 
       final_label = "#" .. option.block.id
+      display_label = final_label
       sort_text = final_label
 
       documentation = {
@@ -464,12 +496,13 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
         local cur_new_text = note:format_link {
           label = final_label,
           format = resolve_link_format,
-          anchor = option.anchor,
+          anchor = formatted_anchor,
           block = option.block,
         }
         if not cc.new_text_to_option[cur_new_text] then
           cc.new_text_to_option[cur_new_text] = {
             label = final_label,
+            display_label = display_label,
             new_text = cur_new_text,
             sort_text = sort_text,
             documentation = documentation,
@@ -481,11 +514,12 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
     else
       cc.new_text_to_option[new_text] = {
         label = final_label,
+        display_label = display_label,
         new_text = new_text,
         sort_text = sort_text,
         documentation = documentation,
         note = option.label and note or nil,
-        anchor = option.anchor,
+        anchor = formatted_anchor,
         block = option.block,
       }
     end
@@ -533,8 +567,8 @@ local function process_search_results(cc, results)
   end
 
   for _, option in pairs(cc.new_text_to_option) do
-    -- TODO: need a better label, maybe just the note's display name?
-    local option_label = option.label or ""
+    local option_label = option.display_label or option.label or ""
+    local filter_label = option.label or option_label
     ---@type string
     local label
     if Obsidian.opts.link.style == "wiki" then
@@ -550,7 +584,7 @@ local function process_search_results(cc, results)
     table.insert(completion_items, {
       documentation = option.documentation,
       sortText = option.sort_text,
-      filterText = completion.get_filter_text(option_label),
+      filterText = completion.get_filter_text(filter_label),
       label = label,
       kind = vim.lsp.protocol.CompletionItemKind.Reference,
       textEdit = {

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -7,6 +7,7 @@ local cache = require "obsidian.cache"
 
 ---@class obsidian.completion.sources.refs.options
 ---@field label string|?
+---@field display_label string|?
 ---@field new_text string
 ---@field sort_text string|?
 ---@field documentation table|?
@@ -145,6 +146,29 @@ local function format_current_block_link(block)
     return Obsidian.opts.link.style { label = "", path = "", block = block }
   end
   error "not implemented"
+end
+
+---Use the headings' original spelling in wiki-link completion while retaining
+---nested anchor paths when the selected anchor includes them.
+---@param anchor obsidian.note.HeaderAnchor|?
+---@return obsidian.note.HeaderAnchor|?
+local function wiki_completion_anchor(anchor)
+  if not anchor or Obsidian.opts.link.style ~= "wiki" then
+    return anchor
+  end
+
+  local headers = { anchor.header }
+  if anchor.anchor:find("#", 2, true) then
+    local parent = anchor.parent
+    while parent do
+      table.insert(headers, 1, parent.header)
+      parent = parent.parent
+    end
+  end
+
+  local formatted = vim.tbl_extend("force", anchor, { anchor = "#" .. table.concat(headers, "#") })
+  ---@cast formatted obsidian.note.HeaderAnchor
+  return formatted
 end
 
 ---@param request obsidian.completion.Request
@@ -566,15 +590,21 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
 
   -- De-duplicate options relative to their `new_text`.
   for _, option in ipairs(new_options) do
-    local final_label, sort_text, new_text, documentation
+    local final_label, display_label, sort_text, new_text, documentation
+    local formatted_anchor = wiki_completion_anchor(option.anchor)
     if option.label then
-      new_text = note:format_link { label = option.label, anchor = option.anchor, block = option.block }
+      new_text = note:format_link { label = option.label, anchor = formatted_anchor, block = option.block }
 
       final_label = option.alt_label or option.label
+      display_label = final_label
       if option.anchor then
         final_label = final_label .. option.anchor.anchor
+        local display_anchor = assert(formatted_anchor, "formatted heading anchor is required")
+        display_label = display_label
+          .. (Obsidian.opts.link.style == "wiki" and display_anchor.anchor or "#" .. option.anchor.header)
       elseif option.block then
         final_label = final_label .. "#" .. option.block.id
+        display_label = final_label
       end
       sort_text = final_label
 
@@ -599,6 +629,7 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
       end
 
       final_label = option.anchor.anchor
+      display_label = "#" .. option.anchor.header
       sort_text = final_label
 
       documentation = {
@@ -610,6 +641,7 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
       new_text = format_current_block_link(option.block)
 
       final_label = "#" .. option.block.id
+      display_label = final_label
       sort_text = final_label
 
       documentation = {
@@ -648,12 +680,13 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
         local cur_new_text = note:format_link {
           label = final_label,
           format = resolve_link_format,
-          anchor = option.anchor,
+          anchor = formatted_anchor,
           block = option.block,
         }
         if not cc.new_text_to_option[cur_new_text] then
           cc.new_text_to_option[cur_new_text] = {
             label = final_label,
+            display_label = display_label,
             new_text = cur_new_text,
             sort_text = sort_text,
             documentation = documentation,
@@ -665,11 +698,12 @@ local function update_completion_options(cc, label, alt_label, matching_anchors,
     else
       cc.new_text_to_option[new_text] = {
         label = final_label,
+        display_label = display_label,
         new_text = new_text,
         sort_text = sort_text,
         documentation = documentation,
         note = option.label and note or nil,
-        anchor = option.anchor,
+        anchor = formatted_anchor,
         block = option.block,
       }
     end
@@ -717,8 +751,8 @@ local function process_search_results(cc, results)
   end
 
   for _, option in pairs(cc.new_text_to_option) do
-    -- TODO: need a better label, maybe just the note's display name?
-    local option_label = option.label or ""
+    local option_label = option.display_label or option.label or ""
+    local filter_label = option.label or option_label
     ---@type string
     local label
     if Obsidian.opts.link.style == "wiki" then
@@ -734,7 +768,7 @@ local function process_search_results(cc, results)
     table.insert(completion_items, {
       documentation = option.documentation,
       sortText = option.sort_text,
-      filterText = completion.get_filter_text(option_label),
+      filterText = completion.get_filter_text(filter_label),
       label = label,
       kind = vim.lsp.protocol.CompletionItemKind.Reference,
       textEdit = {

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -166,6 +166,14 @@ local function wiki_completion_anchor(anchor)
     end
   end
 
+  -- These characters are parsed as wiki-link syntax rather than heading text.
+  -- Keep the normalized anchor when the original spelling cannot be represented safely.
+  for _, header in ipairs(headers) do
+    if header:find "[|%[%]]" or vim.startswith(header, "^") then
+      return anchor
+    end
+  end
+
   local formatted = vim.tbl_extend("force", anchor, { anchor = "#" .. table.concat(headers, "#") })
   ---@cast formatted obsidian.note.HeaderAnchor
   return formatted

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -530,6 +530,24 @@ T["completion"]["preserves nested heading case in named-note wiki links"] = func
   eq("[[target#Parent Heading#Child Heading]]", item.label)
 end
 
+T["completion"]["uses normalized wiki anchors when heading text contains link syntax"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[target#http",
+    ["target.md"] = "# HTTP | API",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 13 })
+
+  local result = run_completion(0, 13)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.textEdit and candidate.textEdit.newText == "[[target#http--api]]"
+  end)
+
+  assert(item, "no syntax-safe heading completion found")
+  eq("[[target#http--api]]", item.label)
+end
+
 T["completion"]["creates a vault-wide block reference from unlabeled content"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "[[^^needle",

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -277,6 +277,59 @@ Target note content
   eq(true, found)
 end
 
+T["completion"]["preserves heading case in current-note wiki-link labels"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "# HTTP API Guide\n\n[[#http",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 3, 7 })
+
+  local result = run_completion(2, 7)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.textEdit and candidate.textEdit.newText == "[[#HTTP API Guide]]"
+  end)
+
+  assert(item, "no case-preserving current-note heading completion found")
+  eq("[[#HTTP API Guide]]", item.label)
+end
+
+T["completion"]["preserves heading case in named-note wiki links"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[target#http",
+    ["target.md"] = "# HTTP API Guide",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 14 })
+
+  local result = run_completion(0, 14)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.textEdit and candidate.textEdit.newText == "[[target#HTTP API Guide]]"
+  end)
+
+  assert(item, "no case-preserving heading completion found")
+  eq("[[target#HTTP API Guide]]", item.label)
+end
+
+T["completion"]["preserves nested heading case in named-note wiki links"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[target#parent-heading#chi",
+    ["target.md"] = "# Parent Heading\n\n## Child Heading",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 27 })
+
+  local result = run_completion(0, 27)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.textEdit and candidate.textEdit.newText == "[[target#Parent Heading#Child Heading]]"
+  end)
+
+  assert(item, "no case-preserving nested heading completion found")
+  eq("[[target#Parent Heading#Child Heading]]", item.label)
+end
+
 T["completion"]["creates a vault-wide block reference from unlabeled content"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "[[^^needle",

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -477,6 +477,59 @@ T["completion"]["vault heading completion honors markdown link style"] = functio
   eq("[target ❯ HTTP API Guide](target.md#http-api-guide)", item.textEdit.newText)
 end
 
+T["completion"]["preserves heading case in current-note wiki-link labels"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "# HTTP API Guide\n\n[[#http",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 3, 7 })
+
+  local result = run_completion(2, 7)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.textEdit and candidate.textEdit.newText == "[[#HTTP API Guide]]"
+  end)
+
+  assert(item, "no case-preserving current-note heading completion found")
+  eq("[[#HTTP API Guide]]", item.label)
+end
+
+T["completion"]["preserves heading case in named-note wiki links"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[target#http",
+    ["target.md"] = "# HTTP API Guide",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 14 })
+
+  local result = run_completion(0, 14)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.textEdit and candidate.textEdit.newText == "[[target#HTTP API Guide]]"
+  end)
+
+  assert(item, "no case-preserving heading completion found")
+  eq("[[target#HTTP API Guide]]", item.label)
+end
+
+T["completion"]["preserves nested heading case in named-note wiki links"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[target#parent-heading#chi",
+    ["target.md"] = "# Parent Heading\n\n## Child Heading",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 27 })
+
+  local result = run_completion(0, 27)
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.textEdit and candidate.textEdit.newText == "[[target#Parent Heading#Child Heading]]"
+  end)
+
+  assert(item, "no case-preserving nested heading completion found")
+  eq("[[target#Parent Heading#Child Heading]]", item.label)
+end
+
 T["completion"]["creates a vault-wide block reference from unlabeled content"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "[[^^needle",


### PR DESCRIPTION
keep with obsidian app behavior, `[[#Heading One]]` instead of `[[#heading-one]]`
#505 
