### PR TITLE
perf(completion): cache vault-wide block index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Vault-wide block completion reuses an in-memory block index until the vault changes instead of searching on every keystroke.
+- Vault-wide block completion reuses an in-memory candidate index, coalesces overlapping requests, and honors `completion.min_chars`.
 - **Breaking:** `find_files`, `find_notes`, `grep`, and `grep_notes` callbacks now receive a list of selected results. Multiple results use the quickfix list by default.
 - Deprecate old `picker.pick`, internally use `picker.select` with better multi-select and preview_item support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Vault-wide block completion reuses an in-memory candidate index, coalesces overlapping requests, and honors `completion.min_chars`.
+- Vault-wide block completion reuses an in-memory candidate index, updates only affected notes after watched-file changes, coalesces overlapping requests, and honors `completion.min_chars`.
 - **Breaking:** `find_files`, `find_notes`, `grep`, and `grep_notes` callbacks now receive a list of selected results. Multiple results use the quickfix list by default.
 - Deprecate old `picker.pick`, internally use `picker.select` with better multi-select and preview_item support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Vault-wide block completion reuses an in-memory block index until the vault changes instead of searching on every keystroke.
 - **Breaking:** `find_files`, `find_notes`, `grep`, and `grep_notes` callbacks now receive a list of selected results. Multiple results use the quickfix list by default.
 - Deprecate old `picker.pick`, internally use `picker.select` with better multi-select and preview_item support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Vault-wide block completion reuses an in-memory block index until the vault changes instead of searching on every keystroke.
 - **Breaking:** `find_files`, `find_notes`, `grep`, and `grep_notes` callbacks now receive a list of selected results. Multiple results use the quickfix list by default.
 - Deprecate old `picker.pick`, internally use `picker.select` with better multi-select and preview_item support.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The original project has not been actively maintained for quite a while and with
 
 ▶️ **Completion:** Ultra-fast, asynchronous autocompletion for note references and tags via in-process LSP (triggered by typing `[[` for wiki and markdown links, `#` for tags, `[^` for footnotes). Use `[[^query` for the current note, `[[note^query` or `[[note#^query` for a named note, and `[[^^query` across the vault; unlabeled blocks receive an ID when selected.
 
+Vault-wide block candidates are indexed in memory on first use and rebuilt when note files change.
+
 🏃 **Navigation:** Navigate throughout your vault via links, backlinks, tags and etc.
 
 📷 **Images:** Paste images into notes.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The original project has not been actively maintained for quite a while and with
 
 ▶️ **Completion:** Ultra-fast, asynchronous autocompletion for note references and tags via in-process LSP (triggered by typing `[[` for wiki and markdown links, `#` for tags, `[^` for footnotes). Use `[[##query` to search headings across the vault. For blocks, use `[[^query` for the current note, `[[note^query` or `[[note#^query` for a named note, and `[[^^query` across the vault; unlabeled blocks receive an ID when selected.
 
+Vault-wide block candidates are indexed in memory on first use and rebuilt when note files change.
+
 🏃 **Navigation:** Navigate throughout your vault via links, backlinks, tags and etc.
 
 📷 **Images:** Paste images into notes.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The original project has not been actively maintained for quite a while and with
 
 ▶️ **Completion:** Ultra-fast, asynchronous autocompletion for note references and tags via in-process LSP (triggered by typing `[[` for wiki and markdown links, `#` for tags, `[^` for footnotes). Use `[[##query` to search headings across the vault. For blocks, use `[[^query` for the current note, `[[note^query` or `[[note#^query` for a named note, and `[[^^query` across the vault; unlabeled blocks receive an ID when selected.
 
-Vault-wide block candidates are indexed in memory on first use and rebuilt when note files change. The index starts warming at `[[^^`; completion items appear once the block query reaches `completion.min_chars` (set it to `0` to show candidates for a bare prefix).
+Vault-wide block candidates are indexed in memory on first use and updated per note when watched files change. The index starts warming at `[[^^`; completion items appear once the block query reaches `completion.min_chars` (set it to `0` to show candidates for a bare prefix).
 
 🏃 **Navigation:** Navigate throughout your vault via links, backlinks, tags and etc.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The original project has not been actively maintained for quite a while and with
 
 ▶️ **Completion:** Ultra-fast, asynchronous autocompletion for note references and tags via in-process LSP (triggered by typing `[[` for wiki and markdown links, `#` for tags, `[^` for footnotes). Use `[[##query` to search headings across the vault. For blocks, use `[[^query` for the current note, `[[note^query` or `[[note#^query` for a named note, and `[[^^query` across the vault; unlabeled blocks receive an ID when selected.
 
-Vault-wide block candidates are indexed in memory on first use and rebuilt when note files change.
+Vault-wide block candidates are indexed in memory on first use and rebuilt when note files change. The index starts warming at `[[^^`; completion items appear once the block query reaches `completion.min_chars` (set it to `0` to show candidates for a bare prefix).
 
 🏃 **Navigation:** Navigate throughout your vault via links, backlinks, tags and etc.
 

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -4,6 +4,7 @@ local util = require "obsidian.util"
 local api = require "obsidian.api"
 local search = require "obsidian.search"
 local cache = require "obsidian.cache"
+local ignore = require "obsidian.ignore"
 
 ---@class obsidian.completion.sources.refs.options
 ---@field label string|?
@@ -44,7 +45,10 @@ local ALL_LINES = 2147483647
 ---@field candidates obsidian.completion.sources.refs.block_search_candidate[]|?
 ---@field owners_by_path table<string, obsidian.completion.sources.refs.block_search_owner>|?
 ---@field overlays table<string, obsidian.completion.sources.refs.block_search_owner>
----@field note_count integer
+---@field next_note_idx integer
+---@field note_opts obsidian.note.LoadOpts
+---@field workspace obsidian.Workspace
+---@field ignore_checker Glob|?
 
 ---@class obsidian.completion.sources.refs.block_search_owner
 ---@field note obsidian.Note
@@ -89,16 +93,17 @@ local ALL_LINES = 2147483647
 ---@field dir_key string
 ---@field note_opts obsidian.note.LoadOpts
 
+---@class obsidian.completion.sources.refs.block_file_event
+---@field type integer|string
+---@field path string|?
+---@field old_path string|?
+---@field new_path string|?
+
 ---@type table<string, obsidian.completion.sources.refs.block_search_index>
 local vault_block_search_indexes = {}
 ---@type table<string, obsidian.completion.sources.refs.block_search_request>
 local vault_block_search_pending = {}
 local vault_block_search_generation = 0
-
-require("obsidian.lsp.watchfiles").register_handler(function()
-  vault_block_search_indexes = {}
-  vault_block_search_generation = vault_block_search_generation + 1
-end)
 
 --- Returns whether it's possible to complete the search and sets up the search related variables in cc
 ---@param cc obsidian.completion.sources.refs.context
@@ -458,22 +463,180 @@ local function build_vault_block_owner(note, note_idx)
 end
 
 ---@param index obsidian.completion.sources.refs.block_search_index
+local function rebuild_vault_block_candidates(index)
+  local owners = vim.tbl_values(assert(index.owners_by_path, "vault block index owners are missing"))
+  table.sort(owners, function(a, b)
+    return a.note_idx < b.note_idx
+  end)
+
+  local candidates = {}
+  for _, owner in ipairs(owners) do
+    vim.list_extend(candidates, owner.candidates)
+  end
+  index.candidates = candidates
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
 ---@param notes obsidian.Note[]
 local function build_vault_block_index(index, notes)
-  ---@type obsidian.completion.sources.refs.block_search_candidate[]
-  local candidates = {}
   ---@type table<string, obsidian.completion.sources.refs.block_search_owner>
   local owners_by_path = {}
-  index.candidates = candidates
   index.owners_by_path = owners_by_path
   index.overlays = {}
-  index.note_count = #notes
+  index.next_note_idx = #notes + 1
   for note_idx, note in ipairs(notes) do
     local owner = build_vault_block_owner(note, note_idx)
     owners_by_path[owner.path] = owner
-    vim.list_extend(candidates, owner.candidates)
   end
+  rebuild_vault_block_candidates(index)
 end
+
+---@param path string
+---@return string
+local function normalize_vault_block_path(path)
+  path = vim.fn.resolve(path)
+  return vim.fs.normalize(vim.uv.fs_realpath(path) or path)
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param path string
+---@return boolean
+local function vault_block_path_is_in_index(index, path)
+  return util.is_subpath(path, index.dir)
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param path string
+---@return boolean
+local function vault_block_path_is_indexable(index, path)
+  local stat = vim.uv.fs_stat(path)
+  if not stat or stat.type ~= "file" then
+    return false
+  end
+  if not api.path_is_note(path, index.workspace) then
+    return false
+  end
+  local relative_path = util.relpath(index.dir, path)
+  return relative_path ~= nil and (not index.ignore_checker or not index.ignore_checker:check(relative_path))
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param path string
+---@return integer|? removed_note_idx
+local function remove_vault_block_owner(index, path)
+  local owners_by_path = assert(index.owners_by_path, "vault block index owners are missing")
+  local owner = owners_by_path[path]
+  owners_by_path[path] = nil
+  index.overlays[path] = nil
+  return owner and owner.note_idx or nil
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param path string
+---@param preferred_note_idx integer|?
+---@return boolean changed
+local function refresh_vault_block_owner(index, path, preferred_note_idx)
+  local owners_by_path = assert(index.owners_by_path, "vault block index owners are missing")
+  local old_owner = owners_by_path[path]
+  local note_idx = preferred_note_idx or (old_owner and old_owner.note_idx)
+  index.overlays[path] = nil
+
+  if not vault_block_path_is_indexable(index, path) then
+    owners_by_path[path] = nil
+    return old_owner ~= nil
+  end
+
+  local Note = require "obsidian.note"
+  local ok, note = pcall(Note.from_file, path, index.note_opts)
+  if not ok then
+    owners_by_path[path] = nil
+    return old_owner ~= nil
+  end
+
+  if not note_idx then
+    note_idx = index.next_note_idx
+    index.next_note_idx = index.next_note_idx + 1
+  end
+  local owner = build_vault_block_owner(note, note_idx)
+  if owner.path ~= path then
+    owners_by_path[path] = nil
+    index.overlays[owner.path] = nil
+  end
+  owners_by_path[owner.path] = owner
+  return true
+end
+
+---@param event obsidian.completion.sources.refs.block_file_event
+---@return boolean
+local function vault_block_event_is_deleted(event)
+  return event.type == "deleted" or event.type == vim.lsp.protocol.FileChangeType.Deleted
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param events obsidian.completion.sources.refs.block_file_event[]
+---@return boolean changed
+local function refresh_vault_block_index(index, events)
+  local changed = false
+  for _, event in ipairs(events) do
+    if event.type == "renamed" and event.old_path and event.new_path then
+      local old_path = normalize_vault_block_path(event.old_path)
+      local new_path = normalize_vault_block_path(event.new_path)
+      local note_idx
+      if vault_block_path_is_in_index(index, old_path) then
+        note_idx = remove_vault_block_owner(index, old_path)
+        changed = note_idx ~= nil or changed
+      end
+      if vault_block_path_is_in_index(index, new_path) then
+        changed = refresh_vault_block_owner(index, new_path, note_idx) or changed
+      end
+    elseif event.path then
+      local path = normalize_vault_block_path(event.path)
+      if vault_block_path_is_in_index(index, path) then
+        if vault_block_event_is_deleted(event) then
+          changed = remove_vault_block_owner(index, path) ~= nil or changed
+        else
+          changed = refresh_vault_block_owner(index, path) or changed
+        end
+      end
+    end
+  end
+
+  if changed then
+    rebuild_vault_block_candidates(index)
+  end
+  return changed
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param events obsidian.completion.sources.refs.block_file_event[]
+---@return boolean
+local function vault_block_events_touch_index(index, events)
+  for _, event in ipairs(events) do
+    for _, path in ipairs { event.path, event.old_path, event.new_path } do
+      if path and vault_block_path_is_in_index(index, normalize_vault_block_path(path)) then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+require("obsidian.lsp.watchfiles").register_handler(function(events)
+  local touched = false
+  for dir_key, index in pairs(vault_block_search_indexes) do
+    if vault_block_events_touch_index(index, events) then
+      touched = true
+      if index.candidates and index.owners_by_path then
+        refresh_vault_block_index(index, events)
+      else
+        vault_block_search_indexes[dir_key] = nil
+      end
+    end
+  end
+  if touched then
+    vault_block_search_generation = vault_block_search_generation + 1
+  end
+end)
 
 ---@param index obsidian.completion.sources.refs.block_search_index
 ---@param dir obsidian.Path
@@ -501,7 +664,7 @@ local function vault_block_overlays(index, dir, note_opts)
               max_lines = vim.api.nvim_buf_line_count(bufnr),
             })
             local note = Note.from_buffer(bufnr, opts)
-            owner = build_vault_block_owner(note, base and base.note_idx or index.note_count + overlay_idx)
+            owner = build_vault_block_owner(note, base and base.note_idx or index.next_note_idx + overlay_idx - 1)
             owner.bufnr = bufnr
             owner.changedtick = changedtick
           end
@@ -642,8 +805,17 @@ start_vault_block_search_index = function(dir, note_opts)
   if vault_block_search_indexes[dir_key] then
     return
   end
+  local workspace = assert(api.find_workspace(dir), "vault block completion workspace is missing")
+  local workspace_opts = api._workspace_opts(workspace)
   ---@type obsidian.completion.sources.refs.block_search_index
-  local index = { dir = dir_key, overlays = {}, note_count = 0 }
+  local index = {
+    dir = dir_key,
+    overlays = {},
+    next_note_idx = 1,
+    note_opts = note_opts,
+    workspace = workspace,
+    ignore_checker = ignore._build_ignore_checker(workspace_opts.file.ignore_filters),
+  }
   vault_block_search_indexes[dir_key] = index
   local generation = vault_block_search_generation
   search.find_notes_async("", function(results)
@@ -652,12 +824,14 @@ start_vault_block_search_index = function(dir, note_opts)
         vault_block_search_indexes[dir_key] = nil
       end
       if not vault_block_search_indexes[dir_key] then
+        local restart_dir, restart_note_opts = dir, note_opts
         for _, request in pairs(vault_block_search_pending) do
           if request.dir_key == dir_key then
-            start_vault_block_search_index(request.dir, request.note_opts)
+            restart_dir, restart_note_opts = request.dir, request.note_opts
             break
           end
         end
+        start_vault_block_search_index(restart_dir, restart_note_opts)
       end
       return
     end

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -41,15 +41,62 @@ local ALL_LINES = 2147483647
 
 ---@class obsidian.completion.sources.refs.block_search_index
 ---@field dir string
----@field notes obsidian.Note[]|?
----@field pending { cc: obsidian.completion.sources.refs.context, query: string }[]
+---@field candidates obsidian.completion.sources.refs.block_search_candidate[]|?
+---@field owners_by_path table<string, obsidian.completion.sources.refs.block_search_owner>|?
+---@field overlays table<string, obsidian.completion.sources.refs.block_search_owner>
+---@field note_count integer
 
----@type obsidian.completion.sources.refs.block_search_index?
-local vault_block_search_index
+---@class obsidian.completion.sources.refs.block_search_owner
+---@field note obsidian.Note
+---@field path string
+---@field note_idx integer
+---@field checksum string
+---@field candidates obsidian.completion.sources.refs.block_search_candidate[]
+---@field bufnr integer|?
+---@field changedtick integer|?
+
+---@class obsidian.completion.sources.refs.block_search_candidate
+---@field owner obsidian.completion.sources.refs.block_search_owner
+---@field section obsidian.Section
+---@field block obsidian.note.Block
+---@field existing boolean
+---@field searchable_lower string
+---@field label string
+---@field sort_text string
+---@field placement "inline"|"list-item"|"standalone"|?
+---@field indent string|?
+
+---@class obsidian.completion.sources.refs.new_block_target
+---@field path string
+---@field bufnr integer|?
+---@field range lsp.Range
+---@field checksum string
+---@field placement "inline"|"list-item"|"standalone"
+---@field indent string|?
+
+---@class obsidian.completion.sources.refs.block_item_spec
+---@field note obsidian.Note
+---@field block obsidian.note.Block
+---@field label string
+---@field sort_text string
+---@field link string
+---@field new_target obsidian.completion.sources.refs.new_block_target|?
+
+---@class obsidian.completion.sources.refs.block_search_request
+---@field cc obsidian.completion.sources.refs.context
+---@field query string
+---@field dir obsidian.Path
+---@field dir_key string
+---@field note_opts obsidian.note.LoadOpts
+
+---@type table<string, obsidian.completion.sources.refs.block_search_index>
+local vault_block_search_indexes = {}
+---@type table<string, obsidian.completion.sources.refs.block_search_request>
+local vault_block_search_pending = {}
 local vault_block_search_generation = 0
 
 require("obsidian.lsp.watchfiles").register_handler(function()
-  vault_block_search_index = nil
+  vault_block_search_indexes = {}
   vault_block_search_generation = vault_block_search_generation + 1
 end)
 
@@ -169,6 +216,75 @@ local function current_completion_text(request, range)
   return request.cursor_before_line:sub(range.start.character + 1) .. request.cursor_after_line:sub(1, suffix_len)
 end
 
+---@param cc obsidian.completion.sources.refs.context
+---@return lsp.Range
+---@return string placeholder
+---@return string source_path
+local function block_completion_request_context(cc)
+  local range = {
+    start = {
+      line = cc.request.line,
+      character = assert(cc.insert_start, "block completion insert start is missing"),
+    },
+    ["end"] = {
+      line = cc.request.line,
+      character = assert(cc.insert_end, "block completion insert end is missing"),
+    },
+  }
+  local source_name = vim.api.nvim_buf_get_name(cc.request.bufnr)
+  local source_path = vim.uv.fs_realpath(vim.fn.resolve(source_name)) or source_name
+  source_path = vim.fs.normalize(source_path)
+  return range, current_completion_text(cc.request, range), source_path
+end
+
+---@param cc obsidian.completion.sources.refs.context
+---@param range lsp.Range
+---@param placeholder string
+---@param spec obsidian.completion.sources.refs.block_item_spec
+---@return lsp.CompletionItem
+local function make_block_completion_item(cc, range, placeholder, spec)
+  ---@type lsp.CompletionItem
+  local item = {
+    label = spec.label,
+    sortText = spec.sort_text,
+    filterText = "[[" .. assert(cc.search, "block completion search is missing") .. " " .. spec.label,
+    documentation = {
+      kind = "markdown",
+      value = spec.note:display_info { label = spec.link, block = spec.block },
+    },
+    kind = vim.lsp.protocol.CompletionItemKind.Reference,
+    textEdit = {
+      newText = spec.new_target and placeholder or spec.link,
+      range = range,
+    },
+  }
+
+  local target = spec.new_target
+  if target then
+    item.command = {
+      command = "obsidian.block_reference_new",
+      title = "Obsidian create block reference",
+      arguments = {
+        {
+          target_path = target.path,
+          target_bufnr = target.bufnr,
+          target_range = target.range,
+          target_checksum = target.checksum,
+          block_id = spec.block.id,
+          placement = target.placement,
+          indent = target.indent,
+          source_bufnr = cc.request.bufnr,
+          source_range = range,
+          source_text = spec.link,
+          placeholder = placeholder,
+        },
+      },
+    }
+  end
+
+  return item
+end
+
 ---@param results obsidian.Note[]
 ---@param dir obsidian.Path
 ---@param note_opts obsidian.note.LoadOpts
@@ -211,18 +327,9 @@ end
 ---@param query string
 ---@param results obsidian.Note[]
 local function process_block_search_results(cc, scope, query, results)
-  ---@cast cc.insert_start -nil
-  ---@cast cc.insert_end -nil
-  ---@cast cc.search -nil
-  ---@type lsp.Range
-  local range = {
-    start = { line = cc.request.line, character = cc.insert_start },
-    ["end"] = { line = cc.request.line, character = cc.insert_end },
-  }
-  local placeholder = current_completion_text(cc.request, range)
-  local source_name = vim.api.nvim_buf_get_name(cc.request.bufnr)
-  local source_path = vim.uv.fs_realpath(vim.fn.resolve(source_name)) or vim.fs.normalize(source_name)
+  local range, placeholder, source_path = block_completion_request_context(cc)
   local lowered_query = vim.fn.tolower(query)
+  ---@type lsp.CompletionItem[]
   local items = {}
 
   for note_idx, note in ipairs(results) do
@@ -256,47 +363,30 @@ local function process_block_search_results(cc, scope, query, results)
             label = label .. " — " .. note:display_name()
           end
 
-          local item = {
-            label = label,
-            sortText = ("%08d:%08d"):format(note_idx, section.range.start_row),
-            filterText = "[[" .. cc.search .. " " .. label,
-            documentation = {
-              kind = "markdown",
-              value = note:display_info { label = link, block = block },
-            },
-            kind = vim.lsp.protocol.CompletionItemKind.Reference,
-            textEdit = {
-              newText = existing and link or placeholder,
-              range = range,
-            },
-          }
-
+          ---@type obsidian.completion.sources.refs.new_block_target?
+          local new_target
           if not existing then
             local placement, indent = block_id_placement(lines, section)
-            item.command = {
-              command = "obsidian.block_reference_new",
-              title = "Obsidian create block reference",
-              arguments = {
-                {
-                  target_path = tostring(note.path),
-                  target_bufnr = note.bufnr,
-                  target_range = {
-                    start = { line = section.range.start_row, character = 0 },
-                    ["end"] = { line = section.range.end_row, character = 0 },
-                  },
-                  target_checksum = vim.fn.sha256(table.concat(note.contents, "\n")),
-                  block_id = block.id,
-                  placement = placement,
-                  indent = indent,
-                  source_bufnr = cc.request.bufnr,
-                  source_range = range,
-                  source_text = link,
-                  placeholder = placeholder,
-                },
+            new_target = {
+              path = tostring(note.path),
+              bufnr = note.bufnr,
+              range = {
+                start = { line = section.range.start_row, character = 0 },
+                ["end"] = { line = section.range.end_row, character = 0 },
               },
+              checksum = vim.fn.sha256(table.concat(note.contents, "\n")),
+              placement = placement,
+              indent = indent,
             }
           end
-          items[#items + 1] = item
+          items[#items + 1] = make_block_completion_item(cc, range, placeholder, {
+            note = note,
+            block = block,
+            label = label,
+            sort_text = ("%08d:%08d"):format(note_idx, section.range.start_row),
+            link = link,
+            new_target = new_target,
+          })
         end
       end
     end
@@ -305,49 +395,310 @@ local function process_block_search_results(cc, scope, query, results)
   cc.completion_resolve_callback { isIncomplete = true, items = items }
 end
 
+---@param note obsidian.Note
+---@param note_idx integer
+---@return obsidian.completion.sources.refs.block_search_owner
+local function build_vault_block_owner(note, note_idx)
+  local path = vim.fs.normalize(tostring(note.path))
+  ---@type obsidian.completion.sources.refs.block_search_owner
+  local owner = {
+    note = note,
+    path = path,
+    note_idx = note_idx,
+    checksum = vim.fn.sha256(table.concat(note.contents, "\n")),
+    candidates = {},
+  }
+  ---@type table<obsidian.Section, obsidian.note.Block>
+  local existing_by_section = {}
+  for _, block in pairs(note.blocks or {}) do
+    if block.section then
+      existing_by_section[block.section] = block
+    end
+  end
+  ---@type table<string, boolean>
+  local reserved_ids = {}
+
+  for _, section in ipairs(note.block_candidates or {}) do
+    local lines = vim.list_slice(note.contents, section.range.start_row + 1, section.range.end_row)
+    local existing = existing_by_section[section]
+    local text = block_text(lines, existing and existing.id)
+    if text ~= "" then
+      local block = existing and vim.tbl_extend("force", existing, { block = text })
+        or {
+          id = generated_block_id(note, section, text, reserved_ids),
+          line = section.range.end_row,
+          block = text,
+          section = section,
+        }
+      ---@cast block obsidian.note.Block
+      local label = block_label(text)
+      if existing then
+        label = label .. " " .. existing.id
+      end
+      label = label .. " — " .. note:display_name()
+      local placement, indent
+      if not existing then
+        placement, indent = block_id_placement(lines, section)
+      end
+      owner.candidates[#owner.candidates + 1] = {
+        owner = owner,
+        section = section,
+        block = block,
+        existing = existing ~= nil,
+        searchable_lower = vim.fn.tolower(text .. (existing and " " .. existing.id or "")),
+        label = label,
+        sort_text = ("%08d:%08d"):format(note_idx, section.range.start_row),
+        placement = placement,
+        indent = indent,
+      }
+    end
+  end
+
+  return owner
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param notes obsidian.Note[]
+local function build_vault_block_index(index, notes)
+  ---@type obsidian.completion.sources.refs.block_search_candidate[]
+  local candidates = {}
+  ---@type table<string, obsidian.completion.sources.refs.block_search_owner>
+  local owners_by_path = {}
+  index.candidates = candidates
+  index.owners_by_path = owners_by_path
+  index.overlays = {}
+  index.note_count = #notes
+  for note_idx, note in ipairs(notes) do
+    local owner = build_vault_block_owner(note, note_idx)
+    owners_by_path[owner.path] = owner
+    vim.list_extend(candidates, owner.candidates)
+  end
+end
+
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param dir obsidian.Path
+---@param note_opts obsidian.note.LoadOpts
+---@return table<string, obsidian.completion.sources.refs.block_search_owner>
+local function vault_block_overlays(index, dir, note_opts)
+  local owners_by_path = assert(index.owners_by_path, "vault block index owners are missing")
+  local Note = require "obsidian.note"
+  local active = {}
+  local overlay_idx = 0
+
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      local path = vim.uv.fs_realpath(vim.fn.resolve(vim.api.nvim_buf_get_name(bufnr)))
+      path = path and vim.fs.normalize(path)
+      if path and util.is_subpath(path, tostring(dir)) and api.path_is_note(path) then
+        local base = owners_by_path[path]
+        local cached = index.overlays[path]
+        if not base or vim.bo[bufnr].modified or cached then
+          overlay_idx = overlay_idx + 1
+          local changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
+          local owner = cached
+          if not owner or owner.bufnr ~= bufnr or owner.changedtick ~= changedtick then
+            local opts = vim.tbl_extend("force", note_opts, {
+              max_lines = vim.api.nvim_buf_line_count(bufnr),
+            })
+            local note = Note.from_buffer(bufnr, opts)
+            owner = build_vault_block_owner(note, base and base.note_idx or index.note_count + overlay_idx)
+            owner.bufnr = bufnr
+            owner.changedtick = changedtick
+          end
+          active[assert(owner).path] = owner
+        end
+      end
+    end
+  end
+
+  index.overlays = active
+  return active
+end
+
+---@param cc obsidian.completion.sources.refs.context
+---@param query string
+---@param index obsidian.completion.sources.refs.block_search_index
+---@param dir obsidian.Path
+---@param note_opts obsidian.note.LoadOpts
+local function process_vault_block_search_results(cc, query, index, dir, note_opts)
+  local range, placeholder, source_path = block_completion_request_context(cc)
+  local lowered_query = vim.fn.tolower(query)
+  local overlays = vault_block_overlays(index, dir, note_opts)
+  ---@type lsp.CompletionItem[]
+  local items = {}
+
+  ---@param candidate obsidian.completion.sources.refs.block_search_candidate
+  local function add_match(candidate)
+    local owner = candidate.owner
+    local section = candidate.section
+    local same_note = owner.path == source_path
+    if
+      not (same_note and section.range.start_row <= cc.request.line and cc.request.line < section.range.end_row)
+      and candidate.searchable_lower:find(lowered_query, 1, true)
+    then
+      local link = owner.note:format_link { label = owner.note:display_name(), block = candidate.block }
+      ---@type obsidian.completion.sources.refs.new_block_target?
+      local new_target
+      if not candidate.existing then
+        new_target = {
+          path = owner.path,
+          bufnr = owner.note.bufnr,
+          range = {
+            start = { line = section.range.start_row, character = 0 },
+            ["end"] = { line = section.range.end_row, character = 0 },
+          },
+          checksum = owner.checksum,
+          placement = assert(candidate.placement, "generated block placement is missing"),
+          indent = candidate.indent,
+        }
+      end
+      items[#items + 1] = make_block_completion_item(cc, range, placeholder, {
+        note = owner.note,
+        block = candidate.block,
+        label = candidate.label,
+        sort_text = candidate.sort_text,
+        link = link,
+        new_target = new_target,
+      })
+    end
+  end
+
+  for _, candidate in ipairs(assert(index.candidates, "vault block index candidates are missing")) do
+    if not overlays[candidate.owner.path] then
+      add_match(candidate)
+    end
+  end
+  local overlay_owners = vim.tbl_values(overlays)
+  table.sort(overlay_owners, function(a, b)
+    return a.note_idx < b.note_idx
+  end)
+  for _, owner in ipairs(overlay_owners) do
+    for _, candidate in ipairs(owner.candidates) do
+      add_match(candidate)
+    end
+  end
+
+  cc.completion_resolve_callback { isIncomplete = true, items = items }
+end
+
+---@param cc obsidian.completion.sources.refs.context
+---@return string
+local function vault_block_request_key(cc)
+  return ("%d:%d:%d"):format(
+    cc.request.bufnr,
+    cc.request.line,
+    assert(cc.insert_start, "vault block completion insert start is missing")
+  )
+end
+
+---@param cc obsidian.completion.sources.refs.context
+local function cancel_pending_vault_block_request(cc)
+  local key = vault_block_request_key(cc)
+  local pending = vault_block_search_pending[key]
+  if pending then
+    vault_block_search_pending[key] = nil
+    pending.cc.completion_resolve_callback(EMPTY_RESPONSE)
+  end
+end
+
+---@param cc obsidian.completion.sources.refs.context
+---@param query string
+---@param dir obsidian.Path
+---@param note_opts obsidian.note.LoadOpts
+local function queue_vault_block_request(cc, query, dir, note_opts)
+  local key = vault_block_request_key(cc)
+  local pending = vault_block_search_pending[key]
+  if pending then
+    vault_block_search_pending[key] = nil
+    pending.cc.completion_resolve_callback(EMPTY_RESPONSE)
+  end
+  vault_block_search_pending[key] = {
+    cc = cc,
+    query = query,
+    dir = dir,
+    dir_key = tostring(dir),
+    note_opts = note_opts,
+  }
+end
+
+---@param dir_key string
+---@return obsidian.completion.sources.refs.block_search_request[]
+local function take_pending_vault_block_requests(dir_key)
+  local pending = {}
+  for key, request in pairs(vault_block_search_pending) do
+    if request.dir_key == dir_key then
+      vault_block_search_pending[key] = nil
+      pending[#pending + 1] = request
+    end
+  end
+  return pending
+end
+
+---@type fun(dir: obsidian.Path, note_opts: obsidian.note.LoadOpts)
+local start_vault_block_search_index
+
+start_vault_block_search_index = function(dir, note_opts)
+  local dir_key = tostring(dir)
+  if vault_block_search_indexes[dir_key] then
+    return
+  end
+  ---@type obsidian.completion.sources.refs.block_search_index
+  local index = { dir = dir_key, overlays = {}, note_count = 0 }
+  vault_block_search_indexes[dir_key] = index
+  local generation = vault_block_search_generation
+  search.find_notes_async("", function(results)
+    if generation ~= vault_block_search_generation or vault_block_search_indexes[dir_key] ~= index then
+      if vault_block_search_indexes[dir_key] == index then
+        vault_block_search_indexes[dir_key] = nil
+      end
+      if not vault_block_search_indexes[dir_key] then
+        for _, request in pairs(vault_block_search_pending) do
+          if request.dir_key == dir_key then
+            start_vault_block_search_index(request.dir, request.note_opts)
+            break
+          end
+        end
+      end
+      return
+    end
+
+    build_vault_block_index(index, results)
+    for _, request in ipairs(take_pending_vault_block_requests(dir_key)) do
+      process_vault_block_search_results(request.cc, request.query, index, request.dir, request.note_opts)
+    end
+  end, {
+    dir = dir,
+    search = { sort = false, include_templates = false, ignore_case = true },
+    notes = note_opts,
+  })
+end
+
 ---@param cc obsidian.completion.sources.refs.context
 ---@param query string
 ---@param dir obsidian.Path
 ---@param note_opts obsidian.note.LoadOpts
 local function process_vault_block_search(cc, query, dir, note_opts)
   local dir_key = tostring(dir)
-  local index = vault_block_search_index
-  if not index or index.dir ~= dir_key then
-    index = { dir = dir_key, pending = { { cc = cc, query = query } } }
-    vault_block_search_index = index
-    local generation = vault_block_search_generation
-    search.find_notes_async("", function(results)
-      if generation ~= vault_block_search_generation then
-        local pending = index.pending
-        index.pending = {}
-        for _, request in ipairs(pending) do
-          process_vault_block_search(request.cc, request.query, dir, note_opts)
-        end
-        return
-      end
-      index.notes = results
-      local pending = index.pending
-      index.pending = {}
-      for _, request in ipairs(pending) do
-        process_block_search_results(
-          request.cc,
-          "vault",
-          request.query,
-          include_loaded_notes(vim.list_slice(index.notes), dir, note_opts, true)
-        )
-      end
-    end, {
-      dir = dir,
-      search = { sort = false, include_templates = false, ignore_case = true },
-      notes = note_opts,
-    })
+  local index = vault_block_search_indexes[dir_key]
+  local has_index = index ~= nil
+  local should_complete = vim.fn.strchars(query) >= Obsidian.opts.completion.min_chars
+
+  if not should_complete then
+    cancel_pending_vault_block_request(cc)
+    cc.completion_resolve_callback(EMPTY_RESPONSE)
+    if not has_index then
+      start_vault_block_search_index(dir, note_opts)
+    end
     return
   end
 
-  if index.notes then
-    process_block_search_results(cc, "vault", query, include_loaded_notes(vim.list_slice(index.notes), dir, note_opts, true))
+  if not has_index then
+    queue_vault_block_request(cc, query, dir, note_opts)
+    start_vault_block_search_index(dir, note_opts)
+  elseif index.candidates then
+    process_vault_block_search_results(cc, query, index, dir, note_opts)
   else
-    index.pending[#index.pending + 1] = { cc = cc, query = query }
+    queue_vault_block_request(cc, query, dir, note_opts)
   end
 end
 
@@ -356,6 +707,11 @@ end
 ---@param query string
 ---@param target string|?
 local function process_block_search(cc, scope, query, target)
+  if scope ~= "vault" and vim.fn.strchars(query) < Obsidian.opts.completion.min_chars then
+    cc.completion_resolve_callback(EMPTY_RESPONSE)
+    return
+  end
+
   if scope == "current" then
     local note = api.current_note(cc.request.bufnr, {
       max_lines = vim.api.nvim_buf_line_count(cc.request.bufnr),

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -184,6 +184,7 @@ local function include_loaded_notes(results, dir, note_opts, include_unmatched)
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_loaded(bufnr) then
       local path = vim.uv.fs_realpath(vim.fn.resolve(vim.api.nvim_buf_get_name(bufnr)))
+      path = path and vim.fs.normalize(path)
       if path and util.is_subpath(path, tostring(dir)) and api.path_is_note(path) then
         local idx = path_to_idx[path]
         if not idx or vim.bo[bufnr].modified then

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -39,6 +39,20 @@ local EMPTY_RESPONSE = {
 ---@type integer
 local ALL_LINES = 2147483647
 
+---@class obsidian.completion.sources.refs.block_search_index
+---@field dir string
+---@field notes obsidian.Note[]|?
+---@field pending { cc: obsidian.completion.sources.refs.context, query: string }[]
+
+---@type obsidian.completion.sources.refs.block_search_index?
+local vault_block_search_index
+local vault_block_search_generation = 0
+
+require("obsidian.lsp.watchfiles").register_handler(function()
+  vault_block_search_index = nil
+  vault_block_search_generation = vault_block_search_generation + 1
+end)
+
 --- Returns whether it's possible to complete the search and sets up the search related variables in cc
 ---@param cc obsidian.completion.sources.refs.context
 ---@return boolean success provides a chance to return early if the request didn't meet the requirements
@@ -171,16 +185,19 @@ local function include_loaded_notes(results, dir, note_opts, include_unmatched)
     if vim.api.nvim_buf_is_loaded(bufnr) then
       local path = vim.uv.fs_realpath(vim.fn.resolve(vim.api.nvim_buf_get_name(bufnr)))
       if path and util.is_subpath(path, tostring(dir)) and api.path_is_note(path) then
-        local opts = vim.tbl_extend("force", note_opts, {
-          max_lines = vim.api.nvim_buf_line_count(bufnr),
-        })
-        local note = Note.from_buffer(bufnr, opts)
-        local idx = path_to_idx[tostring(note.path)]
-        if idx then
-          results[idx] = note
-        elseif include_unmatched ~= false then
-          results[#results + 1] = note
-          path_to_idx[tostring(note.path)] = #results
+        local idx = path_to_idx[path]
+        if not idx or vim.bo[bufnr].modified then
+          local opts = vim.tbl_extend("force", note_opts, {
+            max_lines = vim.api.nvim_buf_line_count(bufnr),
+          })
+          local note = Note.from_buffer(bufnr, opts)
+          idx = path_to_idx[tostring(note.path)]
+          if idx then
+            results[idx] = note
+          elseif include_unmatched ~= false then
+            results[#results + 1] = note
+            path_to_idx[tostring(note.path)] = #results
+          end
         end
       end
     end
@@ -288,6 +305,52 @@ local function process_block_search_results(cc, scope, query, results)
 end
 
 ---@param cc obsidian.completion.sources.refs.context
+---@param query string
+---@param dir obsidian.Path
+---@param note_opts obsidian.note.LoadOpts
+local function process_vault_block_search(cc, query, dir, note_opts)
+  local dir_key = tostring(dir)
+  local index = vault_block_search_index
+  if not index or index.dir ~= dir_key then
+    index = { dir = dir_key, pending = { { cc = cc, query = query } } }
+    vault_block_search_index = index
+    local generation = vault_block_search_generation
+    search.find_notes_async("", function(results)
+      if generation ~= vault_block_search_generation then
+        local pending = index.pending
+        index.pending = {}
+        for _, request in ipairs(pending) do
+          process_vault_block_search(request.cc, request.query, dir, note_opts)
+        end
+        return
+      end
+      index.notes = results
+      local pending = index.pending
+      index.pending = {}
+      for _, request in ipairs(pending) do
+        process_block_search_results(
+          request.cc,
+          "vault",
+          request.query,
+          include_loaded_notes(vim.list_slice(index.notes), dir, note_opts, true)
+        )
+      end
+    end, {
+      dir = dir,
+      search = { sort = false, include_templates = false, ignore_case = true },
+      notes = note_opts,
+    })
+    return
+  end
+
+  if index.notes then
+    process_block_search_results(cc, "vault", query, include_loaded_notes(vim.list_slice(index.notes), dir, note_opts, true))
+  else
+    index.pending[#index.pending + 1] = { cc = cc, query = query }
+  end
+end
+
+---@param cc obsidian.completion.sources.refs.context
 ---@param scope "current"|"note"|"vault"
 ---@param query string
 ---@param target string|?
@@ -305,7 +368,7 @@ local function process_block_search(cc, scope, query, target)
   local dir = api.resolve_workspace_dir()
   local note_opts = { max_lines = ALL_LINES, collect_blocks = true, collect_block_candidates = true }
   local function on_results(results)
-    process_block_search_results(cc, scope, query, include_loaded_notes(results, dir, note_opts, scope == "vault"))
+    process_block_search_results(cc, scope, query, include_loaded_notes(results, dir, note_opts, false))
   end
   if scope == "note" then
     search.resolve_note_async(
@@ -315,11 +378,7 @@ local function process_block_search(cc, scope, query, target)
     )
     return
   end
-  search.find_notes_async(query, on_results, {
-    dir = dir,
-    search = { sort = false, include_templates = false, ignore_case = true },
-    notes = note_opts,
-  })
+  process_vault_block_search(cc, query, dir, note_opts)
 end
 
 ---@param query string

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -38,6 +38,20 @@ local EMPTY_RESPONSE = {
 ---@type integer
 local ALL_LINES = 2147483647
 
+---@class obsidian.completion.sources.refs.block_search_index
+---@field dir string
+---@field notes obsidian.Note[]|?
+---@field pending { cc: obsidian.completion.sources.refs.context, query: string }[]
+
+---@type obsidian.completion.sources.refs.block_search_index?
+local vault_block_search_index
+local vault_block_search_generation = 0
+
+require("obsidian.lsp.watchfiles").register_handler(function()
+  vault_block_search_index = nil
+  vault_block_search_generation = vault_block_search_generation + 1
+end)
+
 --- Returns whether it's possible to complete the search and sets up the search related variables in cc
 ---@param cc obsidian.completion.sources.refs.context
 ---@return boolean success provides a chance to return early if the request didn't meet the requirements
@@ -165,17 +179,20 @@ local function include_loaded_notes(results, dir, include_unmatched)
     if vim.api.nvim_buf_is_loaded(bufnr) then
       local path = vim.uv.fs_realpath(vim.fn.resolve(vim.api.nvim_buf_get_name(bufnr)))
       if path and util.is_subpath(path, tostring(dir)) and api.path_is_note(path) then
-        local note = Note.from_buffer(bufnr, {
-          max_lines = vim.api.nvim_buf_line_count(bufnr),
-          collect_blocks = true,
-          collect_block_candidates = true,
-        })
-        local idx = path_to_idx[tostring(note.path)]
-        if idx then
-          results[idx] = note
-        elseif include_unmatched ~= false then
-          results[#results + 1] = note
-          path_to_idx[tostring(note.path)] = #results
+        local idx = path_to_idx[path]
+        if not idx or vim.bo[bufnr].modified then
+          local note = Note.from_buffer(bufnr, {
+            max_lines = vim.api.nvim_buf_line_count(bufnr),
+            collect_blocks = true,
+            collect_block_candidates = true,
+          })
+          idx = path_to_idx[tostring(note.path)]
+          if idx then
+            results[idx] = note
+          elseif include_unmatched ~= false then
+            results[#results + 1] = note
+            path_to_idx[tostring(note.path)] = #results
+          end
         end
       end
     end
@@ -283,6 +300,52 @@ local function process_block_search_results(cc, scope, query, results)
 end
 
 ---@param cc obsidian.completion.sources.refs.context
+---@param query string
+---@param dir obsidian.Path
+---@param note_opts obsidian.note.LoadOpts
+local function process_vault_block_search(cc, query, dir, note_opts)
+  local dir_key = tostring(dir)
+  local index = vault_block_search_index
+  if not index or index.dir ~= dir_key then
+    index = { dir = dir_key, pending = { { cc = cc, query = query } } }
+    vault_block_search_index = index
+    local generation = vault_block_search_generation
+    search.find_notes_async("", function(results)
+      if generation ~= vault_block_search_generation then
+        local pending = index.pending
+        index.pending = {}
+        for _, request in ipairs(pending) do
+          process_vault_block_search(request.cc, request.query, dir, note_opts)
+        end
+        return
+      end
+      index.notes = results
+      local pending = index.pending
+      index.pending = {}
+      for _, request in ipairs(pending) do
+        process_block_search_results(
+          request.cc,
+          "vault",
+          request.query,
+          include_loaded_notes(vim.list_slice(index.notes), dir, true)
+        )
+      end
+    end, {
+      dir = dir,
+      search = { sort = false, include_templates = false, ignore_case = true },
+      notes = note_opts,
+    })
+    return
+  end
+
+  if index.notes then
+    process_block_search_results(cc, "vault", query, include_loaded_notes(vim.list_slice(index.notes), dir, true))
+  else
+    index.pending[#index.pending + 1] = { cc = cc, query = query }
+  end
+end
+
+---@param cc obsidian.completion.sources.refs.context
 ---@param scope "current"|"note"|"vault"
 ---@param query string
 ---@param target string|?
@@ -300,7 +363,7 @@ local function process_block_search(cc, scope, query, target)
   local dir = api.resolve_workspace_dir()
   local note_opts = { max_lines = ALL_LINES, collect_blocks = true, collect_block_candidates = true }
   local function on_results(results)
-    process_block_search_results(cc, scope, query, include_loaded_notes(results, dir, scope == "vault"))
+    process_block_search_results(cc, scope, query, include_loaded_notes(results, dir, false))
   end
   if scope == "note" then
     search.resolve_note_async(
@@ -310,11 +373,7 @@ local function process_block_search(cc, scope, query, target)
     )
     return
   end
-  search.find_notes_async(query, on_results, {
-    dir = dir,
-    search = { sort = false, include_templates = false, ignore_case = true },
-    notes = note_opts,
-  })
+  process_vault_block_search(cc, query, dir, note_opts)
 end
 
 --- Determines whatever the in_buffer_only should be enabled

--- a/lua/obsidian/completion/sources/refs.lua
+++ b/lua/obsidian/completion/sources/refs.lua
@@ -178,6 +178,7 @@ local function include_loaded_notes(results, dir, include_unmatched)
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_loaded(bufnr) then
       local path = vim.uv.fs_realpath(vim.fn.resolve(vim.api.nvim_buf_get_name(bufnr)))
+      path = path and vim.fs.normalize(path)
       if path and util.is_subpath(path, tostring(dir)) and api.path_is_note(path) then
         local idx = path_to_idx[path]
         if not idx or vim.bo[bufnr].modified then

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -624,19 +624,10 @@ T["completion"]["keeps generated vault block IDs unique across filtered queries"
   )
 end
 
-T["completion"]["reuses the vault block index until the vault changes"] = function()
+T["completion"]["keeps an unsaved source overlay after its watched-file event"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "A needle paragraph\n\n[[^^",
   })
-  child.lua [[
-    _G.block_search_terms = {}
-    local search = require "obsidian.search"
-    local find_notes_async = search.find_notes_async
-    search.find_notes_async = function(term, ...)
-      table.insert(_G.block_search_terms, term)
-      return find_notes_async(term, ...)
-    end
-  ]]
 
   child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
   child.api.nvim_win_set_cursor(0, { 3, 4 })
@@ -653,7 +644,6 @@ T["completion"]["reuses the vault block index until the vault changes"] = functi
     end),
     "cached block index did not include unsaved buffer changes"
   )
-  eq({ "" }, child.lua_get "_G.block_search_terms")
 
   child.lua [[
     require("obsidian.lsp.handlers.did_change_watched_files") {
@@ -666,7 +656,6 @@ T["completion"]["reuses the vault block index until the vault changes"] = functi
     }
   ]]
   result = run_completion(2, 9)
-  eq({ "", "" }, child.lua_get "_G.block_search_terms")
 
   local item = vim.iter(result.items or {}):find(function(candidate)
     return candidate.command and candidate.label == "A fresh paragraph — source"
@@ -677,6 +666,123 @@ T["completion"]["reuses the vault block index until the vault changes"] = functi
   local block_id = lines[1]:match "(%^[0-9a-f]+)$"
   assert(block_id, "same-note block did not receive an ID")
   eq("[[source#" .. block_id .. "]]", lines[3])
+end
+
+T["completion"]["refreshes only the changed note in the vault block index"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^cached",
+    ["changed.md"] = "Changed cached block",
+    ["untouched.md"] = "Untouched cached block",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 10 })
+  local result = run_completion(0, 10)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Untouched cached block — untouched"
+    end),
+    "initial untouched candidate was missing"
+  )
+
+  child.lua [[
+    local changed = tostring(Obsidian.dir / "changed.md")
+    vim.fn.writefile({ "Fresh changed block" }, changed)
+    vim.fn.writefile({ "Unannounced disk block" }, tostring(Obsidian.dir / "untouched.md"))
+    require("obsidian.lsp.handlers.did_change_watched_files") {
+      changes = { { uri = vim.uri_from_fname(changed), type = vim.lsp.protocol.FileChangeType.Changed } },
+    }
+  ]]
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^fresh" })
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+  result = run_completion(0, 9)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Fresh changed block — changed"
+    end),
+    "changed note candidate was not refreshed"
+  )
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^untouched" })
+  child.api.nvim_win_set_cursor(0, { 1, 13 })
+  result = run_completion(0, 13)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Untouched cached block — untouched"
+    end),
+    "unrelated cached note was refreshed without a watched-file event"
+  )
+  assert(not vim.iter(result.items or {}):any(function(candidate)
+    return candidate.label == "Unannounced disk block — untouched"
+  end), "unrelated disk change leaked into the incrementally refreshed index")
+end
+
+T["completion"]["uses the indexed workspace ignore filters during incremental refresh"] = function()
+  child.fn.mkdir(tostring(child.Obsidian.dir / "ignored"), "p")
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^visible",
+    ["visible.md"] = "Visible target block",
+    ["ignored/hidden.md"] = "Hidden ignored block",
+  })
+  child.lua [[
+    local Path = require "obsidian.path"
+    local Workspace = require "obsidian.workspace"
+    local primary = assert(Workspace.new {
+      name = "primary",
+      path = Obsidian.dir,
+      strict = true,
+      overrides = { file = { ignore_filters = { "ignored/**" } } },
+    })
+    local secondary_dir = Path.temp { suffix = "-secondary-workspace" }
+    secondary_dir:mkdir()
+    local secondary_config_dir = secondary_dir / ".obsidian"
+    secondary_config_dir:mkdir()
+    local secondary = assert(Workspace.new {
+      name = "secondary",
+      path = secondary_dir,
+      strict = true,
+    })
+    Obsidian.workspaces = { primary, secondary }
+    require("obsidian.workspace").set(primary)
+    _G.primary_block_workspace = primary
+    _G.secondary_block_workspace = secondary
+    _G.secondary_block_workspace_dir = secondary_dir
+  ]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 11 })
+  local result = run_completion(0, 11)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Visible target block — visible"
+    end),
+    "primary workspace index did not finish building"
+  )
+
+  child.lua [[
+    local Workspace = require "obsidian.workspace"
+    Workspace.set(_G.secondary_block_workspace)
+    local hidden = tostring(_G.primary_block_workspace.root / "ignored" / "hidden.md")
+    vim.fn.writefile({ "Hidden refreshed block" }, hidden)
+    require("obsidian.lsp.handlers.did_change_watched_files") {
+      changes = { { uri = vim.uri_from_fname(hidden), type = vim.lsp.protocol.FileChangeType.Changed } },
+    }
+    Workspace.set(_G.primary_block_workspace)
+  ]]
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^hidden" })
+  child.api.nvim_win_set_cursor(0, { 1, 10 })
+  result = run_completion(0, 10)
+  child.lua [[
+    vim.fn.delete(tostring(_G.secondary_block_workspace_dir), "rf")
+    _G.primary_block_workspace = nil
+    _G.secondary_block_workspace = nil
+    _G.secondary_block_workspace_dir = nil
+  ]]
+  assert(not vim.iter(result.items or {}):any(function(candidate)
+    return candidate.label == "Hidden refreshed block — hidden"
+  end), "incremental refresh ignored the indexed workspace's file.ignore_filters")
 end
 
 T["completion"]["retains a saved buffer overlay until the vault index is invalidated"] = function()
@@ -716,6 +822,68 @@ T["completion"]["retains a saved buffer overlay until the vault index is invalid
       return candidate.label == "Fresh target block — target"
     end),
     "saved-buffer overlay was dropped before index invalidation"
+  )
+
+  child.lua [[
+    local target = tostring(Obsidian.dir / "target.md")
+    vim.fn.writefile({ "External target block" }, target)
+    require("obsidian.lsp.handlers.did_change_watched_files") {
+      changes = { { uri = vim.uri_from_fname(target), type = vim.lsp.protocol.FileChangeType.Changed } },
+    }
+  ]]
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^external" })
+  child.api.nvim_win_set_cursor(0, { 1, 12 })
+  result = run_completion(0, 12)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "External target block — target"
+    end),
+    "watched-file change did not replace the retained buffer overlay"
+  )
+end
+
+T["completion"]["restarts a bare vault block warm-up invalidated while loading"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^",
+    ["target.md"] = "Stale target block",
+  })
+  child.lua [[
+    Obsidian.opts.completion.min_chars = 2
+    _G.block_search_scans = 0
+    local search = require "obsidian.search"
+    local find_notes_async = search.find_notes_async
+    search.find_notes_async = function(term, callback, ...)
+      _G.block_search_scans = _G.block_search_scans + 1
+      local scan = _G.block_search_scans
+      return find_notes_async(term, function(results)
+        if scan == 1 then
+          local target = tostring(Obsidian.dir / "target.md")
+          vim.fn.writefile({ "Fresh target block" }, target)
+          require("obsidian.lsp.handlers.did_change_watched_files") {
+            changes = {
+              { uri = vim.uri_from_fname(target), type = vim.lsp.protocol.FileChangeType.Changed },
+            },
+          }
+        end
+        callback(results)
+      end, ...)
+    end
+  ]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 4 })
+  local result = run_completion(0, 4)
+  eq({}, result.items)
+  h.child_wait(child, [[return _G.block_search_scans == 2]], { desc = "restarted bare block-index warm-up" })
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^fresh" })
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+  result = run_completion(0, 9)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Fresh target block — target"
+    end),
+    "restarted bare warm-up did not index the watched-file change"
   )
 end
 
@@ -833,6 +1001,7 @@ T["completion"]["refreshes vault block candidates after note creation and deleti
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "[[^^alpha",
     ["old.md"] = "Alpha original",
+    ["untouched.md"] = "Untouched cached block",
   })
 
   child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
@@ -848,6 +1017,7 @@ T["completion"]["refreshes vault block candidates after note creation and deleti
   child.lua [[
     local created = tostring(Obsidian.dir / "new.md")
     vim.fn.writefile({ "Beta created" }, created)
+    vim.fn.writefile({ "Unannounced disk block" }, tostring(Obsidian.dir / "untouched.md"))
     require("obsidian.lsp.handlers.did_change_watched_files") {
       changes = { { uri = vim.uri_from_fname(created), type = vim.lsp.protocol.FileChangeType.Created } },
     }
@@ -860,6 +1030,16 @@ T["completion"]["refreshes vault block candidates after note creation and deleti
       return candidate.label == "Beta created — new"
     end),
     "created note was not added to the vault block index"
+  )
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^untouched" })
+  child.api.nvim_win_set_cursor(0, { 1, 13 })
+  result = run_completion(0, 13)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Untouched cached block — untouched"
+    end),
+    "note creation refreshed an unrelated cached note"
   )
 
   child.lua [[
@@ -875,6 +1055,16 @@ T["completion"]["refreshes vault block candidates after note creation and deleti
   assert(not vim.iter(result.items or {}):any(function(candidate)
     return candidate.label == "Alpha original — old"
   end), "deleted note remained in the vault block index")
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^untouched" })
+  child.api.nvim_win_set_cursor(0, { 1, 13 })
+  result = run_completion(0, 13)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Untouched cached block — untouched"
+    end),
+    "note deletion refreshed an unrelated cached note"
+  )
 end
 
 T["completion"]["creates a block embed while preserving the leading bang"] = function()

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -307,6 +307,99 @@ T["completion"]["creates a vault-wide block reference from unlabeled content"] =
   eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
 end
 
+T["completion"]["reuses the vault block index until the vault changes"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "A needle paragraph\n\n[[^^",
+  })
+  child.lua [[
+    _G.block_search_terms = {}
+    local search = require "obsidian.search"
+    local find_notes_async = search.find_notes_async
+    search.find_notes_async = function(term, ...)
+      table.insert(_G.block_search_terms, term)
+      return find_notes_async(term, ...)
+    end
+  ]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 3, 4 })
+  run_completion(2, 4)
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "A fresh paragraph" })
+  child.api.nvim_buf_set_lines(0, 2, 3, false, { "[[^^fresh" })
+  child.api.nvim_win_set_cursor(0, { 3, 9 })
+  child.api.nvim_exec_autocmds("InsertLeave", {})
+  local result = run_completion(2, 9)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "A fresh paragraph — source"
+    end),
+    "cached block index did not include unsaved buffer changes"
+  )
+  eq({ "" }, child.lua_get "_G.block_search_terms")
+
+  child.lua [[
+    require("obsidian.lsp.watchfiles").handle {
+      {
+        path = vim.api.nvim_buf_get_name(0),
+        type = vim.lsp.protocol.FileChangeType.Changed,
+      },
+    }
+  ]]
+  result = run_completion(2, 9)
+  eq({ "", "" }, child.lua_get "_G.block_search_terms")
+
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "A fresh paragraph — source"
+  end)
+  assert(item, "rebuilt block index did not include the source note")
+  accept_completion(item)
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  local block_id = lines[1]:match "(%^[0-9a-f]+)$"
+  assert(block_id, "same-note block did not receive an ID")
+  eq("[[source#" .. block_id .. "]]", lines[3])
+end
+
+T["completion"]["rebuilds a vault block index invalidated while loading"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^fresh",
+    ["target.md"] = "Stale target",
+  })
+  child.lua [[
+    local target_path = tostring(Obsidian.dir / "target.md")
+    vim.fn.bufload(vim.fn.bufadd(target_path))
+
+    _G.block_search_scans = 0
+    local search = require "obsidian.search"
+    local find_notes_async = search.find_notes_async
+    search.find_notes_async = function(term, callback, ...)
+      _G.block_search_scans = _G.block_search_scans + 1
+      if _G.block_search_scans == 1 then
+        return find_notes_async(term, function(results)
+          vim.fn.writefile({ "Fresh external target" }, target_path)
+          require("obsidian.lsp.watchfiles").handle {
+            { path = target_path, type = vim.lsp.protocol.FileChangeType.Changed },
+          }
+          callback(results)
+        end, ...)
+      end
+      return find_notes_async(term, callback, ...)
+    end
+  ]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+  local result = run_completion(0, 9)
+
+  eq(2, child.lua_get "_G.block_search_scans")
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Fresh external target — target"
+    end),
+    "completion used an invalidated block index"
+  )
+end
+
 T["completion"]["creates a block embed while preserving the leading bang"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "![[^^embed needle",

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -507,6 +507,123 @@ T["completion"]["creates a vault-wide block reference from unlabeled content"] =
   eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
 end
 
+T["completion"]["honors min chars for vault block queries while warming the index"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^n",
+    ["target.md"] = "A needle paragraph",
+  })
+  child.lua [[Obsidian.opts.completion.min_chars = 2]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 5 })
+  local result = run_completion(0, 5)
+  eq({}, result.items)
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^ne" })
+  child.api.nvim_win_set_cursor(0, { 1, 6 })
+  result = run_completion(0, 6)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "A needle paragraph — target"
+    end),
+    "vault block completion did not use the warmed index at min_chars"
+  )
+end
+
+T["completion"]["coalesces overlapping vault block queries to the latest request"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^old",
+    ["target.md"] = "Old block\n\nNew block",
+  })
+  child.lua [=[
+    _G.block_items_materialized = 0
+    Obsidian.opts.link.style = function(opts)
+      _G.block_items_materialized = _G.block_items_materialized + 1
+      return "[[" .. opts.path .. (opts.block and "#" .. opts.block.id or "") .. "]]"
+    end
+  ]=]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 7 })
+  local responses = h.child_await(
+    child,
+    [=[
+      local handler = require "obsidian.lsp.handlers.completion"
+      local responses = {}
+      local callbacks = 0
+      local function params()
+        return {
+          textDocument = { uri = vim.uri_from_bufnr(0) },
+          position = { line = 0, character = 7 },
+        }
+      end
+      local function finish(name, response)
+        responses[name] = response
+        callbacks = callbacks + 1
+        if callbacks == 2 then
+          responses.materialized = _G.block_items_materialized
+          done(responses)
+        end
+      end
+
+      handler(params(), function(_, response)
+        finish("old", response)
+      end)
+      vim.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^new" })
+      handler(params(), function(_, response)
+        finish("new", response)
+      end)
+    ]=],
+    { desc = "overlapping completion responses" }
+  )
+
+  eq({}, responses.old.items)
+  eq(1, responses.materialized)
+  assert(
+    vim.iter(responses.new.items or {}):any(function(candidate)
+      return candidate.label == "New block — target"
+    end),
+    "latest vault block query was not completed"
+  )
+end
+
+T["completion"]["keeps generated vault block IDs unique across filtered queries"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^alpha",
+    ["target.md"] = "Alpha paragraph\n\nBeta paragraph",
+  })
+  child.lua [[
+    _G.obsidian_test_sha256 = vim.fn.sha256
+    vim.fn.sha256 = function(value)
+      return string.rep(vim.endswith(value, ":1") and "b" or "a", 64)
+    end
+  ]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+  local result = run_completion(0, 9)
+  local alpha = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.label == "Alpha paragraph — target"
+  end)
+  assert(alpha and alpha.command, "alpha block completion was not generated")
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^beta" })
+  child.api.nvim_win_set_cursor(0, { 1, 8 })
+  result = run_completion(0, 8)
+  child.lua [[
+    vim.fn.sha256 = _G.obsidian_test_sha256
+    _G.obsidian_test_sha256 = nil
+  ]]
+  local beta = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.label == "Beta paragraph — target"
+  end)
+  assert(beta and beta.command, "beta block completion was not generated")
+  assert(
+    alpha.command.arguments[1].block_id ~= beta.command.arguments[1].block_id,
+    "filtered vault queries reused a generated block ID"
+  )
+end
+
 T["completion"]["reuses the vault block index until the vault changes"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "A needle paragraph\n\n[[^^",
@@ -539,10 +656,12 @@ T["completion"]["reuses the vault block index until the vault changes"] = functi
   eq({ "" }, child.lua_get "_G.block_search_terms")
 
   child.lua [[
-    require("obsidian.lsp.watchfiles").handle {
-      {
-        path = vim.api.nvim_buf_get_name(0),
-        type = vim.lsp.protocol.FileChangeType.Changed,
+    require("obsidian.lsp.handlers.did_change_watched_files") {
+      changes = {
+        {
+          uri = vim.uri_from_fname(vim.api.nvim_buf_get_name(0)),
+          type = vim.lsp.protocol.FileChangeType.Changed,
+        },
       },
     }
   ]]
@@ -558,6 +677,46 @@ T["completion"]["reuses the vault block index until the vault changes"] = functi
   local block_id = lines[1]:match "(%^[0-9a-f]+)$"
   assert(block_id, "same-note block did not receive an ID")
   eq("[[source#" .. block_id .. "]]", lines[3])
+end
+
+T["completion"]["retains a saved buffer overlay until the vault index is invalidated"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^old",
+    ["target.md"] = "Old target block",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 7 })
+  local result = run_completion(0, 7)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Old target block — target"
+    end),
+    "initial disk-backed block candidate was missing"
+  )
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "target.md"))
+  local target_bufnr = child.api.nvim_get_current_buf()
+  child.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "Fresh target block" })
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^fresh" })
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+  result = run_completion(0, 9)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Fresh target block — target"
+    end),
+    "modified-buffer overlay was missing"
+  )
+
+  child.lua(("vim.bo[%d].modified = false"):format(target_bufnr))
+  result = run_completion(0, 9)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Fresh target block — target"
+    end),
+    "saved-buffer overlay was dropped before index invalidation"
+  )
 end
 
 T["completion"]["rebuilds a vault block index invalidated while loading"] = function()
@@ -577,8 +736,10 @@ T["completion"]["rebuilds a vault block index invalidated while loading"] = func
       if _G.block_search_scans == 1 then
         return find_notes_async(term, function(results)
           vim.fn.writefile({ "Fresh external target" }, target_path)
-          require("obsidian.lsp.watchfiles").handle {
-            { path = target_path, type = vim.lsp.protocol.FileChangeType.Changed },
+          require("obsidian.lsp.handlers.did_change_watched_files") {
+            changes = {
+              { uri = vim.uri_from_fname(target_path), type = vim.lsp.protocol.FileChangeType.Changed },
+            },
           }
           callback(results)
         end, ...)
@@ -598,6 +759,122 @@ T["completion"]["rebuilds a vault block index invalidated while loading"] = func
     end),
     "completion used an invalidated block index"
   )
+end
+
+T["completion"]["keeps a newer vault block index build when a stale build finishes"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^old",
+    ["target.md"] = "New target block",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 7 })
+  local result = h.child_await(
+    child,
+    [=[
+      local completion_handler = require "obsidian.lsp.handlers.completion"
+      local watch_handler = require "obsidian.lsp.handlers.did_change_watched_files"
+      local search = require "obsidian.search"
+      local find_notes_async = search.find_notes_async
+      local scan_callbacks = {}
+      local scans = 0
+      local latest_response
+      local function params()
+        return {
+          textDocument = { uri = vim.uri_from_bufnr(0) },
+          position = { line = 0, character = 7 },
+        }
+      end
+
+      search.find_notes_async = function(term, callback, ...)
+        scans = scans + 1
+        local scan = scans
+        scan_callbacks[scan] = callback
+        if scan == 1 then
+          return find_notes_async(term, function(results)
+            watch_handler {
+              changes = {
+                {
+                  uri = vim.uri_from_fname(tostring(Obsidian.dir / "target.md")),
+                  type = vim.lsp.protocol.FileChangeType.Changed,
+                },
+              },
+            }
+            vim.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^new" })
+            completion_handler(params(), function(_, response)
+              latest_response = response
+            end)
+
+            scan_callbacks[1](results)
+            scan_callbacks[2](results)
+            vim.schedule(function()
+              done { scans = scans, latest_response = latest_response }
+            end)
+          end, ...)
+        end
+      end
+
+      completion_handler(params(), function() end)
+    ]=],
+    { desc = "stale and current vault block index builds" }
+  )
+
+  eq(2, result.scans)
+  assert(result.latest_response, "newer vault block index build did not settle its request")
+  assert(
+    vim.iter(result.latest_response.items or {}):any(function(candidate)
+      return candidate.label == "New target block — target"
+    end),
+    "newer vault block index build did not return its completion"
+  )
+end
+
+T["completion"]["refreshes vault block candidates after note creation and deletion"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^alpha",
+    ["old.md"] = "Alpha original",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+  local result = run_completion(0, 9)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Alpha original — old"
+    end),
+    "initial vault block candidate was missing"
+  )
+
+  child.lua [[
+    local created = tostring(Obsidian.dir / "new.md")
+    vim.fn.writefile({ "Beta created" }, created)
+    require("obsidian.lsp.handlers.did_change_watched_files") {
+      changes = { { uri = vim.uri_from_fname(created), type = vim.lsp.protocol.FileChangeType.Created } },
+    }
+  ]]
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^beta" })
+  child.api.nvim_win_set_cursor(0, { 1, 8 })
+  result = run_completion(0, 8)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Beta created — new"
+    end),
+    "created note was not added to the vault block index"
+  )
+
+  child.lua [[
+    local deleted = tostring(Obsidian.dir / "old.md")
+    vim.fn.delete(deleted)
+    require("obsidian.lsp.handlers.did_change_watched_files") {
+      changes = { { uri = vim.uri_from_fname(deleted), type = vim.lsp.protocol.FileChangeType.Deleted } },
+    }
+  ]]
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[^^alpha" })
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+  result = run_completion(0, 9)
+  assert(not vim.iter(result.items or {}):any(function(candidate)
+    return candidate.label == "Alpha original — old"
+  end), "deleted note remained in the vault block index")
 end
 
 T["completion"]["creates a block embed while preserving the leading bang"] = function()
@@ -623,6 +900,29 @@ T["completion"]["creates a block embed while preserving the leading bang"] = fun
   local block_id = target_line:match "(%^[0-9a-f]+)$"
   assert(block_id, "embedded target has no generated block ID")
   eq("![[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
+end
+
+T["completion"]["honors min chars for named-note block queries"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[target#^n",
+    ["target.md"] = "A named needle paragraph",
+  })
+  child.lua [[Obsidian.opts.completion.min_chars = 2]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 11 })
+  local result = run_completion(0, 11)
+  eq({}, result.items)
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "[[target#^ne" })
+  child.api.nvim_win_set_cursor(0, { 1, 12 })
+  result = run_completion(0, 12)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "A named needle paragraph"
+    end),
+    "named-note block completion did not honor min_chars"
+  )
 end
 
 T["completion"]["creates a named-note block reference from unlabeled content after hash caret"] = function()
@@ -706,10 +1006,33 @@ T["completion"]["searches and displays existing block IDs"] = function()
   eq("[[target#^quote-of-the-day]]", item.textEdit.newText)
 end
 
+T["completion"]["honors min chars for current-note block queries"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "A local paragraph\n\n[[^l",
+  })
+  child.lua [[Obsidian.opts.completion.min_chars = 2]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 3, 4 })
+  local result = run_completion(2, 4)
+  eq({}, result.items)
+
+  child.api.nvim_buf_set_lines(0, 2, 3, false, { "[[^lo" })
+  child.api.nvim_win_set_cursor(0, { 3, 5 })
+  result = run_completion(2, 5)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "A local paragraph"
+    end),
+    "current-note block completion did not honor min_chars"
+  )
+end
+
 T["completion"]["creates a current-note block reference from a bare caret trigger"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "A local paragraph\n\n[[^",
   })
+  child.lua [[Obsidian.opts.completion.min_chars = 0]]
 
   child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
   child.api.nvim_win_set_cursor(0, { 3, 3 })
@@ -1136,6 +1459,7 @@ T["completion"]["avoids generated block ID collisions"] = function()
     ["target.md"] = "First paragraph\n\nSecond paragraph",
   })
   child.lua [[
+    Obsidian.opts.completion.min_chars = 0
     _G.obsidian_test_sha256 = vim.fn.sha256
     vim.fn.sha256 = function(value)
       return string.rep(vim.endswith(value, ":1") and "b" or "a", 64)

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -507,6 +507,99 @@ T["completion"]["creates a vault-wide block reference from unlabeled content"] =
   eq("[[target#" .. block_id .. "]]", child.api.nvim_get_current_line())
 end
 
+T["completion"]["reuses the vault block index until the vault changes"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "A needle paragraph\n\n[[^^",
+  })
+  child.lua [[
+    _G.block_search_terms = {}
+    local search = require "obsidian.search"
+    local find_notes_async = search.find_notes_async
+    search.find_notes_async = function(term, ...)
+      table.insert(_G.block_search_terms, term)
+      return find_notes_async(term, ...)
+    end
+  ]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 3, 4 })
+  run_completion(2, 4)
+
+  child.api.nvim_buf_set_lines(0, 0, 1, false, { "A fresh paragraph" })
+  child.api.nvim_buf_set_lines(0, 2, 3, false, { "[[^^fresh" })
+  child.api.nvim_win_set_cursor(0, { 3, 9 })
+  child.api.nvim_exec_autocmds("InsertLeave", {})
+  local result = run_completion(2, 9)
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "A fresh paragraph — source"
+    end),
+    "cached block index did not include unsaved buffer changes"
+  )
+  eq({ "" }, child.lua_get "_G.block_search_terms")
+
+  child.lua [[
+    require("obsidian.lsp.watchfiles").handle {
+      {
+        path = vim.api.nvim_buf_get_name(0),
+        type = vim.lsp.protocol.FileChangeType.Changed,
+      },
+    }
+  ]]
+  result = run_completion(2, 9)
+  eq({ "", "" }, child.lua_get "_G.block_search_terms")
+
+  local item = vim.iter(result.items or {}):find(function(candidate)
+    return candidate.command and candidate.label == "A fresh paragraph — source"
+  end)
+  assert(item, "rebuilt block index did not include the source note")
+  accept_completion(item)
+  local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
+  local block_id = lines[1]:match "(%^[0-9a-f]+)$"
+  assert(block_id, "same-note block did not receive an ID")
+  eq("[[source#" .. block_id .. "]]", lines[3])
+end
+
+T["completion"]["rebuilds a vault block index invalidated while loading"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["source.md"] = "[[^^fresh",
+    ["target.md"] = "Stale target",
+  })
+  child.lua [[
+    local target_path = tostring(Obsidian.dir / "target.md")
+    vim.fn.bufload(vim.fn.bufadd(target_path))
+
+    _G.block_search_scans = 0
+    local search = require "obsidian.search"
+    local find_notes_async = search.find_notes_async
+    search.find_notes_async = function(term, callback, ...)
+      _G.block_search_scans = _G.block_search_scans + 1
+      if _G.block_search_scans == 1 then
+        return find_notes_async(term, function(results)
+          vim.fn.writefile({ "Fresh external target" }, target_path)
+          require("obsidian.lsp.watchfiles").handle {
+            { path = target_path, type = vim.lsp.protocol.FileChangeType.Changed },
+          }
+          callback(results)
+        end, ...)
+      end
+      return find_notes_async(term, callback, ...)
+    end
+  ]]
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "source.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 9 })
+  local result = run_completion(0, 9)
+
+  eq(2, child.lua_get "_G.block_search_scans")
+  assert(
+    vim.iter(result.items or {}):any(function(candidate)
+      return candidate.label == "Fresh external target — target"
+    end),
+    "completion used an invalidated block index"
+  )
+end
+
 T["completion"]["creates a block embed while preserving the leading bang"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["source.md"] = "![[^^embed needle",


### PR DESCRIPTION
# Cache vault-wide block completion

Follow-up to #924, implementing the [suggested performance optimization](https://github.com/obsidian-nvim/obsidian.nvim/pull/924#issuecomment-5274234812).

Related to #505 and #749. This is a performance follow-up and does not close either broader tracker.

## What does the PR do?

Vault-wide `[[^^query` completion now builds a flattened in-memory index of block candidates on first use instead of searching and parsing the vault on every keystroke.

In response to the review feedback:

- A bare or below-threshold `[[^^` request starts warming the index but returns no items.
- Block queries honor `completion.min_chars` using the query after the block prefix; setting it to `0` preserves bare-prefix completion.
- Cached candidates contain request-independent block data. Only candidates matching the current query become LSP completion items.
- Overlapping requests at the same insertion point are coalesced so the latest query wins and every callback settles exactly once.

The index also:

- Is invalidated when watched note files are created, changed, or deleted.
- Is rebuilt on the next vault-wide block completion request.
- Overlays modified buffers so unsaved edits remain searchable, and retains a saved overlay until watcher invalidation prevents stale results during the save/watch race.
- Uses refreshed disk content instead of stale, unmodified loaded buffers after external changes.
- Prevents stale in-flight builds from replacing a newer build after invalidation.
- Generates stable, collision-free block IDs across filtered queries.

## Performance

Synthetic vault: 500 notes, 20 blank-separated paragraphs per note (10,000 block candidates). The selective query matched one item. Times below are medians through the public LSP completion handler.

| Scenario | Before | This PR |
| --- | ---: | ---: |
| Bare `[[^^` response | 390.22 ms / 10,000 items | 4.44 ms / 0 items |
| Warm selective query | 13.60 ms | 2.23 ms |
| Cold selective query | 212.10 ms | 252.59 ms |

Warm selective completion is about 6.1× faster. The cold selective build is about 19% slower because it precomputes reusable candidate metadata; the below-threshold bare request now starts that work in the background without constructing or returning all 10,000 items.

Method: six alternating fresh-process samples for bare and cold queries; 36 warm samples across three processes after one prime per process; `completion.min_chars = 2`, `completion.create_new = false`, GC outside each timer, shared OS filesystem cache.

## Screenshots

N/A — this changes completion performance without changing the UI.

## Testing

- `TZ=UTC make test`: 826 cases, 62 groups, 0 failures.
- Focused completion suite: 65/65 passed.
- Added regressions for `min_chars`, lazy item materialization, generated-ID stability, request coalescing, create/change/delete invalidation, unsaved and just-saved buffer overlays, and stale-build ownership.
- StyLua and `git diff --check` passed locally.
- GitHub Actions validates lint, types, generated docs, changelog, and the supported OS/Neovim test matrix.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md](https://github.com/obsidian-nvim/obsidian.nvim/blob/main/CONTRIBUTING.md) file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the `README.md` file
- [x] The code complies with `make chores` (style, lint, types, and tests are covered locally and/or by GitHub Actions)
