### PR TITLE
feat(daily): configure start of week

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `daily_notes.start_of_week` for configuring Moment-style week formats.
 - Obsidian-style block completion with previews and automatic IDs for unlabeled blocks, using `[[^query`, `[[note^query`, `[[note#^query`, or `[[^^query` (#505, #749).
 - Added separate icons module to support obsidian related filetypes and usecases.
 - Fallback libuv-based fs walker that makes `ripgrep` optional in file finding.

--- a/docs/Daily-Notes.md
+++ b/docs/Daily-Notes.md
@@ -59,7 +59,16 @@ daily_notes = {
 }
 ```
 
-Will create notes in path `daily_notes.folder/year/month/day.md`
+Will create notes in path `daily_notes.folder/year/month/day.md`.
+
+For weekly folders that start on Sunday, set `start_of_week = 0`. This adjusts the Moment-style week tokens `W`, `WW`, `Wo`, `GG`, and `GGGG` without changing the daily date:
+
+```lua
+daily_notes = {
+  date_format = "GGGG-[W]WW/YYYY-MM-DD",
+  start_of_week = 0,
+}
+```
 
 ## Notes
 
@@ -77,6 +86,7 @@ Will create notes in path `daily_notes.folder/year/month/day.md`
 ---@field template? string
 ---@field default_tags? string[]
 ---@field workdays_only? boolean
+---@field start_of_week? integer 0 is Sunday, 1 is Monday, ..., 6 is Saturday.
 daily_notes = {
   enabled = true,
   folder = nil,
@@ -84,5 +94,6 @@ daily_notes = {
   alias_format = nil,
   default_tags = { "daily-notes" },
   workdays_only = true,
+  start_of_week = 1, -- Monday; use 0 for Sunday
 }
 ```

--- a/lua/obsidian/config/default.lua
+++ b/lua/obsidian/config/default.lua
@@ -196,6 +196,7 @@ return {
   ---@field template? string
   ---@field default_tags? string[]
   ---@field workdays_only? boolean
+  ---@field start_of_week? integer 0 is Sunday, 1 is Monday, ..., 6 is Saturday.
   daily_notes = {
     enabled = true,
     folder = nil,
@@ -203,6 +204,7 @@ return {
     alias_format = nil,
     default_tags = { "daily-notes" },
     workdays_only = true,
+    start_of_week = 1, -- Monday
   },
 
   ---@class obsidian.config.UICharSpec

--- a/lua/obsidian/daily/init.lua
+++ b/lua/obsidian/daily/init.lua
@@ -25,7 +25,7 @@ M.daily_note_path = function(datetime, dir)
   end
 
   local date_format = assert(options.daily_notes.date_format, "daily notes date_format is required")
-  local id = tostring(util.format_date(datetime, date_format))
+  local id = tostring(util.format_date(datetime, date_format, options.daily_notes.start_of_week))
 
   path = Path.new(vim.fs.joinpath(tostring(path), id .. ".md"))
 
@@ -56,7 +56,7 @@ local _daily = function(datetime, opts)
   ---@type string|?
   local alias
   if options.daily_notes.alias_format ~= nil then
-    alias = tostring(util.format_date(datetime, options.daily_notes.alias_format))
+    alias = tostring(util.format_date(datetime, options.daily_notes.alias_format, options.daily_notes.start_of_week))
   end
 
   ---@type obsidian.Note

--- a/lua/obsidian/lib/moment/format.lua
+++ b/lua/obsidian/lib/moment/format.lua
@@ -88,14 +88,26 @@ local function week_of_year(date)
   return math.floor((date.yday + (jan1.wday - 1) - 1) / 7) + 1
 end
 
-local function iso_week(date, time)
+local function shift_week(date, time, start_of_week)
+  local day_offset = (1 - (start_of_week or 1)) % 7
+  if day_offset == 0 then
+    return date, time
+  end
+
+  local shifted_time = time + (day_offset * 86400)
+  return os.date("*t", shifted_time), shifted_time
+end
+
+local function iso_week(date, time, start_of_week)
+  date, time = shift_week(date, time, start_of_week)
   local wday = iso_weekday(date.wday)
   local thursday = time + (4 - wday) * 86400
   local thursday_date = os.date("*t", thursday)
   return math.floor((thursday_date.yday - 1) / 7) + 1
 end
 
-local function iso_week_year(date, time)
+local function iso_week_year(date, time, start_of_week)
+  date, time = shift_week(date, time, start_of_week)
   local wday = iso_weekday(date.wday)
   local thursday = time + (4 - wday) * 86400
   return os.date("*t", thursday).year
@@ -202,11 +214,11 @@ end
 handlers["ww"] = function(d)
   return string.format("%02d", week_of_year(d))
 end
-handlers["W"] = function(d, time)
-  return iso_week(d, time)
+handlers["W"] = function(d, time, start_of_week)
+  return iso_week(d, time, start_of_week)
 end
-handlers["WW"] = function(d, time)
-  return string.format("%02d", iso_week(d, time))
+handlers["WW"] = function(d, time, start_of_week)
+  return string.format("%02d", iso_week(d, time, start_of_week))
 end
 handlers["Q"] = function(d)
   return math.floor((d.month - 1) / 3) + 1
@@ -215,15 +227,15 @@ handlers["Qo"] = function(d)
   local q = math.floor((d.month - 1) / 3) + 1
   return tostring(q) .. ordinal_suffix(q)
 end
-handlers["Wo"] = function(d, time)
-  local w = iso_week(d, time)
+handlers["Wo"] = function(d, time, start_of_week)
+  local w = iso_week(d, time, start_of_week)
   return tostring(w) .. ordinal_suffix(w)
 end
-handlers["GGGG"] = function(d, time)
-  return string.format("%04d", iso_week_year(d, time))
+handlers["GGGG"] = function(d, time, start_of_week)
+  return string.format("%04d", iso_week_year(d, time, start_of_week))
 end
-handlers["GG"] = function(d, time)
-  return string.format("%02d", iso_week_year(d, time) % 100)
+handlers["GG"] = function(d, time, start_of_week)
+  return string.format("%02d", iso_week_year(d, time, start_of_week) % 100)
 end
 handlers["Z"] = function(_, time)
   local offset = os.date("%z", time)
@@ -338,8 +350,9 @@ end
 
 ---@param time number
 ---@param fmt string
+---@param start_of_week? integer 0 is Sunday, 1 is Monday, ..., 6 is Saturday.
 ---@returns string
-return function(time, fmt)
+return function(time, fmt, start_of_week)
   local date = os.date("*t", time)
   local ast = grammar:match(fmt)
 
@@ -349,7 +362,7 @@ return function(time, fmt)
 
   for _, node in ipairs(ast) do
     if node.type == "token" then
-      out[#out + 1] = tostring(handlers[node.value](date, time))
+      out[#out + 1] = tostring(handlers[node.value](date, time, start_of_week))
     else
       out[#out + 1] = node.value
     end

--- a/lua/obsidian/resolvers.lua
+++ b/lua/obsidian/resolvers.lua
@@ -109,7 +109,8 @@ local function daily_note_path(datetime)
   end
 
   local date_format = assert(options.daily_notes.date_format, "daily notes date_format is required")
-  local daily_path = path / (tostring(util.format_date(datetime, date_format)) .. ".md")
+  local daily_path = path
+    / (tostring(util.format_date(datetime, date_format, options.daily_notes.start_of_week)) .. ".md")
   ---@cast daily_path obsidian.Path
   return daily_path
 end
@@ -126,10 +127,13 @@ M.builtin.date = function(ctx, done)
 
   ---@type obsidian.PickerEntry[]
   local dailies = {}
+  local options = Obsidian.opts
   for offset = ctx.offset_end, ctx.offset_start, -1 do
     local datetime = os.time() + (offset * 3600 * 24)
     local daily_path = daily_note_path(datetime)
-    local label = tostring(util.format_date(datetime, Obsidian.opts.daily_notes.alias_format or "%A %B %-d, %Y"))
+    local label = tostring(
+      util.format_date(datetime, options.daily_notes.alias_format or "%A %B %-d, %Y", options.daily_notes.start_of_week)
+    )
     if offset == 0 then
       label = label .. " @today"
     elseif offset == -1 then

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -243,14 +243,15 @@ end
 ---
 ---@param time integer
 ---@param fmt string
+---@param start_of_week? integer First day of the week for Moment-style week tokens (0 is Sunday).
 ---@return string formatted date
-util.format_date = function(time, fmt)
+util.format_date = function(time, fmt, start_of_week)
   if fmt:find "%%" then
     local time_string = os.date(fmt, time)
     ---@cast time_string string
     return time_string
   end
-  return require("obsidian.lib.moment").format(time, fmt)
+  return require("obsidian.lib.moment").format(time, fmt, start_of_week)
 end
 
 --- Format a timestamp with strftime or moment.js date format

--- a/tests/test_daily.lua
+++ b/tests/test_daily.lua
@@ -27,6 +27,16 @@ T["daily_note_path"]["should support moment date_format"] = function()
   Obsidian.opts.daily_notes.date_format = previous
 end
 
+T["daily_note_path"]["should support Sunday as the start of the week"] = function()
+  Obsidian.opts.daily_notes.date_format = "GGGG-[W]WW/YYYY-MM-DD"
+  Obsidian.opts.daily_notes.start_of_week = 0
+
+  local sunday = os.time { year = 2026, month = 1, day = 4, hour = 12 }
+  local path, id = M.daily_note_path(sunday)
+  assert(vim.endswith(tostring(path), "2026-W02/2026-01-04.md"))
+  eq("2026-01-04", id)
+end
+
 T["daily_note_path"]["should resolve from an explicit vault directory"] = function()
   local dir = Obsidian.dir / "nested-vault"
   dir:mkdir()


### PR DESCRIPTION
## Summary

- Add `daily_notes.start_of_week`, defaulting to Monday (`1`), with `0` selecting Sunday.
- Apply the configured boundary to Moment-style week number and week-year tokens (`W`, `WW`, `Wo`, `GG`, and `GGGG`) used by daily-note paths and aliases.
- Keep calendar-date tokens unchanged, so Sunday can move to the next weekly folder without changing its daily filename.
- Document the option and add a regression test covering a Sunday boundary.

## Example

```lua
daily_notes = {
  date_format = "GGGG-[W]WW/YYYY-MM-DD",
  start_of_week = 0,
}
```

With this configuration, Sunday 2026-01-04 resolves to `2026-W02/2026-01-04.md`; with the default Monday start it resolves to `2026-W01/2026-01-04.md`.

## Testing

- `make chores`
- 786 tests pass

Closes #767

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented
- [x] The code complies with `make chores` (style, lint, types, and tests)
