### PR TITLE
fix(templates): support absolute folder paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Absolute `templates.folder` paths resolve outside the vault without creating nested directories inside it (#761).
 - `ripgrep` tag search will work for `fileformat=dos`.
 - Fzf-lua builtin previews work with the fzf-tmux profile.
 - Fzf-lua picker selections now honor multi-select consistently across files, grep, and list pickers.

--- a/docs/Template.md
+++ b/docs/Template.md
@@ -233,6 +233,7 @@ biography = {
 ---@class obsidian.config.TemplateOpts
 ---
 ---@field enabled boolean|?
+---Folder containing templates, either relative to the vault root or an absolute path.
 ---@field folder string|obsidian.Path|?
 ---@field date_format string
 ---@field time_format string

--- a/lua/obsidian/api.lua
+++ b/lua/obsidian/api.lua
@@ -52,8 +52,13 @@ M.templates_dir = function(workspace)
     return nil
   end
 
-  local paths_to_check =
-    { (workspace or Obsidian.workspace).root / opts.templates.folder, Path.new(opts.templates.folder) }
+  local configured_path = Path.new(opts.templates.folder)
+  local paths_to_check
+  if configured_path:is_absolute() then
+    paths_to_check = { configured_path }
+  else
+    paths_to_check = { (workspace or Obsidian.workspace).root / configured_path, configured_path }
+  end
   for _, path in ipairs(paths_to_check) do
     if path:is_dir() then
       return path

--- a/lua/obsidian/config/default.lua
+++ b/lua/obsidian/config/default.lua
@@ -91,6 +91,7 @@ return {
   ---@class obsidian.config.TemplateOpts
   ---
   ---@field enabled boolean|?
+  ---Folder containing templates, either relative to the vault root or an absolute path.
   ---@field folder string|obsidian.Path|?
   ---@field date_format string
   ---@field time_format string

--- a/lua/obsidian/workspace.lua
+++ b/lua/obsidian/workspace.lua
@@ -154,7 +154,11 @@ Workspace.set = function(workspace)
   end
 
   if options.templates.enabled and options.templates.folder then
-    (dir / options.templates.folder):mkdir { parents = true }
+    local templates_dir = Path.new(options.templates.folder)
+    if not templates_dir:is_absolute() then
+      templates_dir = dir / templates_dir
+    end
+    templates_dir:mkdir { parents = true }
   end
 
   if options.daily_notes.enabled and options.daily_notes.folder then

--- a/tests/test_templates.lua
+++ b/tests/test_templates.lua
@@ -102,6 +102,27 @@ T["substitute_template_variables()"]["should pass suffix to substitution functio
   eq("value is hello", M.substitute_template_variables(text, tmp_template_context()))
 end
 
+T["templates_dir()"] = new_set()
+
+T["templates_dir()"]["should support an absolute path outside the vault"] = function()
+  local Path = require "obsidian.path"
+  local Workspace = require "obsidian.workspace"
+  local templates_dir = Path.temp { suffix = "-templates" }
+  templates_dir:mkdir()
+
+  local malformed_dir = Obsidian.dir / templates_dir
+  local ws = assert(Workspace.new {
+    path = Obsidian.dir,
+    overrides = { templates = { folder = tostring(templates_dir) } },
+  })
+  Workspace.set(ws)
+
+  eq(templates_dir, api.templates_dir())
+  eq(false, malformed_dir:exists())
+
+  vim.fn.delete(tostring(templates_dir), "rf")
+end
+
 T["clone_template()"] = new_set()
 
 T["clone_template()"]["should transfer title from partial_note"] = function()


### PR DESCRIPTION
## What does the PR do?

- Resolves absolute `templates.folder` paths directly instead of joining them to the vault root.
- Creates the configured absolute templates directory without creating a malformed nested path inside the vault.
- Adds regression coverage and documents absolute-path support.

Closes #761

## Screenshots

Not applicable; this changes path resolution behavior.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] The changes are documented in the template configuration docs
- [x] The code complies with `make chores` (for style, lint, types, and tests)
