### PR TITLE
feat(bookmark): add, del and picker actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional `bufnr` and `position` arguments on `api.cursor_link` / `api.cursor_tag`.
 - `Note.rename` for scripting note renames.
 - Invalid filenames are checked on `Note.create` and `Note.rename`.
+- Bookmark management support for adding the current note, heading, block, or URL, bookmarking note picker selections, removing bookmarks, and moving bookmarks into groups.
 
 ### Fixed
 

--- a/docs/Bookmarks.md
+++ b/docs/Bookmarks.md
@@ -16,4 +16,4 @@ See: <https://help.obsidian.md/bookmarks>
 
 - No `graph` type — Obsidian app does not bookmark graph views.
 - `search` type is partial — passes raw query to grep. Proper Obsidian search-term parser pending: https://github.com/obsidian-nvim/obsidian.nvim/issues/542
-- Adding / editing / removing bookmarks not implemented. Read-only for now — manage them in Obsidian app.
+- Editing bookmarks is not implemented. Bookmarks can be added from code actions and note pickers, moved into groups from the bookmark picker, or removed through the Lua API.

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -670,7 +670,7 @@ local function bookmark_context()
   -- URL under cursor (Markdown link)
   local link, link_type = api.cursor_link()
   if link and link_type == "markdown" then
-    local loc = link:match "%((.-)%)"
+    local loc = link:match "^%[.-%]%((.*)%)$"
     if loc then
       local is_uri, scheme = util.is_uri(loc)
       if is_uri and (scheme == "http" or scheme == "https") then
@@ -707,12 +707,12 @@ M.add_bookmark = function()
   end
 
   local note = api.current_note(0)
-  local ctime = os.time() * 1000
+  local ctime = Bookmarks.new_ctime()
 
   if ctx.kind == "url" then
     local link = api.cursor_link()
     local title = link and link:match "%[(.-)%]" or nil
-    local url = link and link:match "%((.-)%)" or nil
+    local url = link and link:match "^%[.-%]%((.*)%)$" or nil
     if not url then
       return log.warn "No URL under cursor"
     end

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -662,6 +662,117 @@ M.toggle_recording = function()
   require("obsidian.core-plugins.audio_recorder").toggle()
 end
 
+---Inspect cursor context and return a description of what would be bookmarked.
+---@return { kind: "url"|"block"|"heading"|"note", label: string }?
+local function bookmark_context()
+  local note = api.current_note(0)
+
+  -- URL under cursor (Markdown link)
+  local link, link_type = api.cursor_link()
+  if link and link_type == "markdown" then
+    local loc = link:match "%((.-)%)"
+    if loc then
+      local is_uri, scheme = util.is_uri(loc)
+      if is_uri and (scheme == "http" or scheme == "https") then
+        return { kind = "url", label = "URL under cursor" }
+      end
+    end
+  end
+
+  -- Block under cursor
+  local line = vim.api.nvim_get_current_line()
+  local block = util.parse_block(line)
+  if block and note then
+    return { kind = "block", label = "block under cursor" }
+  end
+
+  -- Heading under cursor
+  local heading = api.cursor_heading()
+  if heading and note then
+    return { kind = "heading", label = "heading under cursor" }
+  end
+
+  if note then
+    return { kind = "note", label = "current note" }
+  end
+end
+
+---Bookmark whatever is under the cursor: URL, block, heading; fallback to the current note.
+M.add_bookmark = function()
+  local Bookmarks = require "obsidian.bookmarks"
+  local ctx = bookmark_context()
+  if not ctx then
+    log.warn "Nothing to bookmark"
+    return
+  end
+
+  local note = api.current_note(0)
+  local ctime = os.time() * 1000
+
+  if ctx.kind == "url" then
+    local link = api.cursor_link()
+    local title = link and link:match "%[(.-)%]" or nil
+    local url = link and link:match "%((.-)%)" or nil
+    if not url then
+      return log.warn "No URL under cursor"
+    end
+    local ok = Bookmarks.add { type = "url", url = url, title = title or url, ctime = ctime }
+    if ok then
+      log.info("Bookmarked URL: %s", url)
+    end
+  elseif ctx.kind == "block" and note then
+    local line = vim.api.nvim_get_current_line()
+    local block = util.parse_block(line)
+    local rel = note.path and note.path:vault_relative_path()
+    if not rel then
+      return log.err "Cannot resolve note path"
+    end
+    local subpath = "#" .. block
+    local ok = Bookmarks.add {
+      type = "file",
+      path = rel,
+      subpath = subpath,
+      title = (note.title or note.id or rel) .. " > " .. block,
+      ctime = ctime,
+    }
+    if ok then
+      log.info("Bookmarked block: %s", block)
+    end
+  elseif ctx.kind == "heading" and note then
+    local heading = api.cursor_heading()
+    local rel = note.path and note.path:vault_relative_path()
+    if not rel or not heading then
+      return log.err "Cannot resolve heading"
+    end
+    local ok = Bookmarks.add {
+      type = "file",
+      path = rel,
+      subpath = "#" .. heading.header,
+      title = (note.title or note.id or rel) .. " > " .. heading.header,
+      ctime = ctime,
+    }
+    if ok then
+      log.info("Bookmarked heading: %s", heading.header)
+    end
+  elseif ctx.kind == "note" and note then
+    local rel = note.path and note.path:vault_relative_path()
+    if not rel then
+      return log.err "Cannot resolve note path"
+    end
+    local ok = Bookmarks.add {
+      type = "file",
+      path = rel,
+      title = note.title or note.id or rel,
+      ctime = ctime,
+    }
+    if ok then
+      log.info("Bookmarked note: %s", rel)
+    end
+  end
+end
+
+M._bookmark_context = bookmark_context
+
 M.add_property = function()
   local note = assert(api.current_note(0))
 

--- a/lua/obsidian/bookmarks.lua
+++ b/lua/obsidian/bookmarks.lua
@@ -6,6 +6,26 @@ local util = require "obsidian.util"
 
 local M = {}
 
+---@type integer
+local last_ctime = 0
+
+---@return integer
+M.new_ctime = function()
+  local seconds, microseconds = vim.uv.gettimeofday()
+  if not seconds or not microseconds then
+    last_ctime = last_ctime + 1
+    return last_ctime
+  end
+  local ctime = math.floor(seconds * 1000 + microseconds / 1000)
+  ---@cast ctime integer
+  if ctime <= last_ctime then
+    ctime = last_ctime + 1
+    ---@cast ctime integer
+  end
+  last_ctime = ctime
+  return ctime
+end
+
 ---@class obsidian.Bookmark
 ---@field ctime integer
 ---@field type "group" | "file" | "folder" | "search" | "url"
@@ -111,7 +131,7 @@ local function preview_group(bookmark, buf)
   vim.bo[buf].filetype = "markdown"
   local lines = vim.tbl_map(function(bm)
     return "- " .. format_bookmark(bm)
-  end, bookmark.items)
+  end, bookmark.items or {})
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   return { buf = buf }
 end
@@ -185,37 +205,47 @@ M.resolve_bookmark_file = function(opts)
       f:write '{"items":[]}'
       f:close()
     else
-      log.info "bookmark file does not exist, adding and managing bookmarks is not supported yet"
+      log.info "bookmark file does not exist"
       return
     end
   end
   return tostring(bookmark_file)
 end
 
----Append a bookmark to the vault's bookmarks.json file.
----@param bookmark obsidian.Bookmark
----@return boolean ok
-M.add = function(bookmark)
-  local fp = M.resolve_bookmark_file { create = true }
+---@param create boolean
+---@return string?, { items: obsidian.Bookmark[] }?
+local function read_bookmark_file(create)
+  local fp = M.resolve_bookmark_file { create = create }
   if not fp then
-    return false
+    return nil, nil
   end
 
   local f = io.open(fp, "r")
   if not f then
     log.err "failed to open bookmarks file"
-    return false
+    return nil, nil
   end
   local src = f:read "*a"
   f:close()
 
   local ok, obj = pcall(vim.json.decode, src)
   if not ok or type(obj) ~= "table" then
-    obj = { items = {} }
+    log.err "failed to parse bookmarks file"
+    return nil, nil
   end
-  obj.items = obj.items or {}
-  table.insert(obj.items, bookmark)
+  if obj.items == nil then
+    obj.items = {}
+  elseif type(obj.items) ~= "table" then
+    log.err "invalid items in bookmarks file"
+    return nil, nil
+  end
+  return fp, obj
+end
 
+---@param fp string
+---@param obj { items: obsidian.Bookmark[] }
+---@return boolean ok
+local function write_bookmark_file(fp, obj)
   local out = io.open(fp, "w")
   if not out then
     log.err "failed to write bookmarks file"
@@ -224,6 +254,112 @@ M.add = function(bookmark)
   out:write(vim.json.encode(obj))
   out:close()
   return true
+end
+
+---Append a bookmark to the vault's bookmarks.json file.
+---@param bookmark obsidian.Bookmark
+---@return boolean ok
+M.add = function(bookmark)
+  local fp, obj = read_bookmark_file(true)
+  if not fp or not obj then
+    return false
+  end
+
+  table.insert(obj.items, bookmark)
+  return write_bookmark_file(fp, obj)
+end
+
+---@param items obsidian.Bookmark[]
+---@param ctime integer
+---@return obsidian.Bookmark?
+local function remove_bookmark(items, ctime)
+  for i, bookmark in ipairs(items) do
+    if bookmark.ctime == ctime then
+      return table.remove(items, i)
+    end
+    if bookmark.items then
+      local removed = remove_bookmark(bookmark.items, ctime)
+      if removed then
+        return removed
+      end
+    end
+  end
+end
+
+---@param bookmark obsidian.Bookmark
+---@return boolean ok
+M.del = function(bookmark)
+  local fp, obj = read_bookmark_file(false)
+  if not fp or not obj or not remove_bookmark(obj.items, bookmark.ctime) then
+    return false
+  end
+  return write_bookmark_file(fp, obj)
+end
+
+---@type obsidian.Bookmark
+local CREATE_NEW_GROUP = { ctime = -1, type = "group", title = "", items = {} }
+
+---@param items obsidian.Bookmark[]
+---@param groups obsidian.Bookmark[]
+local function collect_groups(items, groups)
+  for _, bookmark in ipairs(items) do
+    if bookmark.type == "group" then
+      groups[#groups + 1] = bookmark
+      collect_groups(bookmark.items or {}, groups)
+    end
+  end
+end
+
+---@param bookmark obsidian.Bookmark
+M.move_to_group = function(bookmark)
+  local fp, obj = read_bookmark_file(false)
+  if not fp or not obj then
+    return
+  end
+
+  local moved = remove_bookmark(obj.items, bookmark.ctime)
+  if not moved then
+    log.warn "Bookmark no longer exists"
+    return
+  end
+
+  local groups = {}
+  collect_groups(obj.items, groups)
+  groups[#groups + 1] = CREATE_NEW_GROUP
+
+  picker.select(groups, {
+    prompt = "Move bookmark to group",
+    format_item = function(group)
+      if group == CREATE_NEW_GROUP then
+        return "+ Create new group"
+      end
+      return group.title or "Untitled group"
+    end,
+  }, function(choices)
+    ---@type obsidian.Bookmark?
+    local group = choices[1]
+    if not group then
+      return
+    end
+
+    if group == CREATE_NEW_GROUP then
+      local title = api.input "New bookmark group name"
+      if not title or title == "" then
+        return
+      end
+      group = {
+        ctime = M.new_ctime(),
+        type = "group",
+        title = title,
+        items = {},
+      }
+      obj.items[#obj.items + 1] = group
+    end
+
+    group.items = group.items or {}
+    group.items[#group.items + 1] = moved
+    write_bookmark_file(fp, obj)
+  end)
 end
 
 ---@param src string
@@ -241,7 +377,7 @@ local function open_bookmark(bookmark)
   if bookmark.type == "url" and bookmark.url then
     vim.ui.open(bookmark.url)
   elseif bookmark.type == "group" then
-    M.pick(bookmark.items)
+    M.pick(bookmark.items or {})
   elseif bookmark.type == "search" and bookmark.query then
     -- TODO: proper obsidian search term parser and search
     picker.grep {
@@ -276,6 +412,16 @@ M.pick = function(bookmarks)
     prompt = "Bookmarks",
     format_item = format_bookmark,
     preview_item = preview_bookmark,
+    selection_mappings = {
+      ["<C-g>"] = {
+        desc = "move to group",
+        callback = M.move_to_group,
+      },
+      ["<C-x>"] = {
+        desc = "remove",
+        callback = M.del,
+      },
+    },
   }, function(items)
     open_bookmark(items[1])
   end)

--- a/lua/obsidian/bookmarks.lua
+++ b/lua/obsidian/bookmarks.lua
@@ -9,13 +9,13 @@ local M = {}
 ---@class obsidian.Bookmark
 ---@field ctime integer
 ---@field type "group" | "file" | "folder" | "search" | "url"
----@field path string
----@field _path string resolved path
----@field subpath string
----@field title string
----@field query string
----@field items obsidian.Bookmark[]
----@field url string|?
+---@field path string?
+---@field _path string? resolved path
+---@field subpath string?
+---@field title string?
+---@field query string?
+---@field items obsidian.Bookmark[]?
+---@field url string?
 
 ---@param bookmark obsidian.Bookmark
 ---@return obsidian.PickerEntry entry
@@ -165,15 +165,65 @@ local function preview_bookmark(bookmark)
   end
 end
 
+---@param opts { create: boolean? }?
 ---@return string?
-M.resolve_bookmark_file = function()
+M.resolve_bookmark_file = function(opts)
+  opts = opts or {}
   local bookmark_file = api.resolve_workspace_dir() / ".obsidian" / "bookmarks.json"
 
   if not bookmark_file:exists() then
-    log.info "bookmark file does not exist, adding and managing bookmarks is not supported yet"
-    return
+    if opts.create then
+      local parent = bookmark_file:parent()
+      if parent and not parent:exists() then
+        vim.fn.mkdir(tostring(parent), "p")
+      end
+      local f = io.open(tostring(bookmark_file), "w")
+      if not f then
+        log.err "failed to create bookmarks file"
+        return
+      end
+      f:write '{"items":[]}'
+      f:close()
+    else
+      log.info "bookmark file does not exist, adding and managing bookmarks is not supported yet"
+      return
+    end
   end
   return tostring(bookmark_file)
+end
+
+---Append a bookmark to the vault's bookmarks.json file.
+---@param bookmark obsidian.Bookmark
+---@return boolean ok
+M.add = function(bookmark)
+  local fp = M.resolve_bookmark_file { create = true }
+  if not fp then
+    return false
+  end
+
+  local f = io.open(fp, "r")
+  if not f then
+    log.err "failed to open bookmarks file"
+    return false
+  end
+  local src = f:read "*a"
+  f:close()
+
+  local ok, obj = pcall(vim.json.decode, src)
+  if not ok or type(obj) ~= "table" then
+    obj = { items = {} }
+  end
+  obj.items = obj.items or {}
+  table.insert(obj.items, bookmark)
+
+  local out = io.open(fp, "w")
+  if not out then
+    log.err "failed to write bookmarks file"
+    return false
+  end
+  out:write(vim.json.encode(obj))
+  out:close()
+  return true
 end
 
 ---@param src string

--- a/lua/obsidian/bookmarks.lua
+++ b/lua/obsidian/bookmarks.lua
@@ -417,7 +417,7 @@ M.pick = function(bookmarks)
         desc = "move to group",
         callback = M.move_to_group,
       },
-      ["<C-x>"] = {
+      ["<C-r>"] = {
         desc = "remove",
         callback = M.del,
       },

--- a/lua/obsidian/config/default.lua
+++ b/lua/obsidian/config/default.lua
@@ -164,9 +164,11 @@ return {
   ---@field tag_mappings? obsidian.config.PickerTagMappingOpts
   picker = {
     name = nil,
+    -- TODO: migrate mappings.bookmark mappings.quick_switch mappings.tag or bookmark.mappings quick_switch.mappings tag.mappings | daily_notes.mappings? attachments.mappings?
     note_mappings = {
       new = "<C-x>",
       insert_link = "<C-l>",
+      bookmark = "<C-b>",
     },
     tag_mappings = {
       tag_note = "<C-x>",

--- a/lua/obsidian/config/removed.lua
+++ b/lua/obsidian/config/removed.lua
@@ -25,10 +25,6 @@ return function(user_opts, defaults)
       opts.picker.note_mappings = opts.finder_mappings
       opts.finder_mappings = nil
     end
-    if opts.picker.mappings and not opts.picker.note_mappings then
-      opts.picker.note_mappings = opts.picker.mappings
-      opts.picker.mappings = nil
-    end
   end
 
   if opts.completion ~= nil and opts.completion.preferred_link_style ~= nil then

--- a/lua/obsidian/config/validate.lua
+++ b/lua/obsidian/config/validate.lua
@@ -366,6 +366,7 @@ function M.validate(opts, skip_workspace_overrides)
       fields(errors, "picker.note_mappings", opts.picker.note_mappings, {
         { "new", "string" },
         { "insert_link", "string" },
+        { "bookmark", "string" },
       })
     end
     if type(opts.picker.tag_mappings) == "table" then

--- a/lua/obsidian/lsp/handlers/_code_action.lua
+++ b/lua/obsidian/lsp/handlers/_code_action.lua
@@ -1,25 +1,20 @@
----@class obsidian.lsp.CodeActionData
----@field title string|fun(note: obsidian.Note): string
----@field cond fun(note: obsidian.Note): boolean
-
----@class obsidian.lsp.CodeAction : lsp.CodeAction
----@field data obsidian.lsp.CodeActionData
-
----@type table<string, obsidian.lsp.CodeAction>
+---@type table<string, obsidian.lsp.CodeActionOpts>
 local code_actions = {}
 
 ---@class obsidian.lsp.CodeActionOpts
 ---@field name string unique name
----@field title string|fun(note: obsidian.Note): string text display in code action interface
----@field cond? fun(note: obsidian.Note): boolean function used to determine whether code actoin is shown
+---@field title string|fun(note?: obsidian.Note): string text display in code action interface; may be evaluated each request for dynamic context
+---@field cond? fun(note: obsidian.Note): boolean function used to determine whether code action is shown
 ---@field fn? function
 
----Register a new command.
+---Resolve registered opts into an lsp.CodeAction, evaluating dynamic titles.
 ---@param opts obsidian.lsp.CodeActionOpts
-local add = function(opts)
-  -- TODO: validate
-  local title = type(opts.title) == "string" and opts.title or ""
-  local action = {
+---@param note? obsidian.Note
+---@return lsp.CodeAction
+local resolve = function(opts, note)
+  local title = type(opts.title) == "function" and opts.title(note) or opts.title
+  ---@cast title string
+  return {
     title = title,
     command = {
       title = title,
@@ -34,13 +29,18 @@ local add = function(opts)
       -- TODO: preview?
     },
   }
+end
 
+---Register a new command.
+---@param opts obsidian.lsp.CodeActionOpts
+local add = function(opts)
+  -- TODO: validate
   if opts.fn then
     vim.lsp.commands["obsidian." .. opts.name] = vim.schedule_wrap(function(params)
       opts.fn(unpack(params.arguments or {}))
     end)
   end
-  code_actions[opts.name] = action
+  code_actions[opts.name] = opts
 end
 
 local function in_visual()
@@ -115,6 +115,17 @@ local default_actions = {
       return is_recording_audio() and "Stop recording audio" or "Start recording audio as attachment"
     end,
   },
+
+  add_bookmark = {
+    title = function()
+      local actions = require "obsidian.actions"
+      local ctx = actions._bookmark_context()
+      if not ctx then
+        return "Bookmark current location"
+      end
+      return "Bookmark " .. ctx.label
+    end,
+  },
 }
 
 ---@param name string
@@ -132,4 +143,5 @@ return {
   actions = code_actions,
   add = add,
   del = del,
+  resolve = resolve,
 }

--- a/lua/obsidian/lsp/handlers/_code_action.lua
+++ b/lua/obsidian/lsp/handlers/_code_action.lua
@@ -1,20 +1,25 @@
----@type table<string, obsidian.lsp.CodeActionOpts>
+---@class obsidian.lsp.CodeActionData
+---@field title string|fun(note: obsidian.Note): string
+---@field cond fun(note: obsidian.Note): boolean
+
+---@class obsidian.lsp.CodeAction : lsp.CodeAction
+---@field data obsidian.lsp.CodeActionData
+
+---@type table<string, obsidian.lsp.CodeAction>
 local code_actions = {}
 
 ---@class obsidian.lsp.CodeActionOpts
 ---@field name string unique name
----@field title string|fun(note?: obsidian.Note): string text display in code action interface; may be evaluated each request for dynamic context
----@field cond? fun(note: obsidian.Note): boolean function used to determine whether code action is shown
+---@field title string|fun(note: obsidian.Note): string text display in code action interface
+---@field cond? fun(note: obsidian.Note): boolean function used to determine whether code actoin is shown
 ---@field fn? function
 
----Resolve registered opts into an lsp.CodeAction, evaluating dynamic titles.
+---Register a new command.
 ---@param opts obsidian.lsp.CodeActionOpts
----@param note? obsidian.Note
----@return lsp.CodeAction
-local resolve = function(opts, note)
-  local title = type(opts.title) == "function" and opts.title(note) or opts.title
-  ---@cast title string
-  return {
+local add = function(opts)
+  -- TODO: validate
+  local title = type(opts.title) == "string" and opts.title or ""
+  local action = {
     title = title,
     command = {
       title = title,
@@ -29,18 +34,13 @@ local resolve = function(opts, note)
       -- TODO: preview?
     },
   }
-end
 
----Register a new command.
----@param opts obsidian.lsp.CodeActionOpts
-local add = function(opts)
-  -- TODO: validate
   if opts.fn then
     vim.lsp.commands["obsidian." .. opts.name] = vim.schedule_wrap(function(params)
       opts.fn(unpack(params.arguments or {}))
     end)
   end
-  code_actions[opts.name] = opts
+  code_actions[opts.name] = action
 end
 
 local function in_visual()
@@ -143,5 +143,4 @@ return {
   actions = code_actions,
   add = add,
   del = del,
-  resolve = resolve,
 }

--- a/lua/obsidian/lsp/handlers/code_action.lua
+++ b/lua/obsidian/lsp/handlers/code_action.lua
@@ -1,26 +1,16 @@
-local actions = require("obsidian.lsp.handlers._code_action").actions
+local _ca = require "obsidian.lsp.handlers._code_action"
+local actions = _ca.actions
+local resolve = _ca.resolve
 
----@param title string|fun(note: obsidian.Note): string
----@param note obsidian.Note
----@return string
-local function eval_title(title, note)
-  if type(title) == "function" then
-    return title(note)
-  end
-  return title
-end
-
----@param code_actions table<string, obsidian.lsp.CodeAction>
+---@param code_actions table<string, obsidian.lsp.CodeActionOpts>
 ---@param note obsidian.Note
 ---@return lsp.CodeAction[]
 local function get_commands_by_context(code_actions, note)
   local out = {}
-  for _, code_action in ipairs(vim.tbl_values(code_actions)) do
-    local data = code_action.data
-    if data.cond(note) then
-      local title = eval_title(data.title, note)
-      local command = vim.tbl_extend("force", code_action.command or {}, { title = title })
-      out[#out + 1] = vim.tbl_extend("force", code_action, { title = title, command = command })
+  for _, opts in ipairs(vim.tbl_values(code_actions)) do
+    local cond = opts.cond
+    if not cond or cond(note) then
+      out[#out + 1] = resolve(opts, note)
     end
   end
   return out

--- a/lua/obsidian/lsp/handlers/code_action.lua
+++ b/lua/obsidian/lsp/handlers/code_action.lua
@@ -1,16 +1,26 @@
-local _ca = require "obsidian.lsp.handlers._code_action"
-local actions = _ca.actions
-local resolve = _ca.resolve
+local actions = require("obsidian.lsp.handlers._code_action").actions
 
----@param code_actions table<string, obsidian.lsp.CodeActionOpts>
+---@param title string|fun(note: obsidian.Note): string
+---@param note obsidian.Note
+---@return string
+local function eval_title(title, note)
+  if type(title) == "function" then
+    return title(note)
+  end
+  return title
+end
+
+---@param code_actions table<string, obsidian.lsp.CodeAction>
 ---@param note obsidian.Note
 ---@return lsp.CodeAction[]
 local function get_commands_by_context(code_actions, note)
   local out = {}
-  for _, opts in ipairs(vim.tbl_values(code_actions)) do
-    local cond = opts.cond
-    if not cond or cond(note) then
-      out[#out + 1] = resolve(opts, note)
+  for _, code_action in ipairs(vim.tbl_values(code_actions)) do
+    local data = code_action.data
+    if data.cond(note) then
+      local title = eval_title(data.title, note)
+      local command = vim.tbl_extend("force", code_action.command or {}, { title = title })
+      out[#out + 1] = vim.tbl_extend("force", code_action, { title = title, command = command })
     end
   end
   return out

--- a/lua/obsidian/picker/init.lua
+++ b/lua/obsidian/picker/init.lua
@@ -406,6 +406,13 @@ M._note_selection_mappings = function()
     }
   end
 
+  if key_is_set(note_mappings.bookmark) then
+    mappings[note_mappings.bookmark] = {
+      desc = "bookmark",
+      callback = Mappings.bookmark,
+    }
+  end
+
   return mappings
 end
 

--- a/lua/obsidian/picker/mappings.lua
+++ b/lua/obsidian/picker/mappings.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local Note = require "obsidian.note"
+local Path = require "obsidian.path"
 local log = require "obsidian.log"
 local api = require "obsidian.api"
 
@@ -65,6 +66,19 @@ M.new_note = function(query)
   end
   ---@diagnostic disable-next-line: missing-fields,param-type-mismatch
   require "obsidian.commands.new" { args = query }
+end
+
+---@param path string
+M.bookmark = function(path)
+  if not path or path == "" then
+    return
+  end
+  local Bookmarks = require "obsidian.bookmarks"
+  Bookmarks.add {
+    ctime = Bookmarks.new_ctime(),
+    path = Path.new(path):vault_relative_path(),
+    type = "file",
+  }
 end
 
 return M

--- a/tests/test_bookmarks.lua
+++ b/tests/test_bookmarks.lua
@@ -161,4 +161,154 @@ M.pick {
   eq("wipe", child.lua_get [[preview_bufhidden]])
 end
 
+T["add"], child = h.child_vault {
+  pre_case = [[
+M = require "obsidian.bookmarks"
+A = require "obsidian.actions"
+  ]],
+}
+
+T["add"]["bookmarks current note when nothing under cursor"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "# Hello\n\nbody line\n",
+  })
+
+  child.lua(string.format(
+    [[
+vim.cmd("edit " .. vim.fn.fnameescape(%q))
+vim.api.nvim_win_set_cursor(0, { 3, 0 }) -- on "body line"
+A.add_bookmark()
+
+local fp = M.resolve_bookmark_file()
+local f = io.open(fp, "r")
+_G.src = f:read("*a")
+f:close()
+  ]],
+    tostring(dir / "note.md")
+  ))
+
+  local src = child.lua_get [[src]]
+  local obj = vim.json.decode(src)
+  eq(#obj.items, 1)
+  eq(obj.items[1].type, "file")
+  eq(obj.items[1].path, "note.md")
+end
+
+T["add"]["bookmarks heading under cursor"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "# Hello\n\nbody line\n",
+  })
+
+  child.lua(string.format(
+    [[
+vim.cmd("edit " .. vim.fn.fnameescape(%q))
+vim.api.nvim_win_set_cursor(0, { 1, 0 })
+A.add_bookmark()
+
+local fp = M.resolve_bookmark_file()
+local f = io.open(fp, "r")
+_G.src = f:read("*a")
+f:close()
+  ]],
+    tostring(dir / "note.md")
+  ))
+
+  local src = child.lua_get [[src]]
+  local obj = vim.json.decode(src)
+  eq(#obj.items, 1)
+  eq(obj.items[1].type, "file")
+  eq(obj.items[1].subpath, "#Hello")
+end
+
+T["add"]["bookmarks block under cursor"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "intro line ^my-block\nnext\n",
+  })
+
+  child.lua(string.format(
+    [[
+vim.cmd("edit " .. vim.fn.fnameescape(%q))
+vim.api.nvim_win_set_cursor(0, { 1, 0 })
+A.add_bookmark()
+
+local fp = M.resolve_bookmark_file()
+local f = io.open(fp, "r")
+_G.src = f:read("*a")
+f:close()
+  ]],
+    tostring(dir / "note.md")
+  ))
+
+  local src = child.lua_get [[src]]
+  local obj = vim.json.decode(src)
+  eq(#obj.items, 1)
+  eq(obj.items[1].type, "file")
+  eq(obj.items[1].subpath, "#^my-block")
+end
+
+T["add"]["bookmarks url under cursor"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "see [ChatGPT](https://chatgpt.com/) please\n",
+  })
+
+  child.lua(string.format(
+    [[
+vim.cmd("edit " .. vim.fn.fnameescape(%q))
+vim.api.nvim_win_set_cursor(0, { 1, 8 }) -- inside the markdown link
+A.add_bookmark()
+
+local fp = M.resolve_bookmark_file()
+local f = io.open(fp, "r")
+_G.src = f:read("*a")
+f:close()
+  ]],
+    tostring(dir / "note.md")
+  ))
+
+  local src = child.lua_get [[src]]
+  local obj = vim.json.decode(src)
+  eq(#obj.items, 1)
+  eq(obj.items[1].type, "url")
+  eq(obj.items[1].url, "https://chatgpt.com/")
+  eq(obj.items[1].title, "ChatGPT")
+end
+
+T["add"]["dynamic code action title reflects context"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "# Hello\n\nsee [ChatGPT](https://chatgpt.com/)\n",
+  })
+
+  child.lua(string.format(
+    [[
+vim.cmd("edit " .. vim.fn.fnameescape(%q))
+local ca = require "obsidian.lsp.handlers._code_action"
+local opts = ca.actions.add_bookmark
+
+vim.api.nvim_win_set_cursor(0, { 1, 0 })
+_G.t_heading = ca.resolve(opts).title
+
+vim.api.nvim_win_set_cursor(0, { 3, 8 })
+_G.t_url = ca.resolve(opts).title
+
+vim.api.nvim_win_set_cursor(0, { 3, 0 })
+_G.t_note = ca.resolve(opts).title
+  ]],
+    tostring(dir / "note.md")
+  ))
+
+  eq(child.lua_get [[t_heading]], "Bookmark heading under cursor")
+  eq(child.lua_get [[t_url]], "Bookmark URL under cursor")
+  eq(child.lua_get [[t_note]], "Bookmark current note")
+end
+
 return T

--- a/tests/test_bookmarks.lua
+++ b/tests/test_bookmarks.lua
@@ -161,6 +161,101 @@ M.pick {
   eq("wipe", child.lua_get [[preview_bufhidden]])
 end
 
+T["groups"], child = h.child_vault {
+  pre_case = [[M = require "obsidian.bookmarks"]],
+}
+
+T["groups"]["moves a bookmark into an existing group"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "# Note\n",
+    [".obsidian/bookmarks.json"] = vim.json.encode {
+      items = {
+        { type = "file", ctime = 1, path = "note.md" },
+        { type = "group", ctime = 2, title = "Work", items = {} },
+      },
+    },
+  })
+
+  child.lua [[
+local picker = require "obsidian.picker"
+picker.select = function(items, opts, callback)
+  _G.group_prompt = opts.prompt
+  _G.group_labels = vim.tbl_map(opts.format_item, items)
+  callback { items[1] }
+end
+M.move_to_group { type = "file", ctime = 1, path = "note.md" }
+local f = assert(io.open(M.resolve_bookmark_file(), "r"))
+_G.bookmarks = vim.json.decode(f:read "*a")
+f:close()
+]]
+
+  eq("Move bookmark to group", child.lua_get [[group_prompt]])
+  eq({ "Work", "+ Create new group" }, child.lua_get [[group_labels]])
+  local bookmarks = child.lua_get [[bookmarks]]
+  eq(1, #bookmarks.items)
+  eq("group", bookmarks.items[1].type)
+  eq(1, bookmarks.items[1].items[1].ctime)
+end
+
+T["groups"]["creates a new group when moving a bookmark"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "# Note\n",
+    [".obsidian/bookmarks.json"] = vim.json.encode {
+      items = {
+        { type = "file", ctime = 1, path = "note.md" },
+      },
+    },
+  })
+
+  child.lua [[
+local picker = require "obsidian.picker"
+local api = require "obsidian.api"
+picker.select = function(items, _, callback)
+  callback { items[#items] }
+end
+api.input = function(prompt)
+  _G.group_name_prompt = prompt
+  return "Personal"
+end
+M.move_to_group { type = "file", ctime = 1, path = "note.md" }
+local f = assert(io.open(M.resolve_bookmark_file(), "r"))
+_G.bookmarks = vim.json.decode(f:read "*a")
+f:close()
+]]
+
+  eq("New bookmark group name", child.lua_get [[group_name_prompt]])
+  local bookmarks = child.lua_get [[bookmarks]]
+  eq(1, #bookmarks.items)
+  eq("Personal", bookmarks.items[1].title)
+  eq(1, bookmarks.items[1].items[1].ctime)
+end
+
+T["groups"]["does not delete anything when a bookmark is missing"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    [".obsidian/bookmarks.json"] = vim.json.encode {
+      items = {
+        { type = "url", ctime = 1, url = "https://example.com" },
+      },
+    },
+  })
+
+  child.lua [[
+_G.deleted = M.del { type = "url", ctime = 2, url = "https://example.org" }
+local f = assert(io.open(M.resolve_bookmark_file(), "r"))
+_G.bookmarks = vim.json.decode(f:read "*a")
+f:close()
+]]
+
+  eq(false, child.lua_get [[deleted]])
+  eq(1, #child.lua_get [[bookmarks.items]])
+end
+
 T["add"], child = h.child_vault {
   pre_case = [[
 M = require "obsidian.bookmarks"
@@ -194,6 +289,31 @@ f:close()
   eq(#obj.items, 1)
   eq(obj.items[1].type, "file")
   eq(obj.items[1].path, "note.md")
+end
+
+T["add"]["bookmarks notes through the picker mapping"] = function()
+  local dir = child.Obsidian.dir
+
+  h.mock_vault_contents(dir, {
+    ["note.md"] = "# Hello\n",
+  })
+
+  child.lua(string.format(
+    [[
+local mappings = require("obsidian.picker")._note_selection_mappings()
+mappings["<C-b>"].callback(%q)
+local fp = M.resolve_bookmark_file()
+local f = assert(io.open(fp, "r"))
+_G.src = f:read "*a"
+f:close()
+  ]],
+    tostring(dir / "note.md")
+  ))
+
+  local obj = vim.json.decode(child.lua_get [[src]])
+  eq(1, #obj.items)
+  eq("file", obj.items[1].type)
+  eq("note.md", obj.items[1].path)
 end
 
 T["add"]["bookmarks heading under cursor"] = function()
@@ -291,17 +411,16 @@ T["add"]["dynamic code action title reflects context"] = function()
   child.lua(string.format(
     [[
 vim.cmd("edit " .. vim.fn.fnameescape(%q))
-local ca = require "obsidian.lsp.handlers._code_action"
-local opts = ca.actions.add_bookmark
+local action = require("obsidian.lsp.handlers._code_action").actions.add_bookmark
 
 vim.api.nvim_win_set_cursor(0, { 1, 0 })
-_G.t_heading = ca.resolve(opts).title
+_G.t_heading = action.data.title()
 
 vim.api.nvim_win_set_cursor(0, { 3, 8 })
-_G.t_url = ca.resolve(opts).title
+_G.t_url = action.data.title()
 
 vim.api.nvim_win_set_cursor(0, { 3, 0 })
-_G.t_note = ca.resolve(opts).title
+_G.t_note = action.data.title()
   ]],
     tostring(dir / "note.md")
   ))


### PR DESCRIPTION
## Summary

- Add bookmark write support for creating `.obsidian/bookmarks.json` when needed and appending bookmarks.
- Add `add_bookmark` code action that bookmarks the URL, block, heading, or note at the cursor.
- Add note-picker bookmark mapping (`picker.note_mappings.bookmark`, default `<C-b>`).
- Add bookmark picker actions to remove bookmarks (`<C-r>`) and move bookmarks into groups (`<C-g>`), including creating a new group.

## Screenshots

N/A

## PR Checklist

- [x] The PR contains a description of the changes
- [ ] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)
