### PR TITLE
fix(lsp): refresh and filter link hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Link-suggestion inlay hints exclude templates and refresh immediately after acceptance.
 - Absolute `templates.folder` paths resolve outside the vault without creating nested directories inside it (#761).
 - `ripgrep` tag search will work for `fileformat=dos`.
 - Fzf-lua builtin previews work with the fzf-tmux profile.

--- a/lua/obsidian/inlay_hints.lua
+++ b/lua/obsidian/inlay_hints.lua
@@ -133,6 +133,20 @@ end
 -- TODO: will be unnecessary once something like https://github.com/neovim/neovim/pull/36219 lands in neovim core
 
 ---@param bufnr integer
+---@param client_id integer
+local function refresh(bufnr, client_id)
+  local client = vim.lsp.get_client_by_id(client_id)
+  local handler = vim.lsp.handlers["workspace/inlayHint/refresh"]
+  if client and client.name == "obsidian-ls" and handler then
+    handler(nil, nil, {
+      bufnr = bufnr,
+      client_id = client_id,
+      method = "workspace/inlayHint/refresh",
+    })
+  end
+end
+
+---@param bufnr integer
 ---@param item vim.lsp.inlay_hint.get.ret
 ---@param hint lsp.InlayHint
 local function apply_hint(bufnr, item, hint)
@@ -146,6 +160,8 @@ local function apply_hint(bufnr, item, hint)
   if command then
     execute_lsp_command(command)
   end
+
+  refresh(bufnr, item.client_id)
 end
 
 ---@param bufnr integer | nil

--- a/lua/obsidian/note/link_suggestion.lua
+++ b/lua/obsidian/note/link_suggestion.lua
@@ -88,12 +88,13 @@ function M.symbols(path, opts)
 
   local dir = opts.dir and tostring(opts.dir) or nil
   local current_path = vim.fs.normalize(path) or nil
+  local workspace = api.find_workspace(path)
   local rows = {}
   local ok, cached_rows = pcall(cache.notes.all)
   if ok then
     for p, row in pairs(cached_rows) do
       p = vim.fs.normalize(p)
-      if path_in_dir(p, dir) then
+      if path_in_dir(p, dir) and (not workspace or api.path_is_note(p, workspace)) then
         rows[p] = row
       end
     end

--- a/tests/lsp/test_inlay_hint.lua
+++ b/tests/lsp/test_inlay_hint.lua
@@ -75,6 +75,21 @@ T["suggests wiki brackets for link suggestions"] = function()
   eq(vim.list_extend(link_hints(0, 2, 6), link_hints(0, 23, 27)), run_inlay_hint())
 end
 
+T["excludes cached templates from link suggestions"] = function()
+  local templates_dir = child.Obsidian.dir / "templates"
+  templates_dir:mkdir()
+  local files = h.mock_vault_contents(child.Obsidian.dir, {
+    ["target.md"] = "---\naliases:\n  - destination\n---\n",
+    ["templates/basic.md"] = "---\naliases:\n  - boilerplate\n---\n",
+    ["hints.md"] = "basic boilerplate target destination",
+  })
+  setup_cache()
+
+  child.cmd("edit " .. files["hints.md"])
+
+  eq(vim.list_extend(link_hints(0, 18, 24), link_hints(0, 25, 36)), run_inlay_hint())
+end
+
 T["publishes link suggestions to native inlay hint interface"] = function()
   local files = h.mock_vault_contents(child.Obsidian.dir, {
     ["test.md"] = "# test",
@@ -107,6 +122,13 @@ T["resolves native hints before accepting them"] = function()
   child.lua [[
     local client = vim.lsp.get_clients({ name = "obsidian-ls" })[1]
     client.server_capabilities.inlayHintProvider = { resolveProvider = true }
+    local original_refresh = vim.lsp.handlers["workspace/inlayHint/refresh"]
+    _G.original_inlay_hint_refresh = original_refresh
+    _G.resolved_inlay_hint_refreshes = 0
+    vim.lsp.handlers["workspace/inlayHint/refresh"] = function(...)
+      _G.resolved_inlay_hint_refreshes = _G.resolved_inlay_hint_refreshes + 1
+      return original_refresh(...)
+    end
     require("obsidian.lsp.handlers")["inlayHint/resolve"] = function(hint, callback)
       _G.resolved_inlay_hint = true
       local resolved = vim.deepcopy(hint)
@@ -127,6 +149,8 @@ T["resolves native hints before accepting them"] = function()
   eq(true, child.lua_get [[_G.accepted_resolved_inlay_hint]])
   eq(true, child.lua_get [[_G.resolved_inlay_hint]])
   eq("a resolved", child.lua_get [[vim.api.nvim_get_current_line()]])
+  h.child_wait(child, [[return _G.resolved_inlay_hint_refreshes > 0]], { desc = "resolved inlay hint refresh" })
+  child.lua [[vim.lsp.handlers["workspace/inlayHint/refresh"] = _G.original_inlay_hint_refresh]]
 end
 
 T["does not suggest inside existing wiki links"] = function()
@@ -257,6 +281,44 @@ T["smart action executes the link suggestion command under cursor"] = function()
 
   eq("<cmd>lua require('obsidian.inlay_hints').accept()<cr>", child.lua_get [[_G.link_suggestion_smart_action]])
   h.child_wait(child, [=[return vim.api.nvim_get_current_line() == "a [[test]]"]=], { desc = "link suggestion action" })
+end
+
+T["refreshes neighboring hints after accepting a suggestion"] = function()
+  local files = h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "# test",
+    ["target.md"] = "# target",
+    ["hints.md"] = "test target",
+  })
+  setup_cache()
+
+  child.cmd("edit " .. files["hints.md"])
+  h.child_wait_for_lsp_client(child, "obsidian-ls")
+  child.lua [[vim.lsp.inlay_hint.enable(true, { bufnr = 0 })]]
+  h.child_wait(child, [[return #vim.lsp.inlay_hint.get { bufnr = 0 } == 4]], { desc = "native inlay hints" })
+  child.lua [[
+    local original_refresh = vim.lsp.handlers["workspace/inlayHint/refresh"]
+    _G.original_inlay_hint_refresh = original_refresh
+    _G.accepted_inlay_hint_refreshes = 0
+    vim.lsp.handlers["workspace/inlayHint/refresh"] = function(...)
+      _G.accepted_inlay_hint_refreshes = _G.accepted_inlay_hint_refreshes + 1
+      return original_refresh(...)
+    end
+    vim.api.nvim_win_set_cursor(0, { 1, 2 })
+    require("obsidian.inlay_hints").accept()
+  ]]
+
+  h.child_wait(
+    child,
+    [[
+    local hints = vim.lsp.inlay_hint.get { bufnr = 0 }
+    return #hints == 2 and vim.iter(hints):all(function(item)
+      return item.inlay_hint.data.range.start.character == 9
+    end)
+  ]],
+    { desc = "refreshed neighboring inlay hints" }
+  )
+  eq(1, child.lua_get [[_G.accepted_inlay_hint_refreshes]])
+  child.lua [[vim.lsp.handlers["workspace/inlayHint/refresh"] = _G.original_inlay_hint_refresh]]
 end
 
 T["smart action accepts a multi-word suggestion from its middle word"] = function()


### PR DESCRIPTION
## Summary

- exclude configured template files and their aliases from cache-backed link-suggestion hints
- explicitly refresh native inlay hints after acceptance so accepted hints disappear and neighboring hints are recalculated
- cover synchronous acceptance and asynchronous hint resolution with regression tests

## Screenshots

Not applicable.

## Testing

- `make chores`

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] README documentation is not applicable to these bug fixes
- [x] The code complies with `make chores` (for style, lint, types, and tests)
