### PR TITLE
fix(yaml): improve string quoting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- YAML frontmatter dumping now quotes ambiguous string values and safely handles backslashes and single quotes.
 - Link-suggestion inlay hints exclude templates and refresh immediately after acceptance.
 - Absolute `templates.folder` paths resolve outside the vault without creating nested directories inside it (#761).
 - `ripgrep` tag search will work for `fileformat=dos`.

--- a/lua/obsidian/yaml/init.lua
+++ b/lua/obsidian/yaml/init.lua
@@ -19,30 +19,76 @@ end
 
 ---@param s string
 ---@return boolean
+local resolves_as_non_string = function(s)
+  -- Quote strings that this parser, YAML 1.2, or common YAML 1.1 parsers would
+  -- otherwise resolve as numbers, booleans, or nulls.
+  if resolves_as_number(s) then
+    return true
+  end
+
+  local lower = string.lower(s)
+  return lower == "true"
+    or lower == "false"
+    or lower == "null"
+    or lower == "~"
+    or lower == "y"
+    or lower == "yes"
+    or lower == "n"
+    or lower == "no"
+    or lower == "on"
+    or lower == "off"
+end
+
+---@param s string
+---@return boolean
+local is_date_like = function(s)
+  return s:match "^%d%d%d%d[._%-]%d%d?[._%-]%d%d?$" ~= nil
+    or s:match "^%d%d%d%d[._%-]%d%d?[._%-]%d%d?%s+%d%d?:%d%d$" ~= nil
+    or s:match "^%d%d%d%d[._%-]%d%d?[._%-]%d%d?%s+%d%d?:%d%d:%d%d$" ~= nil
+end
+
+---@param s string
+---@return boolean
 local should_quote = function(s)
-  -- TODO: this probably doesn't cover all edge cases.
-  -- See https://www.yaml.info/learn/quote.html
-  -- Check if it starts with a special character.
-  if string.match(s, [[^["'\\[{&!-].*]]) then
+  -- Plain scalar rules: https://www.yaml.info/learn/quote.html
+  -- We quote conservatively, but still allow backslash-starting scalars like
+  -- Pandoc LaTeX header-includes (`\usepackage{...}`), where double quotes can
+  -- accidentally introduce YAML escape sequences.
+  if s == "" or s:match "^%s" or s:match "%s$" then
     return true
-  -- Check if it has a colon followed by whitespace.
-  elseif string.find(s, ": ", 1, true) then
+  elseif s:match "[%z\1-\8\11\12\14-\31]" then
     return true
-  -- Check for wikilinks (e.g., [[note]], [[note|alias]], [[note#section]])
+  elseif s:match "^[-?:]%s" or s == "-" or s == "?" or s == ":" then
+    return true
+  elseif s:match "^[!&*{}%[%],#|>%%@`\"']" then
+    return true
+  elseif s:match "^%.%.%.%s*$" or s:match "^%-%-%-%s*$" then
+    return true
+  elseif s:find(": ", 1, true) or s:match ":$" then
+    return true
+  elseif s:match "%s#" then
+    return true
   elseif s:match "%[%[.-%]%]" then
     return true
-  -- Check if it's an empty string.
-  elseif s == "" or string.match(s, "^[%s]+$") then
-    return true
-  -- Numeric-looking strings are syntactically valid plain scalars, but they
-  -- resolve as numbers. Quote them to preserve string values.
-  elseif resolves_as_number(s) then
+  elseif resolves_as_non_string(s) then
     return true
   elseif util.is_hex_color(s) then
+    return true
+  elseif s:match "%s" and not is_date_like(s) then
     return true
   else
     return false
   end
+end
+
+---@param s string
+---@return string
+local quote_string = function(s)
+  if s:find("\\", 1, true) then
+    return "'" .. s:gsub("'", "''") .. "'"
+  end
+
+  return '"' .. s:gsub('"', '\\"') .. '"'
 end
 
 ---@param s string
@@ -65,8 +111,7 @@ local function dump_string(s, indent)
   end
 
   if should_quote(s) then
-    s = string.gsub(s, '"', '\\"')
-    return { indent_str .. [["]] .. s .. [["]] }
+    return { indent_str .. quote_string(s) }
   else
     return { indent_str .. s }
   end

--- a/lua/obsidian/yaml/parser.lua
+++ b/lua/obsidian/yaml/parser.lua
@@ -568,11 +568,20 @@ end
 ---@param text string
 ---@return boolean, string|?, string
 Parser._parse_string = function(_, _, text)
+  text = vim.trim(text)
   if vim.startswith(text, [["]]) and vim.endswith(text, [["]]) then
-    -- when the text is enclosed with double-quotes we need to un-escape certain characters.
+    -- When the text is enclosed with double quotes, un-escape the escapes this
+    -- dumper emits.
+    text = yaml_util.strip_enclosing_chars(text)
     text = string.gsub(text, vim.pesc [[\"]], [["]])
+  elseif vim.startswith(text, [[']]) and vim.endswith(text, [[']]) then
+    -- YAML single-quoted strings escape a single quote as two single quotes.
+    text = yaml_util.strip_enclosing_chars(text)
+    text = string.gsub(text, "''", "'")
+  else
+    text = yaml_util.strip_enclosing_chars(text)
   end
-  return true, nil, yaml_util.strip_enclosing_chars(vim.trim(text))
+  return true, nil, text
 end
 
 ---Parse a string value.

--- a/tests/yaml/test_parser.lua
+++ b/tests/yaml/test_parser.lua
@@ -22,6 +22,10 @@ T["should parse strings with escaped quotes"] = function()
   eq([["foo"]], parser:parse_string [["\"foo\""]])
 end
 
+T["should parse single quoted strings with escaped single quotes"] = function()
+  eq("It's me", parser:parse_string [['It''s me']])
+end
+
 T["should parse numbers while trimming whitespace"] = function()
   eq(1, parser:parse_number " 1")
   eq(1.5, parser:parse_number " 1.5")

--- a/tests/yaml/test_yaml.lua
+++ b/tests/yaml/test_yaml.lua
@@ -11,13 +11,14 @@ T["dump"]["should dump numbers"] = function()
 end
 
 T["dump"]["should dump strings"] = function()
-  eq(yaml.dumps "hi there", "hi there")
-  eq(yaml.dumps "hi it's me", "hi it's me")
+  eq(yaml.dumps "hi there", '"hi there"')
+  eq(yaml.dumps "hi it's me", '"hi it\'s me"')
   eq(yaml.dumps { foo = "bar" }, [[foo: bar]])
 end
 
-T["dump"]["should dump strings with a single quote without quoting"] = function()
-  eq(yaml.dumps "hi it's me", "hi it's me")
+T["dump"]["should quote strings with whitespace"] = function()
+  eq(yaml.dumps "hi it's me", '"hi it\'s me"')
+  eq(yaml.dumps { title = "Useful raw LaTeX commands in Markdown" }, 'title: "Useful raw LaTeX commands in Markdown"')
 end
 
 T["dump"]["should dump table with string values"] = function()
@@ -80,6 +81,10 @@ T["dump"]["should otherwise quote strings with a colon followed by whitespace"] 
   eq(yaml.dumps { a = "2023: a letter" }, [[a: "2023: a letter"]])
 end
 
+T["dump"]["should quote strings with comments"] = function()
+  eq(yaml.dumps { a = "foo # bar" }, [[a: "foo # bar"]])
+end
+
 T["dump"]["should quote strings that start with special characters"] = function()
   eq(yaml.dumps { a = "& aaa" }, [[a: "& aaa"]])
   eq(yaml.dumps { a = "! aaa" }, [[a: "! aaa"]])
@@ -90,8 +95,35 @@ T["dump"]["should quote strings that start with special characters"] = function(
   eq(yaml.dumps { a = '"aaa"' }, [[a: "\"aaa\""]])
 end
 
-T["dump"]["should not unnecessarily escape double quotes in strings"] = function()
-  eq(yaml.dumps { a = 'his name is "Winny the Poo"' }, 'a: his name is "Winny the Poo"')
+T["dump"]["should not quote strings that start with backslash"] = function()
+  eq(yaml.dumps { a = [[\usepackage{xcolor}]] }, [[a: \usepackage{xcolor}]])
+end
+
+T["dump"]["should quote and escape double quotes in strings with whitespace"] = function()
+  eq(yaml.dumps { a = 'his name is "Winny the Poo"' }, 'a: "his name is \\"Winny the Poo\\""')
+end
+
+T["dump"]["should single quote strings with backslashes that need quotes"] = function()
+  eq(yaml.dumps { a = [[C:\Program Files]] }, [[a: 'C:\Program Files']])
+end
+
+T["dump"]["should quote string values that resolve as booleans or nulls"] = function()
+  eq(yaml.dumps { a = "true", b = "null", c = "off" }, 'a: "true"\nb: "null"\nc: "off"')
+end
+
+T["dump"]["should quote markdown titles without quoting LaTeX header includes"] = function()
+  local order = { title = 1, author = 2, date = 3, ["header-includes"] = 4 }
+  eq(
+    yaml.dumps({
+      title = "Useful raw LaTeX commands in Markdown",
+      author = "Your Name",
+      date = "today",
+      ["header-includes"] = { [[\usepackage{xcolor}]], [[\usepackage{soul}]] },
+    }, function(a, b)
+      return order[a] < order[b]
+    end),
+    'title: "Useful raw LaTeX commands in Markdown"\nauthor: "Your Name"\ndate: today\nheader-includes:\n  - \\usepackage{xcolor}\n  - \\usepackage{soul}'
+  )
 end
 
 T["dump"]["should dump null array items as bare dash"] = function()


### PR DESCRIPTION
## Summary

Improve native YAML frontmatter serialization so string values remain valid strings across obsidian.nvim and common YAML 1.1/1.2 consumers.

- quote plain scalars with YAML indicators, comment syntax, ambiguous whitespace, or boolean/null-like values
- preserve the existing unquoted date-like format
- leave safe Pandoc/LaTeX values such as `\usepackage{xcolor}` unquoted
- use YAML single quotes when a value with backslashes must be quoted, escaping embedded single quotes correctly
- parse doubled single quotes back to their original value

For example:

```yaml
# String values remain strings instead of becoming comments or typed scalars.
a: "foo # bar"
b: "true"
c: "null"

# Backslashes are not accidentally interpreted as double-quoted YAML escapes.
header-includes:
  - \usepackage{xcolor}
path: 'C:\Program Files'
```

## Testing

- `make style`
- `make lint`
- `make types`
- `make test` (822 cases, 0 failures)

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] README documentation is not needed for this internal serialization fix
- [x] The code complies with `make chores` (style, lint, types, and tests)
