### PR TITLE
fix(lsp): refine note and folder renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `api.templates_dir` resolves against the given workspace root.
 - Search and backlink lookup now resolve the workspace from the searched/note path, and `find_async` applies that workspace's `file.ignore_filters`.
 - `Workspace.set` keeps the single-vault cache aligned when switching workspaces.
+- LSP note rename updates only link destinations, preserving aliases like `[[index|index]]`.
+- LSP folder rename updates vault-relative links without changing stem-only links.
+- Note rename duplicate-name warning only blocks same-folder filename collisions.
 
 ### Changed
 

--- a/lua/obsidian/lsp/handlers/did_rename_files.lua
+++ b/lua/obsidian/lsp/handlers/did_rename_files.lua
@@ -1,12 +1,42 @@
 local obsidian = require "obsidian"
 local Note = obsidian.Note
+local Path = obsidian.Path
 local api = obsidian.api
+local rename = require "obsidian.note.rename"
+
+local function apply_reference_edit(edit, meta, kind, name, dispatchers)
+  if not edit then
+    return
+  end
+
+  if Obsidian.opts.link.auto_update ~= true then
+    local prompt = ("Update %d reference(s) across %d file(s) for renamed %s '%s'?"):format(
+      meta.count,
+      vim.tbl_count(meta.path_lookup),
+      kind,
+      name
+    )
+    local choice = api.confirm(prompt)
+    if choice ~= "Yes" then
+      return
+    end
+  end
+
+  dispatchers.server_request("workspace/applyEdit", {
+    label = "Update renamed note references",
+    edit = edit,
+  })
+end
 
 ---@param file lsp.FileRename
 ---@param dispatchers table
 local function rename_note(file, dispatchers)
   local new_path = vim.uri_to_fname(file.newUri)
   local note = Note.from_file(new_path)
+  if not note then
+    return
+  end
+
   local new_name = vim.fs.basename(new_path):gsub("%.md$", "")
   note:build_rename_edit(new_name, {
     old_path = vim.uri_to_fname(file.oldUri),
@@ -14,26 +44,36 @@ local function rename_note(file, dispatchers)
     include_file_rename = false,
     dir = api.resolve_workspace_dir(new_path),
   }, function(edit, meta)
-    if not edit then
-      return
-    end
+    apply_reference_edit(edit, meta, "note", new_name, dispatchers)
+  end)
+end
 
-    if Obsidian.opts.link.auto_update ~= true then
-      local prompt = ("Update %d reference(s) across %d file(s) for renamed note '%s'?"):format(
-        meta.count,
-        vim.tbl_count(meta.path_lookup),
-        new_name
-      )
-      local choice = api.confirm(prompt)
-      if choice ~= "Yes" then
-        return
-      end
-    end
+---@param file lsp.FileRename
+---@param dispatchers table
+local function rename_folder(file, dispatchers)
+  local old_folder = Path.new(vim.uri_to_fname(file.oldUri))
+  local new_folder = Path.new(vim.uri_to_fname(file.newUri))
+  local path_pairs = {}
 
-    dispatchers.server_request("workspace/applyEdit", {
-      label = "Update renamed note references",
-      edit = edit,
-    })
+  for path in api.dir(new_folder) do
+    local new_path = Path.new(path)
+    local rel_path = new_path:relative_to(new_folder)
+    path_pairs[#path_pairs + 1] = {
+      old_path = tostring(old_folder / rel_path),
+      new_path = tostring(new_path),
+    }
+  end
+
+  if #path_pairs == 0 then
+    return
+  end
+
+  rename.build_edit_for_paths(path_pairs, {
+    include_file_rename = false,
+    include_stem_refs = false,
+    dir = api.resolve_workspace_dir(new_folder),
+  }, function(edit, meta)
+    apply_reference_edit(edit, meta, "folder", new_folder.name or tostring(new_folder), dispatchers)
   end)
 end
 
@@ -45,6 +85,11 @@ return function(params, dispatchers)
   end
 
   for _, file in ipairs(params.files) do
-    rename_note(file, dispatchers)
+    local new_path = Path.new(vim.uri_to_fname(file.newUri))
+    if new_path:is_dir() then
+      rename_folder(file, dispatchers)
+    else
+      rename_note(file, dispatchers)
+    end
   end
 end

--- a/lua/obsidian/lsp/handlers/initialize.lua
+++ b/lua/obsidian/lsp/handlers/initialize.lua
@@ -51,6 +51,13 @@ local initializeResult = {
                 matches = "file",
               },
             },
+            {
+              scheme = "file",
+              pattern = {
+                glob = "**",
+                matches = "folder",
+              },
+            },
           },
         },
       },

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -1652,6 +1652,8 @@ local rename = require "obsidian.note.rename"
 ---@field old_path? string Existing path to rename from. Defaults to `note.path`.
 ---@field new_path? string Destination path. Defaults to sibling path using `new_name .. ".md"`.
 ---@field include_file_rename? boolean Include a file rename operation in the generated edit. Defaults to true.
+---@field include_stem_refs? boolean Update stem-only references. Defaults to true.
+---@field dir? string|obsidian.Path Workspace directory used to find references.
 ---@field apply? boolean Apply the workspace edit directly. Defaults to true.
 ---@field update_buffers? boolean Update the note object/frontmatter and reload buffers after applying. Defaults to true.
 ---@field check_unique? boolean Check whether `new_name` conflicts with existing note ids/stems. Defaults to true.

--- a/lua/obsidian/note/rename.lua
+++ b/lua/obsidian/note/rename.lua
@@ -3,6 +3,9 @@ local M = {}
 local Path = require "obsidian.path"
 local api = require "obsidian.api"
 local log = require "obsidian.log"
+local refs = require "obsidian.parse.refs"
+local search = require "obsidian.search"
+local util = require "obsidian.util"
 
 local has_nvim_0_12 = (vim.fn.has "nvim-0.12.0" == 1)
 
@@ -12,12 +15,90 @@ local function normalize_name(new_name)
   return vim.trim(tostring(new_name)):gsub("%.md$", "", 1)
 end
 
----@param note obsidian.Note
----@param old_path string
----@return obsidian.Note
-local function build_search_note(note, old_path)
-  local search_note = vim.tbl_extend("force", {}, note, { path = Path.new(old_path) })
-  return setmetatable(search_note, getmetatable(note))
+local function strip_md_suffix(path)
+  if vim.endswith(path, ".md") then
+    return path:sub(1, #path - 3)
+  end
+  return path
+end
+
+local function add_replacement(replacements, seen, old_ref, new_ref)
+  if not old_ref or not new_ref or old_ref == "" or seen[old_ref] then
+    return
+  end
+
+  seen[old_ref] = true
+  replacements[#replacements + 1] = { old = old_ref, new = new_ref }
+end
+
+local function add_replacement_variants(replacements, seen, old_ref, new_ref)
+  add_replacement(replacements, seen, old_ref, new_ref)
+  add_replacement(replacements, seen, util.urlencode(old_ref), util.urlencode(new_ref))
+  add_replacement(
+    replacements,
+    seen,
+    util.urlencode(old_ref, { keep_path_sep = true }),
+    util.urlencode(new_ref, { keep_path_sep = true })
+  )
+end
+
+local function relative_path(path, dir)
+  if not dir then
+    return path:vault_relative_path()
+  end
+
+  local ok, relpath = pcall(path.relative_to, path, Path.new(dir))
+  return ok and tostring(relpath) or nil
+end
+
+local function path_replacements(old_path, new_path, include_stem_refs, dir)
+  old_path = Path.new(old_path)
+  new_path = Path.new(new_path)
+
+  local replacements = {}
+  local seen = {}
+
+  if include_stem_refs then
+    add_replacement_variants(replacements, seen, old_path.name, new_path.name)
+    add_replacement_variants(replacements, seen, old_path.stem, new_path.stem)
+  end
+
+  local old_relpath = relative_path(old_path, dir)
+  local new_relpath = relative_path(new_path, dir)
+  if old_relpath and new_relpath then
+    add_replacement_variants(replacements, seen, old_relpath, new_relpath)
+    add_replacement_variants(replacements, seen, strip_md_suffix(old_relpath), strip_md_suffix(new_relpath))
+  end
+
+  return replacements
+end
+
+local function target_offset(ref)
+  if ref.kind == "wiki" then
+    local brackets = ref.raw:find("[[", 1, true)
+    return brackets and brackets + 1 or nil
+  elseif ref.kind == "markdown" then
+    local close_bracket = ref.raw:find("](", 1, true)
+    return close_bracket and close_bracket + 1 or nil
+  end
+end
+
+local function find_target_replacement(ref, replacements)
+  local body_offset = 0
+  if ref.kind == "markdown" then
+    if vim.startswith(ref.target, "./") then
+      body_offset = 2
+    elseif vim.startswith(ref.target, "/") then
+      body_offset = 1
+    end
+  end
+
+  local body = ref.target:sub(body_offset + 1)
+  for _, replacement in ipairs(replacements) do
+    if body == replacement.old then
+      return body_offset, replacement
+    end
+  end
 end
 
 ---@param err string
@@ -52,20 +133,129 @@ M.validate = function(note, new_name, opts)
   end
 
   local old_path = opts.old_path or tostring(note.path)
-  for path in api.dir(api.resolve_workspace_dir(old_path)) do
-    path = Path.new(path)
-    if tostring(path) ~= old_path then
-      if new_name == path.stem then
-        return false, "Note with same name exists"
+  local new_path = opts.new_path or (vim.fs.joinpath(vim.fs.dirname(old_path), new_name) .. ".md")
+  if tostring(new_path) ~= old_path and Path.new(new_path):exists() then
+    return false, "Note with same name exists"
+  end
+
+  return true, nil
+end
+
+---@param path_pairs { old_path: string, new_path: string }[]
+---@param opts? { include_file_rename: boolean|?, include_stem_refs: boolean|?, dir: string|obsidian.Path|? }
+---@param callback fun(edit: lsp.WorkspaceEdit|nil, meta: obsidian.note.RenameMeta)
+M.build_edit_for_paths = function(path_pairs, opts, callback)
+  opts = opts or {}
+
+  local include_file_rename = opts.include_file_rename ~= false
+  local include_stem_refs = opts.include_stem_refs ~= false
+  local dir = opts.dir or (path_pairs[1] and api.resolve_workspace_dir(path_pairs[1].old_path))
+  local replacements = {}
+  local seen = {}
+  local search_refs = {}
+  local search_seen = {}
+
+  for _, pair in ipairs(path_pairs) do
+    for _, replacement in ipairs(path_replacements(pair.old_path, pair.new_path, include_stem_refs, dir)) do
+      if not seen[replacement.old] then
+        seen[replacement.old] = true
+        replacements[#replacements + 1] = replacement
       end
-      local other = Note.from_file(path)
-      if other and new_name == other.id then
-        return false, "Note with same name exists"
+      if not search_seen[replacement.old] then
+        search_seen[replacement.old] = true
+        search_refs[#search_refs + 1] = replacement.old
       end
     end
   end
 
-  return true, nil
+  table.sort(replacements, function(a, b)
+    return #a.old > #b.old
+  end)
+
+  search.find_backlinks_async(nil, function(matches)
+    local count = 0
+    local path_lookup = {}
+    local buf_list = {}
+    local documentChanges = {}
+    local file_edits = {}
+    local file_order = {}
+    local processed_lines = {}
+
+    for _, match in ipairs(matches) do
+      local match_path = tostring(match.path)
+      local line_key = match_path .. ":" .. match.line
+
+      if not processed_lines[line_key] then
+        processed_lines[line_key] = true
+
+        for _, ref in ipairs(refs.extract(match.text)) do
+          local offset = target_offset(ref)
+          local body_offset, replacement = find_target_replacement(ref, replacements)
+          if offset and body_offset and replacement then
+            local start_col = ref.range.start_col + offset + body_offset
+
+            if not file_edits[match_path] then
+              file_edits[match_path] = {}
+              file_order[#file_order + 1] = match_path
+            end
+
+            file_edits[match_path][#file_edits[match_path] + 1] = {
+              range = {
+                start = { line = match.line - 1, character = start_col },
+                ["end"] = { line = match.line - 1, character = start_col + #replacement.old },
+              },
+              newText = replacement.new,
+            }
+            count = count + 1
+          end
+        end
+      end
+    end
+
+    for _, path in ipairs(file_order) do
+      table.sort(file_edits[path], function(a, b)
+        if a.range.start.line == b.range.start.line then
+          return a.range.start.character > b.range.start.character
+        end
+        return a.range.start.line > b.range.start.line
+      end)
+
+      documentChanges[#documentChanges + 1] = {
+        textDocument = {
+          uri = vim.uri_from_fname(path),
+          version = has_nvim_0_12 and vim.NIL or nil,
+        },
+        edits = file_edits[path],
+      }
+
+      buf_list[#buf_list + 1] = vim.fn.bufnr(path, true)
+      path_lookup[path] = true
+    end
+
+    if include_file_rename then
+      for _, pair in ipairs(path_pairs) do
+        if pair.old_path ~= pair.new_path then
+          documentChanges[#documentChanges + 1] = {
+            kind = "rename",
+            oldUri = vim.uri_from_fname(pair.old_path),
+            newUri = vim.uri_from_fname(pair.new_path),
+            options = {},
+          }
+        end
+      end
+    end
+
+    local edit = #documentChanges > 0 and { documentChanges = documentChanges } or nil
+    local first = path_pairs[1]
+
+    callback(edit, {
+      count = count,
+      path_lookup = path_lookup,
+      buf_list = buf_list,
+      old_path = first and first.old_path or "",
+      new_path = first and first.new_path or "",
+    })
+  end, { refs = search_refs, dir = dir })
 end
 
 ---@param note obsidian.Note
@@ -78,126 +268,17 @@ M.build_edit = function(note, new_name, opts, callback)
 
   local old_path = opts.old_path or tostring(assert(note.path, "note path is required"))
   local new_path = opts.new_path or (vim.fs.joinpath(vim.fs.dirname(old_path), new_name) .. ".md")
-  local include_file_rename = opts.include_file_rename ~= false
-  local search_note = build_search_note(note, old_path)
-  local old_refs = search_note:get_reference_paths()
-  -- Pre-compute url-encoded refs for backlink search so backlinks() doesn't repeat get_reference_paths().
-  local search_refs = search_note:get_reference_paths { urlencode = true }
 
-  -- Sort refs by length (longest first) to match most specific reference first.
-  table.sort(old_refs, function(a, b)
-    return #a > #b
-  end)
-
-  local backlink_opts = { refs = search_refs, dir = opts.dir or api.resolve_workspace_dir(old_path) }
-  search_note:backlinks_async(backlink_opts, function(matches)
-    local count = 0
-    local path_lookup = {}
-    local buf_list = {}
-    local documentChanges = {}
-
-    -- Track which lines we've already processed to avoid duplicates.
-    local processed_lines = {}
-
-    for _, match in ipairs(matches) do
-      local match_path = tostring(match.path)
-      local line_key = match_path .. ":" .. match.line
-
-      if not processed_lines[line_key] then
-        processed_lines[line_key] = true
-
-        -- Find all occurrences of refs in this line.
-        local line_edits = {}
-
-        for _, ref in ipairs(old_refs) do
-          local search_start = 1
-          while true do
-            local offset_st, offset_ed = string.find(match.text, ref, search_start, true)
-            if not offset_st then
-              break
-            end
-
-            local new_text = new_name
-            if vim.endswith(ref, ".md") then
-              new_text = new_name .. ".md"
-            end
-
-            -- Longer refs win when matches overlap.
-            local dominated = false
-            for _, existing in ipairs(line_edits) do
-              if offset_st >= existing.start_1idx and offset_ed <= existing.end_1idx then
-                dominated = true
-                break
-              end
-            end
-
-            if not dominated then
-              line_edits[#line_edits + 1] = {
-                start_1idx = offset_st,
-                end_1idx = offset_ed,
-                -- LSP with utf-8 offset_encoding expects byte positions (0-indexed).
-                replace_st = offset_st - 1,
-                replace_ed = offset_ed,
-                new_text = new_text,
-              }
-            end
-
-            ---@cast offset_ed -nil
-            search_start = offset_ed + 1
-          end
-        end
-
-        -- Sort edits right-to-left so edits don't affect each other's positions.
-        table.sort(line_edits, function(a, b)
-          return a.start_1idx > b.start_1idx
-        end)
-
-        if #line_edits > 0 then
-          local edits_for_line = {}
-          for _, edit_info in ipairs(line_edits) do
-            edits_for_line[#edits_for_line + 1] = {
-              range = {
-                start = { line = match.line - 1, character = edit_info.replace_st },
-                ["end"] = { line = match.line - 1, character = edit_info.replace_ed },
-              },
-              newText = edit_info.new_text,
-            }
-            count = count + 1
-          end
-
-          documentChanges[#documentChanges + 1] = {
-            textDocument = {
-              uri = vim.uri_from_fname(match_path),
-              version = has_nvim_0_12 and vim.NIL or nil,
-            },
-            edits = edits_for_line,
-          }
-
-          buf_list[#buf_list + 1] = vim.fn.bufnr(match_path, true)
-          path_lookup[match_path] = true
-        end
-      end
-    end
-
-    if include_file_rename and old_path ~= new_path then
-      documentChanges[#documentChanges + 1] = {
-        kind = "rename",
-        oldUri = vim.uri_from_fname(old_path),
-        newUri = vim.uri_from_fname(new_path),
-        options = {},
-      }
-    end
-
-    local edit = #documentChanges > 0 and { documentChanges = documentChanges } or nil
-
-    callback(edit, {
-      count = count,
-      path_lookup = path_lookup,
-      buf_list = buf_list,
+  M.build_edit_for_paths({
+    {
       old_path = old_path,
       new_path = new_path,
-    })
-  end)
+    },
+  }, {
+    include_file_rename = opts.include_file_rename,
+    include_stem_refs = opts.include_stem_refs,
+    dir = opts.dir,
+  }, callback)
 end
 
 ---@param note obsidian.Note

--- a/tests/lsp/test_did_rename_files.lua
+++ b/tests/lsp/test_did_rename_files.lua
@@ -8,15 +8,19 @@ T["initialize advertises didRenameFiles file operation support"] = function()
     local handler = require "obsidian.lsp.handlers.initialize"
 
     handler(vim.empty_dict(), function(_, res)
-      _G.did_rename_filter = res.capabilities.workspace.fileOperations.didRename.filters[1]
+      _G.did_rename_file_filter = res.capabilities.workspace.fileOperations.didRename.filters[1]
+      _G.did_rename_folder_filter = res.capabilities.workspace.fileOperations.didRename.filters[2]
     end, {
       notification = function() end,
     })
   ]]
 
-  eq("file", child.lua_get "did_rename_filter.scheme")
-  eq("**/*.md", child.lua_get "did_rename_filter.pattern.glob")
-  eq("file", child.lua_get "did_rename_filter.pattern.matches")
+  eq("file", child.lua_get "did_rename_file_filter.scheme")
+  eq("**/*.md", child.lua_get "did_rename_file_filter.pattern.glob")
+  eq("file", child.lua_get "did_rename_file_filter.pattern.matches")
+  eq("file", child.lua_get "did_rename_folder_filter.scheme")
+  eq("**", child.lua_get "did_rename_folder_filter.pattern.glob")
+  eq("folder", child.lua_get "did_rename_folder_filter.pattern.matches")
 end
 
 T["didRenameFiles applies reference edits without file rename"] = function()
@@ -151,6 +155,47 @@ T["didRenameFiles skips applyEdit when confirmation is declined"] = function()
 
   eq("Update 1 reference(s) across 1 file(s) for renamed note 'new'?", child.lua_get "confirm_prompt")
   eq(false, child.lua_get "request_called")
+end
+
+T["didRenameFiles updates folder-relative links only"] = function()
+  local root = child.Obsidian.dir
+  local old_folder = root / "old"
+  local new_folder = root / "new"
+  old_folder:mkdir()
+  h.mock_vault_contents(root, {
+    ["old/index.md"] = "---\nid: index\naliases: []\ntags: []\n---",
+    ["old/other.md"] = "---\nid: other\naliases: []\ntags: []\n---",
+    ["ref.md"] = [==[
+[[old/index]] [[index]] [[old/index|old/index]]
+[Other](old/other.md) [Root](/old/index.md) [Dot](./old/index.md)
+]==],
+  })
+
+  child.lua(([[
+    vim.uv.fs_rename(%q, %q)
+    Obsidian.opts.link.auto_update = true
+    _G._obsidian_folder_rename_done = false
+    require("obsidian.lsp.handlers.did_rename_files")({
+      files = {
+        {
+          oldUri = vim.uri_from_fname(%q),
+          newUri = vim.uri_from_fname(%q),
+        },
+      },
+    }, {
+      server_request = function(_, params)
+        vim.lsp.util.apply_workspace_edit(params.edit, "utf-8")
+        _G._obsidian_folder_rename_done = true
+      end,
+    })
+  ]]):format(tostring(old_folder), tostring(new_folder), tostring(old_folder), tostring(new_folder)))
+
+  h.child_wait(child, [[return _G._obsidian_folder_rename_done == true]], { desc = "folder rename" })
+  child.cmd "wa"
+
+  local ref_text = table.concat(h.read(root / "ref.md"), "\n")
+  eq(true, ref_text:find "%[%[new/index%]%] %[%[index%]%] %[%[new/index|old/index%]%]" ~= nil)
+  eq(true, ref_text:find "%[Other%]%(new/other%.md%) %[Root%]%(/new/index%.md%) %[Dot%]%(./new/index%.md%)" ~= nil)
 end
 
 T["didRenameFiles skips confirmation when auto_update is enabled"] = function()

--- a/tests/lsp/test_rename.lua
+++ b/tests/lsp/test_rename.lua
@@ -127,6 +127,23 @@ end
   eq(false, (root / "bad:name.md"):exists())
 end
 
+T["rename current note allows same name in a different folder"] = function()
+  local root = child.Obsidian.dir
+  local folder = root / "other"
+  folder:mkdir()
+  local files = h.mock_vault_contents(root, {
+    [target] = target_content,
+    ["other/existing.md"] = "",
+  })
+
+  local new_target_path = root / "existing.md"
+
+  child.cmd("edit " .. files[target])
+  rename "existing"
+  h.child_wait_for_path(child, new_target_path)
+  eq(true, new_target_path:exists())
+end
+
 T["rename note under cursor"] = function()
   local root = child.Obsidian.dir
 
@@ -174,6 +191,32 @@ tags: []
 
 [[new_target#^block]]
 ]==]
+
+T["rename note preserves matching wiki alias"] = function()
+  local root = child.Obsidian.dir
+  local files = h.mock_vault_contents(root, {
+    ["index.md"] = [[---
+id: index
+aliases: []
+tags: []
+---]],
+    [ref] = [==[
+
+[[index|index]]
+]==],
+  })
+  local new_target_path = root / "index-new.md"
+
+  child.cmd("edit " .. files[ref])
+  child.api.nvim_win_set_cursor(0, { 2, 0 })
+
+  rename "index-new"
+  h.child_wait_for_path(child, new_target_path)
+  child.cmd "wa"
+
+  local ref_lines = h.read(files[ref])
+  eq(true, table.concat(ref_lines, "\n"):find "%[%[index%-new|index%]%]" ~= nil)
+end
 
 T["rename note without changing blocks and headers"] = function()
   local root = child.Obsidian.dir


### PR DESCRIPTION
## What does the PR do?

Refines note and folder rename handling so reference edits only change link destinations and respect path semantics.

- Preserve wiki aliases and Markdown labels when a note is renamed, for example `[[index|index]]` becomes `[[index-new|index]]`.
- Preserve anchors, block fragments, `.md` suffixes, root/dot prefixes, and URL-encoded path variants.
- Advertise LSP `didRenameFiles` support for folders and update vault-relative links after folder renames.
- Keep stem-only links unchanged during folder moves because the note identity did not change.
- Restrict duplicate-name validation to an actual destination-path collision, allowing the same filename in different folders.
- Reuse the existing confirmation and `link.auto_update` behavior for both note and folder rename events.

Regression coverage includes alias preservation, cross-folder duplicate names, folder-relative wiki/Markdown links, and folder rename capability advertisement.

## Screenshots

N/A — behavior-only LSP changes.

## Testing

- `make chores`
- 827 tests, 0 failures

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] README changes are not required; no user-facing configuration or commands were added
- [x] The code complies with `make chores` (style, lint, types, and tests)
