### PR TITLE
fix(note): no side effect note creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- No `Note.create` interrupt calls in completion.
 - `:Obsidian sync log` opens real obsidian-headless cli logs.
 - YAML frontmatter dumping now quotes ambiguous string values and safely handles backslashes and single quotes.
 - Link-suggestion inlay hints exclude templates and refresh immediately after acceptance.

--- a/lua/obsidian/actions.lua
+++ b/lua/obsidian/actions.lua
@@ -1241,7 +1241,8 @@ end
 --- write note to disk, for lsp completion create note
 ---
 ---@param note obsidian.Note
-M.write_note = function(note)
+---@param scope string|?
+M.write_note = function(note, scope)
   -- Make sure `note` is actually an `obsidian.Note` object.
   -- If it gets serialized by server commands, it will lose its metatable.
   if not Note.is_note_obj(note) then
@@ -1250,6 +1251,7 @@ M.write_note = function(note)
       note.path = setmetatable(note.path, Path)
     end
   end
+  Note._run_creation_lifecycle(note, scope)
   note:write()
 end
 

--- a/lua/obsidian/completion/sources/new.lua
+++ b/lua/obsidian/completion/sources/new.lua
@@ -90,14 +90,14 @@ function M.process_completion(callback, request)
     anchor = { anchor = anchor_link, header = string.sub(anchor_link, 2), level = 1, line = 1 }
   end
 
-  ---@type { label: string, note: obsidian.Note }[]
+  ---@type { label: string, note: obsidian.Note, scope: string }[]
   local new_notes_opts = {}
 
   local source_path = vim.api.nvim_buf_get_name(request.bufnr)
   local workspace_dir = api.resolve_workspace_dir(source_path)
   local note = preview_note { id = term, template = Obsidian.opts.note.template, source_path = source_path }
   if note and note.id and string.len(note.id) > 0 then
-    new_notes_opts[#new_notes_opts + 1] = { label = term, note = note }
+    new_notes_opts[#new_notes_opts + 1] = { label = term, note = note, scope = "plain" }
   end
 
   -- Check for datetime macros. Build missing daily notes directly instead of
@@ -107,24 +107,22 @@ function M.process_completion(callback, request)
       local daily = require "obsidian.daily"
       local timestamp = os.time() + (dt_offset.offset * 3600 * 24)
       local path, id = daily.daily_note_path(timestamp, workspace_dir)
-      if not path:exists() then
-        local aliases = {}
-        if Obsidian.opts.daily_notes.alias_format ~= nil then
-          aliases[1] = tostring(util.format_date(timestamp, Obsidian.opts.daily_notes.alias_format))
-        end
-        note = preview_note {
-          id = id,
-          verbatim = true,
-          aliases = aliases,
-          tags = Obsidian.opts.daily_notes.default_tags or {},
-          dir = path:parent(),
-          template = Obsidian.opts.daily_notes.template,
-          source_path = source_path,
-          scope = "daily",
-        }
-        if note then
-          new_notes_opts[#new_notes_opts + 1] = { label = dt_offset.macro, note = note }
-        end
+      local aliases = {}
+      if Obsidian.opts.daily_notes.alias_format ~= nil then
+        aliases[1] = tostring(util.format_date(timestamp, Obsidian.opts.daily_notes.alias_format))
+      end
+      note = preview_note {
+        id = id,
+        verbatim = true,
+        aliases = aliases,
+        tags = Obsidian.opts.daily_notes.default_tags or {},
+        dir = path:parent(),
+        template = Obsidian.opts.daily_notes.template,
+        source_path = source_path,
+        scope = "daily",
+      }
+      if note and not note:exists() then
+        new_notes_opts[#new_notes_opts + 1] = { label = dt_offset.macro, note = note, scope = "daily" }
       end
     end
   end
@@ -185,7 +183,7 @@ function M.process_completion(callback, request)
       command = {
         command = "obsidian.write_note",
         title = "Obsidian write note",
-        arguments = { new_note },
+        arguments = { new_note, new_note_opts.scope },
       },
       -- NOTE: for [[new_note@template future expansion
       -- command = {

--- a/lua/obsidian/completion/sources/new.lua
+++ b/lua/obsidian/completion/sources/new.lua
@@ -11,6 +11,23 @@ local EMPTY_RESPONSE = {
   items = {},
 }
 
+--- Build the note needed to render a completion item without actually creating it.
+--- In particular, this must not fire note creation callbacks or prompt while the
+--- user is still typing. Invalid intermediate filenames simply produce no item.
+---@param opts obsidian.note.NoteOpts
+---@return obsidian.Note|?
+local function preview_note(opts)
+  ---@diagnostic disable-next-line: access-invisible
+  local ok, id, path, title = pcall(Note._resolve_id_path, opts, false)
+  if not ok then
+    return nil
+  end
+
+  local note = Note.new(id, opts.aliases, opts.tags, path, title)
+  note.template = opts.template
+  return note
+end
+
 --- Runs a generalized version of the complete (nvim_cmp) or get_completions (blink) methods
 ---@param callback fun(resp: lsp.CompletionList)
 ---@param request obsidian.completion.Request
@@ -78,17 +95,36 @@ function M.process_completion(callback, request)
 
   local source_path = vim.api.nvim_buf_get_name(request.bufnr)
   local workspace_dir = api.resolve_workspace_dir(source_path)
-  local note = Note.create { id = term, template = Obsidian.opts.note.template, source_path = source_path }
-  if note.id and string.len(note.id) > 0 then
+  local note = preview_note { id = term, template = Obsidian.opts.note.template, source_path = source_path }
+  if note and note.id and string.len(note.id) > 0 then
     new_notes_opts[#new_notes_opts + 1] = { label = term, note = note }
   end
 
-  -- Check for datetime macros.
+  -- Check for datetime macros. Build missing daily notes directly instead of
+  -- calling daily(), which would call Note.create for every completion request.
   for _, dt_offset in ipairs(util.resolve_date_macro(term)) do
     if dt_offset.cadence == "daily" then
-      note = require("obsidian.daily").daily { offset = dt_offset.offset, dir = workspace_dir }
-      if not note:exists() then
-        new_notes_opts[#new_notes_opts + 1] = { label = dt_offset.macro, note = note }
+      local daily = require "obsidian.daily"
+      local timestamp = os.time() + (dt_offset.offset * 3600 * 24)
+      local path, id = daily.daily_note_path(timestamp, workspace_dir)
+      if not path:exists() then
+        local aliases = {}
+        if Obsidian.opts.daily_notes.alias_format ~= nil then
+          aliases[1] = tostring(util.format_date(timestamp, Obsidian.opts.daily_notes.alias_format))
+        end
+        note = preview_note {
+          id = id,
+          verbatim = true,
+          aliases = aliases,
+          tags = Obsidian.opts.daily_notes.default_tags or {},
+          dir = path:parent(),
+          template = Obsidian.opts.daily_notes.template,
+          source_path = source_path,
+          scope = "daily",
+        }
+        if note then
+          new_notes_opts[#new_notes_opts + 1] = { label = dt_offset.macro, note = note }
+        end
       end
     end
   end

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -435,13 +435,19 @@ Note.create = function(opts)
   local aliases = opts.aliases
   local note = Note.new(new_id, aliases, opts.tags, path, title)
   note.template = opts.template
-  local callback_opts = { scope = opts.scope or "plain" }
+  Note._run_creation_lifecycle(note, opts.scope)
+  return note
+end
+
+---@param note obsidian.Note
+---@param scope string|?
+Note._run_creation_lifecycle = function(note, scope)
+  local callback_opts = { scope = scope or "plain" }
   util.fire_callback("create_note", Obsidian.opts.callbacks.create_note, note, callback_opts)
   vim.api.nvim_exec_autocmds("User", {
     pattern = "ObsidianNoteCreate",
     data = { note = note, opts = callback_opts },
   })
-  return note
 end
 
 --- Instantiates a new Note object

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -1269,6 +1269,57 @@ tags:
   eq(true, found)
 end
 
+T["completion"]["new-note suggestions do not create notes while typing"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[brandnewnote",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 14 })
+  child.lua [[
+    _G.obsidian_completion_create_count = 0
+    Obsidian.opts.callbacks.create_note = function()
+      _G.obsidian_completion_create_count = _G.obsidian_completion_create_count + 1
+    end
+  ]]
+
+  local result = run_completion(0, 14)
+  local create_item = vim.iter(result.items or {}):find(function(item)
+    return item.command and item.command.command == "obsidian.write_note"
+  end)
+
+  assert(create_item, "no create item found")
+  eq(0, child.lua_get "_G.obsidian_completion_create_count")
+end
+
+T["completion"]["invalid partial filenames do not prompt during completion"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[bad:name",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 10 })
+  child.lua [[
+    Obsidian.opts.note_id_func = function(title)
+      return title
+    end
+    _G.obsidian_completion_input_count = 0
+    require("obsidian.api").input = function()
+      _G.obsidian_completion_input_count = _G.obsidian_completion_input_count + 1
+      return "replacement"
+    end
+  ]]
+
+  local result = run_completion(0, 10)
+  eq(0, child.lua_get "_G.obsidian_completion_input_count")
+  eq(
+    false,
+    vim.iter(result.items or {}):any(function(item)
+      return item.command and item.command.command == "obsidian.write_note"
+    end)
+  )
+end
+
 T["completion"]["existing note match sorts before create item for the same title"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["test.md"] = "[[Title",

--- a/tests/lsp/test_completion.lua
+++ b/tests/lsp/test_completion.lua
@@ -1353,6 +1353,52 @@ Existing note content
   assert(existing_idx < create_idx, "existing note item should sort before create item")
 end
 
+T["completion"]["daily create command carries daily scope"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[@today",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 8 })
+
+  local result = run_completion(0, 8)
+  local daily_item = vim.iter(result.items or {}):find(function(item)
+    return item.command and item.command.command == "obsidian.write_note" and item.command.arguments[2] == "daily"
+  end)
+
+  assert(daily_item, "no daily create item found")
+end
+
+T["completion"]["does not offer a daily create item when its resolved path exists"] = function()
+  h.mock_vault_contents(child.Obsidian.dir, {
+    ["test.md"] = "[[@today",
+    ["redirected.md"] = "Existing note content",
+  })
+
+  child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
+  child.api.nvim_win_set_cursor(0, { 1, 8 })
+  child.lua [[
+    local _, daily_id = require("obsidian.daily").daily_note_path()
+    Obsidian.opts.note_id_func = function()
+      return "plain-note"
+    end
+    Obsidian.opts.note_path_func = function(spec)
+      if spec.id == daily_id then
+        return Obsidian.dir / "redirected.md"
+      end
+      return (spec.dir / tostring(spec.id)):with_suffix(".md", true)
+    end
+  ]]
+
+  local result = run_completion(0, 8)
+  local create_items = vim.tbl_filter(function(item)
+    return item.command and item.command.command == "obsidian.write_note"
+  end, result.items or {})
+
+  eq(1, #create_items)
+  eq("plain", create_items[1].command.arguments[2])
+end
+
 T["completion"]["create_new emits write_note command that writes file"] = function()
   h.mock_vault_contents(child.Obsidian.dir, {
     ["test.md"] = "[[brandnewnote",
@@ -1360,6 +1406,25 @@ T["completion"]["create_new emits write_note command that writes file"] = functi
 
   child.cmd("edit " .. tostring(child.Obsidian.dir / "test.md"))
   child.api.nvim_win_set_cursor(0, { 1, 14 })
+  child.lua [[
+    _G.obsidian_completion_create_count = 0
+    _G.obsidian_completion_create_scope = nil
+    _G.obsidian_completion_create_event_count = 0
+    _G.obsidian_completion_create_event_scope = nil
+    Obsidian.opts.callbacks.create_note = function(note, opts)
+      _G.obsidian_completion_create_count = _G.obsidian_completion_create_count + 1
+      _G.obsidian_completion_create_scope = opts.scope
+      note:add_alias "from-callback"
+      note:add_tag "from-callback"
+    end
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "ObsidianNoteCreate",
+      callback = function(ev)
+        _G.obsidian_completion_create_event_count = _G.obsidian_completion_create_event_count + 1
+        _G.obsidian_completion_create_event_scope = ev.data.opts.scope
+      end,
+    })
+  ]]
 
   local result = h.child_await(
     child,
@@ -1377,12 +1442,20 @@ T["completion"]["create_new emits write_note command that writes file"] = functi
               if item.command and item.command.command == "obsidian.write_note" then
                 has_create = true
                 local note = item.command.arguments[1]
-                require("obsidian.actions").write_note(note)
+                require("obsidian.actions").write_note(unpack(item.command.arguments))
                 note_path = tostring(note.path)
                 break
               end
             end
-            return { has_create = has_create, note_path = note_path }
+            return {
+              has_create = has_create,
+              note_path = note_path,
+              contents = table.concat(vim.fn.readfile(note_path), "\n"),
+              callback_count = _G.obsidian_completion_create_count,
+              callback_scope = _G.obsidian_completion_create_scope,
+              event_count = _G.obsidian_completion_create_event_count,
+              event_scope = _G.obsidian_completion_create_event_scope,
+            }
           end)
           if ok then
             done(result)
@@ -1401,6 +1474,11 @@ T["completion"]["create_new emits write_note command that writes file"] = functi
   local note_path = result.note_path
   eq("string", type(note_path))
   eq(1, vim.fn.filereadable(note_path))
+  eq(1, result.callback_count)
+  eq("plain", result.callback_scope)
+  eq(1, result.event_count)
+  eq("plain", result.event_scope)
+  assert(result.contents:find "from%-callback", "callback changes were not written")
 end
 
 return T


### PR DESCRIPTION
since `Note.create` now has invalid name check, it will interrupt completion since it is used too much internally
