### PR TITLE
fix(footer): refresh backlinks on file changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Footer backlink counts now refresh on watched-file changes instead of running a vault-wide search every 10 seconds per buffer (#939).
 - Named-note heading completion now preserves the heading's original case and spelling in wiki links.
 - No `Note.create` interrupt calls in completion.
 - `:Obsidian sync log` opens real obsidian-headless cli logs.

--- a/lua/obsidian/cache/init.lua
+++ b/lua/obsidian/cache/init.lua
@@ -410,6 +410,31 @@ function M.notes.count()
   return n
 end
 
+---Count cached outgoing links that target `note`.
+---@param note obsidian.Note
+---@return integer
+function M.notes.backlink_count(note)
+  if not state or not state.ready then
+    return 0
+  end
+
+  local refs = {}
+  for _, ref in ipairs(note:get_reference_paths { urlencode = true }) do
+    refs[ref:lower()] = true
+  end
+
+  local count = 0
+  for _, row in pairs(state.backend:all()) do
+    for _, link in ipairs(row.links_out or {}) do
+      local target = link.target:gsub("^%./", ""):gsub("^/", ""):lower()
+      if refs[target] then
+        count = count + 1
+      end
+    end
+  end
+  return count
+end
+
 ---@class obsidian.cache.HeadingRow
 ---@field path string
 ---@field header string

--- a/lua/obsidian/footer/init.lua
+++ b/lua/obsidian/footer/init.lua
@@ -1,21 +1,42 @@
 local M = {}
 local ns_id = vim.api.nvim_create_namespace "obsidian.footer"
 local Note = require "obsidian.note"
+local watchfiles = require "obsidian.lsp.watchfiles"
+
+---@class obsidian.footer.State
+---@field backlinks integer?
+---@field unregister fun()
+
+---@type table<integer, obsidian.footer.State>
 local attached_bufs = {}
-
----@type table<integer, uv.uv_timer_t>
-local timers = {}
-
--- HACK: for now before we have cache
-vim.g.obsidian_footer_update_interval = 10000
 
 vim.g.obsidian = "deprecated, use b:obsidian"
 
+---@param format string
+---@param info { words: integer, chars: integer, properties: integer, backlinks: integer }
+---@return string
+local function format_status(format, info)
+  for k, v in pairs(info) do
+    format = format:gsub("{{" .. k .. "}}", v)
+  end
+  return format
+end
+
+---@return boolean
+local function needs_backlinks()
+  local footer_format = Obsidian.opts.footer.format
+  local statusline_format = Obsidian.opts.statusline.format
+  local footer_has_backlinks = footer_format ~= nil and footer_format:find("{{backlinks}}", 1, true) ~= nil
+  local statusline_has_backlinks = Obsidian.opts.statusline.enabled == true
+    and statusline_format ~= nil
+    and statusline_format:find("{{backlinks}}", 1, true) ~= nil
+  return footer_has_backlinks or statusline_has_backlinks
+end
+
 ---@param buf integer
----@param footer_format string
----@param update_backlinks boolean|?
----@param callback fun(result: string|?)
-local note_status = function(buf, footer_format, update_backlinks, callback)
+---@param update_backlinks boolean
+---@param callback fun(info: { words: integer, chars: integer, properties: integer, backlinks: integer }|?)
+local function note_status(buf, update_backlinks, callback)
   if not vim.api.nvim_buf_is_valid(buf) then
     return callback(nil)
   end
@@ -24,20 +45,25 @@ local note_status = function(buf, footer_format, update_backlinks, callback)
     return callback(nil)
   end
   note:status(update_backlinks, function(info)
-    if info == nil then
+    local state = attached_bufs[buf]
+    if not state then
       return callback(nil)
     end
-    local result = footer_format
-    for k, v in pairs(info) do
-      result = result:gsub("{{" .. k .. "}}", v)
+    if info.backlinks ~= nil then
+      state.backlinks = info.backlinks
     end
-    callback(result)
+    callback {
+      words = info.words,
+      chars = info.chars,
+      properties = info.properties,
+      backlinks = state.backlinks or 0,
+    }
   end)
 end
 
 ---@param buf integer
----@param display_text string|?
-local render_footer = function(buf, display_text)
+---@param display_text string
+local function render_footer(buf, display_text)
   if not vim.api.nvim_buf_is_valid(buf) then
     return
   end
@@ -59,42 +85,51 @@ local render_footer = function(buf, display_text)
 end
 
 ---@param buf integer
----@param update_backlinks boolean|?
+---@param update_backlinks boolean
 local update_footer = vim.schedule_wrap(function(buf, update_backlinks)
-  -- TODO: log in the future to a log file
   pcall(function()
-    local footer_format = Obsidian.opts.footer.format
-    ---@cast footer_format -nil
-    note_status(buf, footer_format, update_backlinks, function(display_text)
+    note_status(buf, update_backlinks, function(info)
       pcall(function()
-        if not vim.api.nvim_buf_is_valid(buf) then
+        if not info or not vim.api.nvim_buf_is_valid(buf) then
           return
         end
 
-        render_footer(buf, display_text)
+        local footer_format = Obsidian.opts.footer.format
+        ---@cast footer_format -nil
+        render_footer(buf, format_status(footer_format, info))
 
         local statusline_format = Obsidian.opts.statusline.format
         if Obsidian.opts.statusline.enabled and statusline_format then
-          note_status(buf, statusline_format, true, function(res)
-            pcall(function()
-              if res and vim.api.nvim_buf_is_valid(buf) then
-                vim.b[buf].obsidian_status = res
-              end
-            end)
-          end)
+          vim.b[buf].obsidian_status = format_status(statusline_format, info)
         else
-          vim.b[buf].obsidian_status = display_text
+          vim.b[buf].obsidian_status = format_status(footer_format, info)
         end
       end)
     end)
   end)
 end)
 
+---@param event table
+---@param buf_path string
+---@return boolean
+local function is_current_file(event, buf_path)
+  for _, key in ipairs { "path", "old_path", "new_path" } do
+    if event[key] and vim.fs.normalize(event[key]) == buf_path then
+      return true
+    end
+  end
+  return false
+end
+
 M.start = function(buf)
   if attached_bufs[buf] then
     return
   end
   local group = vim.api.nvim_create_augroup("obsidian.footer-" .. buf, {})
+  local state = {
+    unregister = function() end,
+  }
+  attached_bufs[buf] = state
 
   vim.api.nvim_create_autocmd({
     "FileChangedShellPost",
@@ -106,7 +141,7 @@ M.start = function(buf)
     desc = "Update obsidian footer",
     buffer = buf,
     callback = function()
-      update_footer(buf)
+      update_footer(buf, false)
     end,
   })
   vim.api.nvim_create_autocmd("CursorMoved", {
@@ -114,19 +149,25 @@ M.start = function(buf)
     buffer = buf,
     callback = function()
       if vim.api.nvim_get_mode().mode:lower():find "v" then
-        update_footer(buf)
+        update_footer(buf, false)
       end
     end,
   })
 
-  local timer = vim.uv:new_timer()
-  assert(timer, "Failed to create timer")
-  timer:start(0, vim.g.obsidian_footer_update_interval, function()
-    update_footer(buf, true)
+  state.unregister = watchfiles.register_handler(function(events)
+    if not needs_backlinks() or not vim.api.nvim_buf_is_valid(buf) then
+      return
+    end
+    local buf_path = vim.fs.normalize(vim.api.nvim_buf_get_name(buf))
+    for _, event in ipairs(events) do
+      if not is_current_file(event, buf_path) then
+        update_footer(buf, true)
+        return
+      end
+    end
   end)
 
-  timers[buf] = timer
-  attached_bufs[buf] = true
+  update_footer(buf, needs_backlinks())
 
   vim.api.nvim_create_autocmd({
     "BufWipeout",
@@ -136,13 +177,11 @@ M.start = function(buf)
     group = group,
     buffer = buf,
     callback = function()
-      local buf_timer = timers[buf]
-      if buf_timer ~= nil then
-        buf_timer:stop()
-        buf_timer:close()
-        timers[buf] = nil
+      local buf_state = attached_bufs[buf]
+      if buf_state then
+        buf_state.unregister()
+        attached_bufs[buf] = nil
       end
-      attached_bufs[buf] = nil
       pcall(vim.api.nvim_del_augroup_by_id, group)
     end,
   })

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -1383,25 +1383,20 @@ Note.format_link = function(self, opts)
   end
 end
 
--- HACK: make backlink search lazy before we have proper cache
-local backlink_cache = {}
-
---- Return note status counts, like obsidian's status bar
+--- Return note status counts, like obsidian's status bar.
 ---
----@param update_backlink boolean|?
----@param callback fun(status: { words: integer, chars: integer, properties: integer, backlinks: integer })|?
----@return { words: integer, chars: integer, properties: integer, backlinks: integer }?
-Note.status = function(self, update_backlink, callback)
+---@param update_backlinks boolean|? Set to false to skip computing backlinks.
+---@param callback fun(status: { words: integer, chars: integer, properties: integer, backlinks: integer? })|?
+---@return { words: integer, chars: integer, properties: integer, backlinks: integer? }?
+Note.status = function(self, update_backlinks, callback)
   local status = {}
   local wc = vim.fn.wordcount()
   status.words = wc.visual_words or wc.words
   status.chars = wc.visual_chars or wc.chars
   status.properties = vim.tbl_count(self:frontmatter()) -- TODO: should be zero if no frontmatter
-  local path = tostring(self.path)
 
   local function finish(num_backlinks)
     status.backlinks = num_backlinks
-    backlink_cache[path] = num_backlinks
     if callback then
       callback(status)
     else
@@ -1409,16 +1404,27 @@ Note.status = function(self, update_backlink, callback)
     end
   end
 
-  if self and (update_backlink or backlink_cache[path] == nil) then -- HACK:
-    if callback then
-      self:backlinks_async({}, function(matches)
-        finish(#matches)
+  if update_backlinks == false then
+    return finish(nil)
+  end
+
+  local cache = require "obsidian.cache"
+  if cache.is_enabled() then
+    if cache.is_ready() then
+      return finish(cache.notes.backlink_count(self))
+    elseif callback then
+      return cache.when_ready(function()
+        finish(cache.notes.backlink_count(self))
       end)
-    else
-      return finish(#self:backlinks {})
     end
+  end
+
+  if callback then
+    self:backlinks_async({}, function(matches)
+      finish(#matches)
+    end)
   else
-    return finish(backlink_cache[path] or 0)
+    return finish(#self:backlinks {})
   end
 end
 

--- a/tests/test_cache.lua
+++ b/tests/test_cache.lua
@@ -115,6 +115,33 @@ T["cache backends"]["stores compact rows"] = function()
   eq(nil, row.tasks)
 end
 
+T["cache backends"]["computes backlink counts from cached links"] = function()
+  local dir = Path.temp { suffix = "-obsidian-cache" }
+  dir:mkdir { parents = true }
+  local note_path = tostring(dir / "A.md")
+  helpers.write("# A", note_path)
+  helpers.write("[[A]] [[A|alias]] [A](A.md) [root](/A.md) [[Other]]", dir / "Links.md")
+  Obsidian = { dir = dir }
+
+  local cache = require "obsidian.cache"
+  cache.setup { enabled = true, backend = "memory" }
+  vim.wait(1000, function()
+    return cache.is_ready()
+  end)
+
+  local note = require("obsidian.note").new("A", {}, {}, note_path)
+  note.backlinks_async = function()
+    error "backlink search should not run"
+  end
+  local status
+  note:status(true, function(result)
+    status = result
+  end)
+
+  eq(4, cache.notes.backlink_count(note))
+  eq(4, status.backlinks)
+end
+
 T["cache backends"]["queries headings with original text and locations"] = function()
   local dir = Path.temp { suffix = "-obsidian-cache" }
   dir:mkdir { parents = true }

--- a/tests/test_footer.lua
+++ b/tests/test_footer.lua
@@ -1,0 +1,92 @@
+local eq = MiniTest.expect.equality
+local h = dofile "tests/helpers.lua"
+
+local T, child = h.child_vault()
+
+T["refreshes backlinks only for changes in other files"] = function()
+  child.lua [[
+    local path = vim.fs.joinpath(tostring(Obsidian.dir), "current.md")
+    vim.fn.writefile({ "# Current" }, path)
+    vim.cmd("edit " .. vim.fn.fnameescape(path))
+
+    local original_schedule = vim.schedule
+    vim.schedule = function(fn)
+      fn()
+    end
+
+    local Note = require "obsidian.note"
+    local original_status = Note.status
+    local calls = {}
+    Note.status = function(_, update_backlinks, callback)
+      calls[#calls + 1] = update_backlinks
+      callback({ words = 1, chars = 2, properties = 0, backlinks = update_backlinks and 3 or nil })
+    end
+
+    require("obsidian.footer").start(0)
+    vim.api.nvim_exec_autocmds("TextChanged", { buffer = 0 })
+
+    local watchfiles = require "obsidian.lsp.watchfiles"
+    watchfiles.handle { {
+      path = path,
+      type = vim.lsp.protocol.FileChangeType.Changed,
+    } }
+    _G.calls_after_current_file = #calls
+
+    watchfiles.handle { {
+      path = vim.fs.joinpath(tostring(Obsidian.dir), "other.md"),
+      type = vim.lsp.protocol.FileChangeType.Changed,
+    } }
+
+    _G.initial_update_backlinks = calls[1]
+    _G.text_update_backlinks = calls[2]
+    _G.external_update_backlinks = calls[3]
+    _G.footer_update_interval = vim.g.obsidian_footer_update_interval
+    Note.status = original_status
+    vim.schedule = original_schedule
+  ]]
+
+  eq(true, child.lua_get "initial_update_backlinks")
+  eq(false, child.lua_get "text_update_backlinks")
+  eq(2, child.lua_get "calls_after_current_file")
+  eq(true, child.lua_get "external_update_backlinks")
+  eq(vim.NIL, child.lua_get "footer_update_interval")
+end
+
+T["does not compute backlinks when no display format uses them"] = function()
+  child.lua [[
+    local path = vim.fs.joinpath(tostring(Obsidian.dir), "current.md")
+    vim.fn.writefile({ "# Current" }, path)
+    vim.cmd("edit " .. vim.fn.fnameescape(path))
+    Obsidian.opts.footer.format = "{{words}} words"
+    Obsidian.opts.statusline.enabled = false
+
+    local original_schedule = vim.schedule
+    vim.schedule = function(fn)
+      fn()
+    end
+
+    local Note = require "obsidian.note"
+    local original_status = Note.status
+    local calls = {}
+    Note.status = function(_, update_backlinks, callback)
+      calls[#calls + 1] = update_backlinks
+      callback { words = 1, chars = 2, properties = 0 }
+    end
+
+    require("obsidian.footer").start(0)
+    require("obsidian.lsp.watchfiles").handle { {
+      path = vim.fs.joinpath(tostring(Obsidian.dir), "other.md"),
+      type = vim.lsp.protocol.FileChangeType.Changed,
+    } }
+
+    _G.initial_update_backlinks = calls[1]
+    _G.call_count = #calls
+    Note.status = original_status
+    vim.schedule = original_schedule
+  ]]
+
+  eq(false, child.lua_get "initial_update_backlinks")
+  eq(1, child.lua_get "call_count")
+end
+
+return T


### PR DESCRIPTION
Closes #939

What does the PR do?

- removes the per-buffer 10-second backlink search timer and naive global backlink cache
- refreshes backlink counts when watched files outside the current note change
- skips backlink work when neither the footer nor statusline displays backlinks
- computes backlink counts from cached outgoing links when caching is enabled
- shares one status calculation between the footer and statusline

## Screenshots

Not applicable.

## PR Checklist

- [x] The PR contains a description of the changes
- [x] I read the [CONTRIBUTING.md] file
- [x] The `CHANGELOG.md` is updated
- [x] README documentation is not applicable to this internal bug fix
- [x] The code complies with `make chores` (style, lint, types, and tests)
