### PR TITLE
fix: Merge user edits and frontmatter updates into single undo operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prompt to confirm deletion for notes that have backlinks and attachments.
 - Attachment destination and vault-wide reference resolution, with `attachment.rename()` and `attachment.delete()` APIs.
 - Line-level Markdown list item and task parsers (`obsidian.parse.line.list_items`, `obsidian.parse.line.tasks`) with unified marker, indentation, and task-state metadata.
+- Edits to frontmatter upon editing notes are now merged with said edits in the undo tree. Now you only need to press undo once to revert said note changes instead of twice to revert the frontmattter change as well.
 
 ### Changed
 

--- a/lua/obsidian/autocmds.lua
+++ b/lua/obsidian/autocmds.lua
@@ -99,7 +99,9 @@ vim.api.nvim_create_autocmd("FileType", {
       exec_autocmds "ObsidianNoteWritePre"
       local note = Note.from_buffer(ev.buf)
       if not vim.b[ev.buf].obsidian_help then
+        pcall(vim.cmd, "undojoin")
         note:update_frontmatter(ev.buf) -- Update buffer with new frontmatter.
+        pcall(vim.cmd, "undojoin")
       end
     end)
     create_autocmd("BufWritePost", args.buf, function(ev)


### PR DESCRIPTION
copied from here: https://github.com/obsidian-nvim/obsidian.nvim/pull/691

# Merge user edits and frontmatter updates into single undo operation

Use undojoin before and after frontmatter updates in BufWritePre autocmd to combine user modifications and automatic frontmatter changes into a single undo step. This improves UX by allowing users to undo both changes with a single 'u' command.

Wrap undojoin calls with pcall to handle cases where it's not available (e.g., after fugitive operations).

Fixes #690

## Screenshots


## PR Checklist

- [X] The PR contains a description of the changes
- [X] I read the [CONTRIBUTING.md] file
- [ ] The `CHANGELOG.md` is updated
- [ ] The changes are documented in the `README.md` file
- [ ] The code complies with `make chores` (for style, lint, types, and tests)